### PR TITLE
Implement multiple pools per tenant

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -12,7 +12,7 @@ defmodule Supavisor.ClientHandler do
   @behaviour :gen_statem
 
   alias Supavisor.DbHandler, as: Db
-  alias Supavisor.{Tenants, Tenants.Tenant, Protocol.Server, Monitoring.Telem, Manager}
+  alias Supavisor.{Tenants, Tenants.User, Protocol.Server, Monitoring.Telem, Manager}
 
   @impl true
   def start_link(ref, _socket, transport, opts) do
@@ -43,6 +43,7 @@ defmodule Supavisor.ClientHandler do
       trans: trans,
       db_pid: nil,
       tenant: nil,
+      user_alias: nil,
       pool: nil,
       manager: nil,
       query_start: nil
@@ -64,20 +65,17 @@ defmodule Supavisor.ClientHandler do
   def handle_event(:info, {:tcp, _, bin}, :exchange, %{socket: socket} = data) do
     hello = decode_startup_packet(bin)
     Logger.warning("Client startup message: #{inspect(hello)}")
-
-    external_id =
-      hello.payload["user"]
-      |> get_external_id()
-
+    {user, external_id} = parse_user_info(hello.payload["user"])
     Logger.metadata(project: external_id)
 
-    case Tenants.get_tenant_by_external_id(external_id) do
-      %Tenant{db_password: pass} ->
-        {:keep_state, %{data | tenant: external_id},
+    case Tenants.get_user(external_id, user) do
+      {:ok, %User{db_password: pass, db_user_alias: db_alias}} ->
+        {:keep_state, %{data | tenant: external_id, user_alias: db_alias},
          {:next_event, :internal, {:handle, fn -> pass end}}}
 
-      _ ->
-        Server.send_error(socket, "XX000", "Tenant not found")
+      {:error, reason} ->
+        Logger.error("User not found: #{inspect(reason)} #{inspect({user, external_id})}")
+        Server.send_error(socket, "XX000", "Tenant or user not found")
         {:stop, :normal, data}
     end
   end
@@ -101,12 +99,12 @@ defmodule Supavisor.ClientHandler do
     end
   end
 
-  def handle_event(:internal, :subscribe, _, %{tenant: tenant} = data) do
-    Logger.info("Subscribe to tenant #{tenant}")
+  def handle_event(:internal, :subscribe, _, %{tenant: tenant, user_alias: db_alias} = data) do
+    Logger.info("Subscribe to tenant #{inspect({db_alias, tenant})}")
 
-    with {:ok, tenant_sup} <- Supavisor.start(tenant),
+    with {:ok, tenant_sup} <- Supavisor.start(tenant, db_alias),
          {:ok, %{manager: manager, pool: pool}} <-
-           Supavisor.subscribe_global(node(tenant_sup), self(), tenant),
+           Supavisor.subscribe_global(node(tenant_sup), self(), tenant, db_alias),
          ps <-
            Manager.get_parameter_status(manager) do
       Process.monitor(manager)
@@ -132,7 +130,7 @@ defmodule Supavisor.ClientHandler do
   def handle_event(:info, {:tcp, _, bin}, :idle, data) do
     ts = System.monotonic_time()
     {time, db_pid} = :timer.tc(:poolboy, :checkout, [data.pool, true, 60_000])
-    Telem.pool_checkout_time(time, data.tenant)
+    Telem.pool_checkout_time(time, data.tenant, data.user_alias)
     Process.link(db_pid)
 
     {:next_state, :busy, %{data | db_pid: db_pid, query_start: ts},
@@ -204,8 +202,8 @@ defmodule Supavisor.ClientHandler do
 
       Process.unlink(data.db_pid)
       :poolboy.checkin(data.pool, data.db_pid)
-      Telem.network_usage(:client, data.socket, data.tenant)
-      Telem.client_query_time(data.query_start, data.tenant)
+      Telem.network_usage(:client, data.socket, data.tenant, data.user_alias)
+      Telem.client_query_time(data.query_start, data.tenant, data.user_alias)
       {:next_state, :idle, %{data | db_pid: nil}, reply}
     else
       Logger.debug("Client is not ready")
@@ -228,11 +226,17 @@ defmodule Supavisor.ClientHandler do
 
   ## Internal functions
 
-  @spec get_external_id(String.t()) :: String.t()
-  def get_external_id(username) do
-    username
-    |> String.split(".")
-    |> List.last()
+  @spec parse_user_info(String.t()) :: {String.t() | nil, String.t()}
+  def parse_user_info(username) do
+    case :binary.matches(username, ".") do
+      [] ->
+        {nil, username}
+
+      matches ->
+        {pos, _} = List.last(matches)
+        {name, "." <> external_id} = String.split_at(username, pos)
+        {name, external_id}
+    end
   end
 
   def decode_startup_packet(<<len::integer-32, _protocol::binary-4, rest::binary>>) do

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -100,7 +100,7 @@ defmodule Supavisor.ClientHandler do
   end
 
   def handle_event(:internal, :subscribe, _, %{tenant: tenant, user_alias: db_alias} = data) do
-    Logger.info("Subscribe to tenant #{inspect({db_alias, tenant})}")
+    Logger.info("Subscribe to tenant #{inspect({tenant, db_alias})}")
 
     with {:ok, tenant_sup} <- Supavisor.start(tenant, db_alias),
          {:ok, %{manager: manager, pool: pool}} <-

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -30,6 +30,7 @@ defmodule Supavisor.DbHandler do
       caller: nil,
       sent: false,
       auth: args.auth,
+      user_alias: args.user_alias,
       tenant: args.tenant,
       buffer: [],
       db_state: nil,
@@ -150,8 +151,7 @@ defmodule Supavisor.DbHandler do
 
       {ps, db_state} ->
         Logger.debug("DB ready_for_query: #{inspect(db_state)} #{inspect(ps, pretty: true)}")
-
-        Supavisor.set_parameter_status(data.tenant, ps)
+        Supavisor.set_parameter_status(data.tenant, data.user_alias, ps)
 
         {:next_state, :idle, %{data | parameter_status: ps},
          {:next_event, :internal, :check_buffer}}
@@ -174,7 +174,7 @@ defmodule Supavisor.DbHandler do
     :ok = Client.client_call(data.caller, bin, ready)
 
     if ready do
-      Telem.network_usage(:db, data.socket, data.tenant)
+      Telem.network_usage(:db, data.socket, data.tenant, data.user_alias)
     end
 
     :keep_state_and_data

--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -28,10 +28,10 @@ defmodule Supavisor.Monitoring.PromEx do
     ]
   end
 
-  @spec remove_metrics(String.t()) :: non_neg_integer()
-  def remove_metrics(tenant) do
+  @spec remove_metrics(String.t(), String.t()) :: non_neg_integer()
+  def remove_metrics(tenant, user_alias) do
     Supavisor.Monitoring.PromEx.Metrics
-    |> :ets.select_delete([{{{:_, %{tenant: tenant}}, :_}, [], [true]}])
+    |> :ets.select_delete([{{{:_, %{tenant: tenant, user_alias: user_alias}}, :_}, [], [true]}])
   end
 
   @spec set_metrics_tags() :: :ok

--- a/lib/supavisor/monitoring/telem.ex
+++ b/lib/supavisor/monitoring/telem.ex
@@ -3,14 +3,14 @@ defmodule Supavisor.Monitoring.Telem do
 
   require Logger
 
-  @spec network_usage(atom(), port(), String.t()) :: :ok
-  def network_usage(type, socket, tenant) do
+  @spec network_usage(atom(), port(), String.t(), String.t()) :: :ok
+  def network_usage(type, socket, tenant, user_alias) do
     case :inet.getstat(socket) do
       {:ok, values} ->
         :telemetry.execute(
           [:supavisor, type, :network, :stat],
           Map.new(values),
-          %{tenant: tenant}
+          %{tenant: tenant, user_alias: user_alias}
         )
 
       {:error, reason} ->
@@ -18,21 +18,21 @@ defmodule Supavisor.Monitoring.Telem do
     end
   end
 
-  @spec pool_checkout_time(integer(), String.t()) :: :ok
-  def pool_checkout_time(time, tenant) do
+  @spec pool_checkout_time(integer(), String.t(), String.t()) :: :ok
+  def pool_checkout_time(time, tenant, user_alias) do
     :telemetry.execute(
       [:supavisor, :pool, :checkout, :stop],
       %{duration: time},
-      %{tenant: tenant}
+      %{tenant: tenant, user_alias: user_alias}
     )
   end
 
-  @spec client_query_time(integer(), String.t()) :: :ok
-  def client_query_time(start, tenant) do
+  @spec client_query_time(integer(), String.t(), String.t()) :: :ok
+  def client_query_time(start, tenant, user_alias) do
     :telemetry.execute(
       [:supavisor, :client, :query, :stop],
       %{duration: System.monotonic_time() - start},
-      %{tenant: tenant}
+      %{tenant: tenant, user_alias: user_alias}
     )
   end
 end

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -30,7 +30,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :pool, :checkout, :stop],
           measurement: :duration,
           description: "Duration of the checkout process in the tenant db pool.",
