### PR TITLE
docs(openapi): match tenant update implementation

### DIFF
--- a/lib/supavisor_web/open_api_schemas.ex
+++ b/lib/supavisor_web/open_api_schemas.ex
@@ -58,7 +58,43 @@ defmodule SupavisorWeb.OpenApiSchemas do
 
   defmodule TenantCreate do
     @moduledoc false
-    def params(), do: {"Tenant Create Params", "application/json", Tenant}
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        tenant: %Schema{
+          type: :object,
+          properties: %{
+            db_host: %Schema{type: :string, description: "Database host"},
+            db_port: %Schema{type: :integer, description: "Database port"},
+            db_user: %Schema{type: :string, description: "Database user"},
+            db_database: %Schema{type: :string, description: "Database name"},
+            db_password: %Schema{type: :string, description: "Database password"},
+            pool_size: %Schema{type: :integer, description: "Pool size"}
+          },
+          required: [
+            :db_host,
+            :db_port,
+            :db_user,
+            :db_database,
+            :db_password,
+            :pool_size
+          ],
+          example: %{
+            db_host: "localhost",
+            db_port: 5432,
+            db_user: "db_user",
+            db_database: "my_database",
+            db_password: "db_password",
+            pool_size: 10
+          }
+        }
+      },
+      required: [:tenant]
+    })
+
+    def params(), do: {"Tenant Create Params", "application/json", __MODULE__}
   end
 
   defmodule Created do


### PR DESCRIPTION
The `PUT /api/tenants/{external_id}` controller method accepts a JSON body containing a partial tenant—excluding `id`, `external_id`, and timestamps—all wrapped in a `tenant` key.

External ID is obtained through a path parameter.

This change updates the definition of the body to match the controller implementation.

## What kind of change does this PR introduce?

This PR updates documentation that lives within application code.

## What is the current behavior?

Currently, the documentation does not reflect the implemented behavior.

## What is the new behavior?

<img width="1410" alt="Screen Shot 2023-04-10 at 7 31 27 AM" src="https://user-images.githubusercontent.com/6108845/230921934-e4d9cd73-453c-4c8c-9aaf-59a3a5ab9cff.png">

## Additional context

Add any other context or screenshots.
