### PR TITLE
Don't connect to tenant db during the shutdown

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -7,6 +7,13 @@ defmodule Supavisor.Application do
 
   @impl true
   def start(_type, _args) do
+    :ok =
+      :gen_event.swap_sup_handler(
+        :erl_signal_server,
+        {:erl_signal_handler, []},
+        {Supavisor.SignalHandler, []}
+      )
+
     :ranch.start_listener(
       :pg_proxy,
       :ranch_tcp,

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -8,7 +8,7 @@ defmodule Supavisor.DbHandler do
 
   @behaviour :gen_statem
 
-  alias Supavisor.Protocol.Server
+  alias Supavisor.{Protocol.Server, SignalHandler}
   alias Supavisor.ClientHandler, as: Client
 
   def start_link(config) do
@@ -39,7 +39,12 @@ defmodule Supavisor.DbHandler do
       server_proof: nil
     }
 
-    {:ok, :connect, data, {:next_event, :internal, :connect}}
+    if SignalHandler.shutdown_in_progress?() do
+      Logger.warn("Shutdown in progress, skip connection to DB")
+      {:ok, :wait_shutdown, nil}
+    else
+      {:ok, :connect, data, {:next_event, :internal, :connect}}
+    end
   end
 
   @impl true

--- a/lib/supavisor/signal_handler.ex
+++ b/lib/supavisor/signal_handler.ex
@@ -1,0 +1,41 @@
+defmodule Supavisor.SignalHandler do
+  @moduledoc """
+  Supavisor.SignalHandler is a module that provides a custom signal handling behavior
+  for the Supavisor application. It implements the :gen_event behavior and intercepts
+  system signals, such as SIGTERM, to manage application state during shutdown.
+
+  The module ensures that the shutdown process is properly communicated to the rest
+  of the application by updating the :shutdown_in_progress environment variable.
+  """
+
+  @behaviour :gen_event
+  require Logger
+
+  @spec shutdown_in_progress?() :: boolean()
+  def shutdown_in_progress? do
+    !!Application.get_env(:supavisor, :shutdown_in_progress)
+  end
+
+  @impl true
+  def init(_) do
+    Logger.info("#{__MODULE__} is being initialized...")
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_event(signal, state) do
+    Logger.warn("#{__MODULE__}: #{inspect(signal)} received")
+
+    if signal == :sigterm do
+      Application.put_env(:supavisor, :shutdown_in_progress, true)
+    end
+
+    :erl_signal_handler.handle_event(signal, state)
+  end
+
+  @impl true
+  defdelegate handle_info(info, state), to: :erl_signal_handler
+
+  @impl true
+  defdelegate handle_call(request, state), to: :erl_signal_handler
+end


### PR DESCRIPTION
This PR prevents restarting connections to DBs after receiving a shutdown signal by redefining `:erl_signal_server` and bringing the global variable `shutdown_in_progress`. This is made to avoid zombies connecting to Postgres, which can keep them if clients don't disconnect gracefully.