-          tags: [:tenant],
+          tags: [:tenant, :user_alias],
           unit: {:microsecond, :millisecond},
           reporter_options: [
             buckets: [125, 250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 60_000]
@@ -41,7 +41,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :client, :query, :stop],
           measurement: :duration,
           description: "Duration of processing the query.",
-          tags: [:tenant],
+          tags: [:tenant, :user_alias],
           unit: {:native, :millisecond},
           reporter_options: [
             buckets: [10, 100, 500, 1_000, 5_000, 10_000, 30_000, 60_000, 120_000, 300_000]
@@ -52,20 +52,20 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :client, :network, :stat],
           measurement: :recv_oct,
           description: "The total number of bytes received by clients.",
-          tags: [:tenant]
+          tags: [:tenant, :user_alias]
         ),
         sum(
           [:supavisor, :client, :network, :send],
           event_name: [:supavisor, :client, :network, :stat],
           measurement: :send_oct,
           description: "The total number of bytes sent by clients.",
-          tags: [:tenant]
+          tags: [:tenant, :user_alias]
         ),
         counter(
           [:supavisor, :client, :queries, :count],
           event_name: [:supavisor, :pool, :checkout, :stop],
           description: "The total number of queries received by clients.",
-          tags: [:tenant]
+          tags: [:tenant, :user_alias]
         )
       ]
     )
