### PR TITLE
Tests for Supavisor.Jwt.authorize/2

### DIFF
--- a/lib/supavisor/jwt.ex
+++ b/lib/supavisor/jwt.ex
@@ -35,8 +35,6 @@ defmodule Supavisor.Jwt do
     |> verify(secret)
   end
 
-  def authorize(_token, _secret), do: {:error, :token_not_a_string}
-
   defp clean_token(token) do
     Regex.replace(~r/\s|\n/, URI.decode(token), "")
   end

--- a/test/supavisor/jwt_test.exs
+++ b/test/supavisor/jwt_test.exs
@@ -12,8 +12,10 @@ defmodule Supavisor.JwtTest do
       assert claims["role"] == "test"
     end
 
-    test "returns token_not_a_string for non-binary token" do
-      assert {:error, :token_not_a_string} = Jwt.authorize(123, @secret)
+    test "raises an error for non-binary token" do
+      assert_raise FunctionClauseError, fn ->
+        Jwt.authorize(123, @secret)
+      end
     end
 
     test "returns signature_error for a wrong secret" do


### PR DESCRIPTION
This PR adds tests for Supavisor.Jwt.authorize/2, as recommended by @wojtekmach [here](https://github.com/supabase/supavisor/pull/8#discussion_r1088821809)