@@ -80,14 +80,14 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :db, :network, :stat],
           measurement: :recv_oct,
           description: "The total number of bytes received by db process",
-          tags: [:tenant]
+          tags: [:tenant, :user_alias]
         ),
         sum(
           [:supavisor, :db, :network, :send],
           event_name: [:supavisor, :db, :network, :stat],
           measurement: :send_oct,
           description: "The total number of bytes sent by db process",
-          tags: [:tenant]
+          tags: [:tenant, :user_alias]
         )
       ]
     )
@@ -104,7 +104,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :connections],
           description: "The total count of connected clients for a tenant.",
           measurement: :connected,
-          tags: [:tenant]
+          tags: [:tenant, :user_alias]
         )
       ]
     )
@@ -118,11 +118,11 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
   end
 
   @spec emit_telemetry_for_tenant({String.t(), pid(), :ets.tid()}) :: :ok
-  def emit_telemetry_for_tenant({tenant, _pid, tid}) do
+  def emit_telemetry_for_tenant({{tenant, user_alias}, _pid, tid}) do
     :telemetry.execute(
       [:supavisor, :connections],
       %{connected: :ets.info(tid, :size)},
-      %{tenant: tenant}
+      %{tenant: tenant, user_alias: user_alias}
     )
   end
 end

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -117,7 +117,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
     |> Enum.each(&emit_telemetry_for_tenant/1)
   end
 
-  @spec emit_telemetry_for_tenant({String.t(), pid(), :ets.tid()}) :: :ok
+  @spec emit_telemetry_for_tenant({{String.t(), String.t()}, pid(), :ets.tid()}) :: :ok
   def emit_telemetry_for_tenant({{tenant, user_alias}, _pid, tid}) do
     :telemetry.execute(
       [:supavisor, :connections],

--- a/lib/supavisor/syn_handler.ex
+++ b/lib/supavisor/syn_handler.ex
@@ -5,15 +5,22 @@ defmodule Supavisor.SynHandler do
   require Logger
   alias Supavisor.Monitoring.PromEx
 
-  def on_process_unregistered(:tenants, {tenant, user_alias}, _pid, _meta, reason) do
+  def on_process_unregistered(
+        :tenants,
+        {tenant, user_alias},
+        _pid,
+        _meta,
+        reason
+      ) do
     Logger.debug("Process unregistered: #{inspect({tenant, user_alias})} #{inspect(reason)}")
+
     # remove all Prometheus metrics for the specified tenant
     PromEx.remove_metrics(tenant, user_alias)
   end
 
   def resolve_registry_conflict(
         :tenants,
-        tenant,
+        {tenant, user_alias},
         {pid1, _, time1},
         {pid2, _, time2}
       ) do
@@ -38,11 +45,13 @@ defmodule Supavisor.SynHandler do
           end
 
         Logger.warn(
-          "Resolving #{inspect(tenant)} conflict, stop local pid: #{inspect(stop)}, response: #{inspect(resp)}"
+          "Resolving #{inspect({tenant, user_alias})} conflict, stop local pid: #{inspect(stop)}, response: #{inspect(resp)}"
         )
       end)
     else
-      Logger.warn("Resolving #{inspect(tenant)} conflict, remote pid: #{inspect(stop)}")
+      Logger.warn(
+        "Resolving #{inspect({tenant, user_alias})} conflict, remote pid: #{inspect(stop)}"
+      )
     end
 
     keep

--- a/lib/supavisor/syn_handler.ex
+++ b/lib/supavisor/syn_handler.ex
@@ -5,10 +5,10 @@ defmodule Supavisor.SynHandler do
   require Logger
   alias Supavisor.Monitoring.PromEx
 
-  def on_process_unregistered(:tenants, tenant, _pid, _meta, reason) do
-    Logger.debug("Process unregistered: #{inspect(tenant)} #{inspect(reason)}")
+  def on_process_unregistered(:tenants, {tenant, user_alias}, _pid, _meta, reason) do
+    Logger.debug("Process unregistered: #{inspect({tenant, user_alias})} #{inspect(reason)}")
     # remove all Prometheus metrics for the specified tenant
-    PromEx.remove_metrics(tenant)
+    PromEx.remove_metrics(tenant, user_alias)
   end
 
   def resolve_registry_conflict(
@@ -38,11 +38,11 @@ defmodule Supavisor.SynHandler do
           end
 
         Logger.warn(
-          "Resolving #{tenant} conflict, stop local pid: #{inspect(stop)}, response: #{inspect(resp)}"
+          "Resolving #{inspect(tenant)} conflict, stop local pid: #{inspect(stop)}, response: #{inspect(resp)}"
         )
       end)
     else
-      Logger.warn("Resolving #{tenant} conflict, remote pid: #{inspect(stop)}")
+      Logger.warn("Resolving #{inspect(tenant)} conflict, remote pid: #{inspect(stop)}")
     end
 
     keep

--- a/lib/supavisor/tenant_supervisor.ex
+++ b/lib/supavisor/tenant_supervisor.ex
@@ -4,17 +4,17 @@ defmodule Supavisor.TenantSupervisor do
 
   alias Supavisor.Manager
 
-  @spec start_link(atom | %{:tenant => any, optional(any) => any}) ::
-          :ignore | {:error, any} | {:ok, pid}
   def start_link(args) do
-    name = {:via, :syn, {:tenants, args.tenant}}
+    name = {:via, :syn, {:tenants, {args.tenant, args.user_alias}}}
     Supervisor.start_link(__MODULE__, args, name: name)
   end
 
   @impl true
-  def init(%{tenant: tenant, pool_size: pool_size} = args) do
+  def init(%{tenant: tenant, user_alias: user_alias, pool_size: pool_size} = args) do
+    id = {tenant, user_alias}
+
     pool_spec = [
-      name: {:via, Registry, {Supavisor.Registry.Tenants, {:pool, tenant}}},
+      name: {:via, Registry, {Supavisor.Registry.Tenants, {:pool, id}}},
       worker_module: Supavisor.DbHandler,
       size: pool_size,
       max_overflow: 0
@@ -22,7 +22,7 @@ defmodule Supavisor.TenantSupervisor do
 
     children = [
       %{
-        id: {:pool, args.tenant},
+        id: {:pool, id},
         start: {:poolboy, :start_link, [pool_spec, args]},
         restart: :transient
       },
@@ -34,7 +34,7 @@ defmodule Supavisor.TenantSupervisor do
 
   def child_spec(args) do
     %{
-      id: args.tenant,
+      id: {args.tenant, args.user_alias},
       start: {__MODULE__, :start_link, [args]},
       restart: :transient
     }

--- a/lib/supavisor/tenants.ex
+++ b/lib/supavisor/tenants.ex
@@ -7,6 +7,7 @@ defmodule Supavisor.Tenants do
   alias Supavisor.Repo
 
   alias Supavisor.Tenants.Tenant
+  alias Supavisor.Tenants.User
 
   @doc """
   Returns the list of tenants.
@@ -39,8 +40,43 @@ defmodule Supavisor.Tenants do
 
   @spec get_tenant_by_external_id(String.t()) :: Tenant.t() | nil
   def get_tenant_by_external_id(external_id) do
-    Tenant
-    |> Repo.get_by(external_id: external_id)
+    Tenant |> Repo.get_by(external_id: external_id) |> Repo.preload(:users)
+  end
+
+  @spec get_user(String.t(), String.t() | nil) ::
+          {:ok, User.t()} | {:error, :not_found | :multiple_results}
+  def get_user(external_id, nil) do
+    query = from p in User, where: p.tenant_external_id == ^external_id
+
+    case Repo.all(query) do
+      nil ->
+        {:error, :not_found}
+
+      [%User{} = user] ->
+        {:ok, user}
+
+      _ ->
+        {:error, :multiple_results}
+    end
+  end
+
+  def get_user(external_id, user) do
+    case Repo.get_by(User, db_user_alias: user, tenant_external_id: external_id) do
+      nil -> {:error, :not_found}
+      %User{} = user -> {:ok, user}
+    end
+  end
+
+  def get_pool_config(external_id, user) do
+    query =
+      from a in User,
+        where: a.db_user_alias == ^user
+
+    Repo.one(
+      from p in Tenant,
+        where: p.external_id == ^external_id,
+        preload: [users: ^query]
+    )
   end
 
   @doc """
@@ -119,5 +155,85 @@ defmodule Supavisor.Tenants do
   """
   def change_tenant(%Tenant{} = tenant, attrs \\ %{}) do
     Tenant.changeset(tenant, attrs)
+  end
+
+  alias Supavisor.Tenants.User
+
+  @doc """
+  Returns the list of users.
+
+  ## Examples
+
+      iex> list_users()
+      [%User{}, ...]
+
+  """
+  def list_users do
+    Repo.all(User)
+  end
+
+  @doc """
+  Creates a user.
+
+  ## Examples
+
+      iex> create_user(%{field: value})
+      {:ok, %User{}}
+
+      iex> create_user(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_user(attrs \\ %{}) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a user.
+
+  ## Examples
+
+      iex> update_user(user, %{field: new_value})
+      {:ok, %User{}}
+
+      iex> update_user(user, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_user(%User{} = user, attrs) do
+    user
+    |> User.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a user.
+
+  ## Examples
+
+      iex> delete_user(user)
+      {:ok, %User{}}
+
+      iex> delete_user(user)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_user(%User{} = user) do
+    Repo.delete(user)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking user changes.
+
+  ## Examples
+
+      iex> change_user(user)
+      %Ecto.Changeset{data: %User{}}
+
+  """
+  def change_user(%User{} = user, attrs \\ %{}) do
+    User.changeset(user, attrs)
   end
 end

--- a/lib/supavisor/tenants/tenant.ex
+++ b/lib/supavisor/tenants/tenant.ex
@@ -3,21 +3,25 @@ defmodule Supavisor.Tenants.Tenant do
 
   use Ecto.Schema
   import Ecto.Changeset
+  alias Supavisor.Tenants.User
 
   @type t :: %__MODULE__{}
 
   @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   @schema_prefix "_supavisor"
 
   schema "tenants" do
-    field(:db_database, :string)
     field(:db_host, :string)
-    field(:db_password, Supavisor.Encrypted.Binary, source: :db_pass_encrypted)
     field(:db_port, :integer)
-    field(:db_user, :string)
+    field(:db_database, :string)
     field(:external_id, :string)
-    field(:pool_size, :integer)
+
+    has_many(:users, User,
+      foreign_key: :tenant_external_id,
+      references: :external_id,
+      on_delete: :delete_all,
+      on_replace: :delete
+    )
 
     timestamps()
   end
@@ -29,20 +33,15 @@ defmodule Supavisor.Tenants.Tenant do
       :external_id,
       :db_host,
       :db_port,
-      :db_user,
-      :db_database,
-      :db_password,
-      :pool_size
+      :db_database
     ])
     |> validate_required([
       :external_id,
       :db_host,
       :db_port,
-      :db_user,
-      :db_database,
-      :db_password,
-      :pool_size
+      :db_database
     ])
     |> unique_constraint([:external_id])
+    |> cast_assoc(:users, with: &User.changeset/2)
   end
 end

--- a/lib/supavisor/tenants/user.ex
+++ b/lib/supavisor/tenants/user.ex
@@ -1,0 +1,48 @@
+defmodule Supavisor.Tenants.User do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @type t :: %__MODULE__{}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @schema_prefix "_supavisor"
+
+  schema "users" do
+    field(:db_user_alias, :string)
+    field(:db_user, :string)
+    field(:db_password, Supavisor.Encrypted.Binary, source: :db_pass_encrypted)
+    field(:is_manager, :boolean, default: false)
+    field(:mode_type, Ecto.Enum, values: [:transaction])
+    field(:pool_size, :integer)
+    belongs_to(:tenant, Supavisor.Tenants.Tenant, foreign_key: :tenant_external_id, type: :string)
+    timestamps()
+  end
+
+  @doc false
+  def changeset(user, attrs) do
+    attrs =
+      if attrs["db_user_alias"] do
+        attrs
+      else
+        Map.put(attrs, "db_user_alias", attrs["db_user"])
+      end
+
+    user
+    |> cast(attrs, [
+      :db_user_alias,
+      :db_user,
+      :db_password,
+      :pool_size,
+      :mode_type,
+      :is_manager
+    ])
+    |> validate_required([
+      :db_user_alias,
+      :db_user,
+      :db_password,
+      :pool_size,
+      :mode_type
+    ])
+  end
+end

--- a/lib/supavisor_web/controllers/tenant_controller.ex
+++ b/lib/supavisor_web/controllers/tenant_controller.ex
@@ -2,8 +2,8 @@ defmodule SupavisorWeb.TenantController do
   use SupavisorWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
-  alias Supavisor.Tenants
-  alias Supavisor.Tenants.Tenant, as: TenantModel
+  alias Supavisor.{Tenants, Repo}
+  alias Tenants.Tenant, as: TenantModel
 
   alias SupavisorWeb.OpenApiSchemas.{Tenant, TenantList, TenantCreate, NotFound, Created, Empty}
 
@@ -85,6 +85,8 @@ defmodule SupavisorWeb.TenantController do
         create(conn, %{"tenant" => Map.put(tenant_params, "external_id", id)})
 
       tenant ->
+        tenant = Repo.preload(tenant, :users)
+
         with {:ok, %TenantModel{} = tenant} <- Tenants.update_tenant(tenant, tenant_params) do
           render(conn, "show.json", tenant: tenant)
         end

--- a/lib/supavisor_web/open_api_schemas.ex
+++ b/lib/supavisor_web/open_api_schemas.ex
@@ -4,6 +4,52 @@ defmodule SupavisorWeb.OpenApiSchemas do
   """
   alias OpenApiSpex.Schema
 
+  defmodule User do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, format: :binary_id, readOnly: true},
+        tenant_external_id: %Schema{type: :string, description: "External Teanant ID"},
+        db_user_alias: %Schema{type: :string, description: "Database user alias"},
+        db_user: %Schema{type: :string, description: "Database user"},
+        db_password: %Schema{type: :string, description: "Database password"},
+        pool_size: %Schema{type: :integer, description: "Pool size"},
+        mode_type: %Schema{type: :string, description: "Pooling mode type"},
+        is_manager: %Schema{
+          type: :boolean,
+          description: "The users who can be used for internal needs"
+        },
+        inserted_at: %Schema{type: :string, format: :date_time, readOnly: true},
+        updated_at: %Schema{type: :string, format: :date_time, readOnly: true}
+      },
+      required: [
+        :db_host,
+        :db_port,
+        :db_user,
+        :db_database,
+        :db_password,
+        :pool_size
+      ],
+      example: %{
+        id: "b1024a4c-4eb4-4c64-8f49-c8a46c2b2e16",
+        external_id: "dev_tenant",
+        db_user_alias: "postgres",
+        db_user: "postgres",
+        db_password: "postgres",
+        pool_size: 10,
+        is_manager: false,
+        mode_type: "transaction",
+        inserted_at: "2023-03-27T12:00:00Z",
+        updated_at: "2023-03-27T12:00:00Z"
+      }
+    })
+
+    def response(), do: {"User Response", "application/json", __MODULE__}
+  end
+
   defmodule Tenant do
     @moduledoc false
     require OpenApiSpex
@@ -15,33 +61,39 @@ defmodule SupavisorWeb.OpenApiSchemas do
         external_id: %Schema{type: :string, description: "External ID"},
         db_host: %Schema{type: :string, description: "Database host"},
         db_port: %Schema{type: :integer, description: "Database port"},
-        db_user: %Schema{type: :string, description: "Database user"},
         db_database: %Schema{type: :string, description: "Database name"},
-        db_password: %Schema{type: :string, description: "Database password"},
-        pool_size: %Schema{type: :integer, description: "Pool size"},
+        users: %Schema{type: :array, items: User},
         inserted_at: %Schema{type: :string, format: :date_time, readOnly: true},
         updated_at: %Schema{type: :string, format: :date_time, readOnly: true}
       },
       required: [
-        # :external_id,
         :db_host,
         :db_port,
-        :db_user,
         :db_database,
-        :db_password,
-        :pool_size
+        :users
       ],
       example: %{
         id: "b1024a4c-4eb4-4c64-8f49-c8a46c2b2e16",
-        external_id: "123",
+        external_id: "dev_tenant",
         db_host: "localhost",
         db_port: 5432,
-        db_user: "db_user",
-        db_database: "my_database",
-        db_password: "db_password",
-        pool_size: 10,
+        db_database: "postgres",
         inserted_at: "2023-03-27T12:00:00Z",
-        updated_at: "2023-03-27T12:00:00Z"
+        updated_at: "2023-03-27T12:00:00Z",
+        users: [
+          %{
+            id: "b1024a4c-4eb4-4c64-8f49-c8a46c2b2e16",
+            external_id: "dev_tenant",
+            db_user_alias: "postgres",
+            db_user: "postgres",
+            db_password: "postgres",
+            pool_size: 10,
+            is_manager: false,
+            mode_type: "transaction",
+            inserted_at: "2023-03-27T12:00:00Z",
+            updated_at: "2023-03-27T12:00:00Z"
+          }
+        ]
       }
     })
 
@@ -66,28 +118,33 @@ defmodule SupavisorWeb.OpenApiSchemas do
         tenant: %Schema{
           type: :object,
           properties: %{
+            id: %Schema{type: :string, format: :binary_id, readOnly: true},
+            external_id: %Schema{type: :string, description: "External ID"},
             db_host: %Schema{type: :string, description: "Database host"},
             db_port: %Schema{type: :integer, description: "Database port"},
-            db_user: %Schema{type: :string, description: "Database user"},
             db_database: %Schema{type: :string, description: "Database name"},
-            db_password: %Schema{type: :string, description: "Database password"},
-            pool_size: %Schema{type: :integer, description: "Pool size"}
+            users: %Schema{type: :array, items: User},
+            inserted_at: %Schema{type: :string, format: :date_time, readOnly: true},
+            updated_at: %Schema{type: :string, format: :date_time, readOnly: true}
           },
           required: [
             :db_host,
             :db_port,
-            :db_user,
             :db_database,
-            :db_password,
-            :pool_size
+            :users
           ],
           example: %{
             db_host: "localhost",
             db_port: 5432,
-            db_user: "db_user",
-            db_database: "my_database",
-            db_password: "db_password",
-            pool_size: 10
+            db_database: "postgres",
+            users: [
+              %{
+                db_user: "postgres",
+                db_password: "postgres",
+                pool_size: 10,
+                mode_type: "transaction"
+              }
+            ]
           }
         }
       },

--- a/lib/supavisor_web/views/tenant_view.ex
+++ b/lib/supavisor_web/views/tenant_view.ex
@@ -1,6 +1,7 @@
 defmodule SupavisorWeb.TenantView do
   use SupavisorWeb, :view
   alias SupavisorWeb.TenantView
+  alias SupavisorWeb.UserView
 
   def render("index.json", %{tenants: tenants}) do
     %{data: render_many(tenants, TenantView, "tenant.json")}
@@ -16,9 +17,8 @@ defmodule SupavisorWeb.TenantView do
       external_id: tenant.external_id,
       db_host: tenant.db_host,
       db_port: tenant.db_port,
-      db_user: tenant.db_user,
       db_database: tenant.db_database,
-      pool_size: tenant.pool_size
+      users: render_many(tenant.users, UserView, "user.json")
     }
   end
 end

--- a/lib/supavisor_web/views/user_view.ex
+++ b/lib/supavisor_web/views/user_view.ex
@@ -1,0 +1,13 @@
+defmodule SupavisorWeb.UserView do
+  use SupavisorWeb, :view
+
+  def render("user.json", %{user: user}) do
+    %{
+      db_user_alias: user.db_user_alias,
+      db_user: user.db_user,
+      pool_size: user.pool_size,
+      is_manager: user.is_manager,
+      mode_type: user.mode_type
+    }
+  end
+end

--- a/priv/repo/migrations/20230125140723_create_tenants.exs
+++ b/priv/repo/migrations/20230125140723_create_tenants.exs
@@ -7,10 +7,7 @@ defmodule Supavisor.Repo.Migrations.CreateTenants do
       add(:external_id, :string, null: false)
       add(:db_host, :string, null: false)
       add(:db_port, :integer, null: false)
-      add(:db_user, :string, null: false)
       add(:db_database, :string, null: false)
-      add(:db_pass_encrypted, :binary, null: false)
-      add(:pool_size, :integer, null: false)
 
       timestamps()
     end

--- a/priv/repo/migrations/20230418151441_create_users.exs
+++ b/priv/repo/migrations/20230418151441_create_users.exs
@@ -1,0 +1,29 @@
+defmodule Supavisor.Repo.Migrations.CreateUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:users, primary_key: false, prefix: "_supavisor") do
+      add(:id, :binary_id, primary_key: true)
+      add(:db_user_alias, :string, null: false)
+      add(:db_user, :string, null: false)
+      add(:db_pass_encrypted, :binary, null: false)
+      add(:pool_size, :integer, null: false)
+      add(:mode_type, :string, null: false)
+      add(:is_manager, :boolean, default: false, null: false)
+
+      add(
+        :tenant_external_id,
+        references(:tenants, on_delete: :delete_all, type: :string, column: :external_id)
+      )
+
+      timestamps()
+    end
+
+    create(
+      index(:users, [:db_user_alias, :tenant_external_id, :mode_type],
+        unique: true,
+        prefix: "_supavisor"
+      )
+    )
+  end
+end

--- a/priv/repo/seeds_after_migration.exs
+++ b/priv/repo/seeds_after_migration.exs
@@ -14,13 +14,18 @@ end
 |> Enum.each(fn tenant ->
   if !Tenants.get_tenant_by_external_id(tenant) do
     %{
-      db_database: db_conf[:database],
       db_host: db_conf[:hostname],
-      db_password: db_conf[:password],
       db_port: db_conf[:port],
-      db_user: db_conf[:username],
+      db_database: db_conf[:database],
       external_id: tenant,
-      pool_size: 3
+      users: [
+        %{
+          "db_user" => db_conf[:username],
+          "db_password" => db_conf[:password],
+          "pool_size" => 3,
+          "mode_type" => "transaction"
+        }
+      ]
     }
     |> Tenants.create_tenant()
   end

--- a/test/supavisor/client_handler_test.exs
+++ b/test/supavisor/client_handler_test.exs
@@ -3,10 +3,17 @@ defmodule Supavisor.ClientHandlerTest do
 
   alias Supavisor.ClientHandler
 
-  describe "get_external_id/1" do
+  describe "parse_user_info/1" do
     test "extracts the external_id from the username" do
       username = "test.user.external_id"
-      external_id = ClientHandler.get_external_id(username)
+      {name, external_id} = ClientHandler.parse_user_info(username)
+      assert name == "test.user"
+      assert external_id == "external_id"
+    end
+
+    test "username consists only of external_id" do
+      username = "external_id"
+      {nil, external_id} = ClientHandler.parse_user_info(username)
       assert external_id == "external_id"
     end
   end

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -5,7 +5,7 @@ defmodule Supavisor.DbHandlerTest do
 
   describe "init/1" do
     test "starts with correct state" do
-      args = %{auth: %{}, tenant: "test_tenant"}
+      args = %{auth: %{}, tenant: "test_tenant", user_alias: "test_user_alias"}
 
       {:ok, :connect, data, {_, next_event, _}} = Db.init(args)
       assert next_event == :internal
@@ -14,6 +14,7 @@ defmodule Supavisor.DbHandlerTest do
       assert data.sent == false
       assert data.auth == args.auth
       assert data.tenant == args.tenant
+      assert data.user_alias == args.user_alias
       assert data.buffer == []
       assert data.db_state == nil
       assert data.parameter_status == %{}

--- a/test/supavisor/prom_ex_test.exs
+++ b/test/supavisor/prom_ex_test.exs
@@ -19,17 +19,17 @@ defmodule Supavisor.PromExTest do
         username: db_conf[:username] <> "." <> @tenant
       )
 
-    %{proxy: proxy}
+    %{proxy: proxy, user: db_conf[:username]}
   end
 
-  test "remove tenant tag upon termination", %{proxy: proxy} do
+  test "remove tenant tag upon termination", %{proxy: proxy, user: user} do
     P.query!(proxy, "select 1;", [])
     Process.sleep(500)
     metrics = PromEx.get_metrics()
     assert metrics =~ "tenant=\"#{@tenant}\""
-    DynamicSupervisor.stop(proxy)
+    DynamicSupervisor.stop(proxy, user)
     Process.sleep(500)
-    Supavisor.stop(@tenant)
+    Supavisor.stop(@tenant, user)
     Process.sleep(500)
     refute PromEx.get_metrics() =~ "tenant=\"#{@tenant}\""
   end

--- a/test/supavisor/syn_handler_test.exs
+++ b/test/supavisor/syn_handler_test.exs
@@ -5,20 +5,21 @@ defmodule Supavisor.SynHandlerTest do
   alias Ecto.Adapters.SQL.Sandbox
 
   @tenant "syn_tenant"
+  @user "postgres"
 
   test "resolving conflict" do
     node2 = :"secondary@127.0.0.1"
 
-    {:ok, pid2} = :erpc.call(node2, Supavisor, :start, [@tenant])
+    {:ok, pid2} = :erpc.call(node2, Supavisor, :start, [@tenant, @user])
     Process.sleep(500)
-    assert pid2 == Supavisor.get_global_sup(@tenant)
+    assert pid2 == Supavisor.get_global_sup(@tenant, @user)
     assert node(pid2) == node2
     true = Node.disconnect(node2)
     Process.sleep(500)
 
-    assert nil == Supavisor.get_global_sup(@tenant)
-    {:ok, pid1} = Supavisor.start(@tenant)
-    assert pid1 == Supavisor.get_global_sup(@tenant)
+    assert nil == Supavisor.get_global_sup(@tenant, @user)
+    {:ok, pid1} = Supavisor.start(@tenant, @user)
+    assert pid1 == Supavisor.get_global_sup(@tenant, @user)
     assert node(pid1) == node()
 
     :pong = Node.ping(node2)
@@ -29,7 +30,7 @@ defmodule Supavisor.SynHandlerTest do
     assert capture_log(fn -> Logger.warn(msg) end) =~
              msg
 
-    assert pid2 == Supavisor.get_global_sup(@tenant)
+    assert pid2 == Supavisor.get_global_sup(@tenant, @user)
     assert node(pid2) == node2
   end
 

--- a/test/supavisor_web/controllers/tenant_controller_test.exs
+++ b/test/supavisor_web/controllers/tenant_controller_test.exs
@@ -7,32 +7,33 @@ defmodule SupavisorWeb.TenantControllerTest do
 
   @jwt "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJvbGUiOiJhbm9uIiwiaWF0IjoxNjQ1MTkyODI0LCJleHAiOjE5NjA3Njg4MjR9.M9jrxyvPLkUxWgOYSf5dNdJ8v_eRrq810ShFRT8N-6M"
 
+  @user_valid_attrs %{
+    db_user_alias: "some db_user",
+    db_user: "some db_user",
+    db_password: "some db_password",
+    pool_size: 3,
+    mode_type: "transaction"
+  }
+
   @create_attrs %{
     db_database: "some db_database",
     db_host: "some db_host",
-    db_password: "some db_password",
     db_port: 42,
-    db_user: "some db_user",
     external_id: "dev_tenant",
-    pool_size: 42
+    users: [@user_valid_attrs]
   }
   @update_attrs %{
     db_database: "some updated db_database",
     db_host: "some updated db_host",
-    db_password: "some updated db_password",
     db_port: 43,
-    db_user: "some updated db_user",
     external_id: "dev_tenant",
-    pool_size: 43
+    users: [@user_valid_attrs]
   }
   @invalid_attrs %{
     db_database: nil,
     db_host: nil,
-    db_password: nil,
     db_port: nil,
-    db_user: nil,
-    external_id: nil,
-    pool_size: nil
+    external_id: nil
   }
 
   setup %{conn: conn} do
@@ -75,9 +76,7 @@ defmodule SupavisorWeb.TenantControllerTest do
                "external_id" => ^external_id,
                "db_database" => "some updated db_database",
                "db_host" => "some updated db_host",
-               "db_port" => 43,
-               "db_user" => "some updated db_user",
-               "pool_size" => 43
+               "db_port" => 43
              } = json_response(conn, 200)["data"]
     end
 

--- a/test/support/fixtures/tenants_fixtures.ex
+++ b/test/support/fixtures/tenants_fixtures.ex
@@ -13,11 +13,16 @@ defmodule Supavisor.TenantsFixtures do
       |> Enum.into(%{
         db_database: "some db_database",
         db_host: "some db_host",
-        db_password: "some db_password",
         db_port: 42,
-        db_user: "some db_user",
         external_id: "dev_tenant",
-        pool_size: 42
+        users: [
+          %{
+            "db_user" => "postgres",
+            "db_password" => "postgres",
+            "pool_size" => 3,
+            "mode_type" => "transaction"
+          }
+        ]
       })
       |> Supavisor.Tenants.create_tenant()
 


### PR DESCRIPTION
This pull request introduces the capability to start multiple connection pools for tenants, organized by user entity.

Connection pools are identified using the pair `{tenant, db_user_alias}`.

The `db_user_alias` field serves as an alias for the `db_user` field, allowing for the creation of different types of pools (transaction/session/etc.) with the same Postgres user simultaneously.

A tenant can have many users, but the following combination for a user should be unique:
```elixir
[:db_user_alias, :tenant_external_id, :mode_type]
```

Supavisor retrieves the user name and tenant from the Postgres `username` field, which is divided by `.`. If a tenant has only one user, it is allowed to use just the tenant name in the username field, for example:
```bash
postgresql://some_tenant@localhost:7654/postgres
```