### PR TITLE
Implement session mode functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ pgbench_init:
 	PGPASSWORD=postgres pgbench -i -h 127.0.0.1 -p 6432 -U postgres -d postgres
 
 pgbench_short:
-	PGPASSWORD=postgres pgbench -M extended --transactions 5 --jobs 4 --client 1 -h localhost -p 7654 -U postgres.localhost postgres
+	PGPASSWORD=postgres pgbench -M extended --transactions 5 --jobs 4 --client 1 -h localhost -p 7654 -U transaction.localhost postgres
 
 pgbench_long:
 	PGPASSWORD=postgres pgbench -M extended --transactions 100 --jobs 10 --client 60 -h localhost -p 7654 -U postgres.localhost postgres

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,7 @@ config :supavisor, SupavisorWeb.Endpoint,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+  metadata: [:request_id, :project, :user]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -63,7 +63,7 @@ config :logger, :console,
   format: "$time [$level] $message $metadata\n",
   level: :debug,
   # level: :error,
-  metadata: [:error_code, :file, :line, :pid, :project]
+  metadata: [:error_code, :file, :line, :pid, :project, :user]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/lib/supavisor.ex
+++ b/lib/supavisor.ex
@@ -110,7 +110,8 @@ defmodule Supavisor do
             %{
               db_user: db_user,
               db_password: db_pass,
-              pool_size: pool_size
+              pool_size: pool_size,
+              mode_type: mode
             }
           ]
         } = tenant_record
@@ -124,7 +125,13 @@ defmodule Supavisor do
           application_name: "supavisor"
         }
 
-        args = %{tenant: tenant, user_alias: user_alias, auth: auth, pool_size: pool_size}
+        args = %{
+          tenant: tenant,
+          user_alias: user_alias,
+          auth: auth,
+          pool_size: pool_size,
+          mode: mode
+        }
 
         DynamicSupervisor.start_child(
           {:via, PartitionSupervisor, {Supavisor.DynamicSupervisor, {tenant, user_alias}}},

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -366,5 +366,5 @@ defmodule Supavisor.ClientHandler do
     nil
   end
 
-  defp handle_db_pid(:ssession, _, db_pid), do: db_pid
+  defp handle_db_pid(:session, _, db_pid), do: db_pid
 end

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -358,7 +358,8 @@ defmodule Supavisor.ClientHandler do
     db_pid
   end
 
-  @spec handle_db_pid(:transaction | :session, pid(), pid()) :: nil | pid
+  @spec handle_db_pid(:transaction, pid(), pid()) :: nil
+  @spec handle_db_pid(:session, pid(), pid()) :: pid()
   defp handle_db_pid(:transaction, pool, db_pid) do
     Process.unlink(db_pid)
     :poolboy.checkin(pool, db_pid)

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -21,8 +21,7 @@ defmodule Supavisor.ClientHandler do
   end
 
   @impl true
-  def callback_mode,
-    do: [:handle_event_function]
+  def callback_mode, do: [:handle_event_function]
 
   def client_call(pid, bin, ready?) do
     :gen_statem.call(pid, {:client_call, bin, ready?}, 5000)
@@ -46,7 +45,9 @@ defmodule Supavisor.ClientHandler do
       user_alias: nil,
       pool: nil,
       manager: nil,
-      query_start: nil
+      query_start: nil,
+      mode: nil,
+      timeout: nil
     }
 
     :gen_statem.enter_loop(__MODULE__, [hibernate_after: 5_000], :exchange, data)
@@ -66,11 +67,18 @@ defmodule Supavisor.ClientHandler do
     hello = decode_startup_packet(bin)
     Logger.warning("Client startup message: #{inspect(hello)}")
     {user, external_id} = parse_user_info(hello.payload["user"])
-    Logger.metadata(project: external_id)
+    Logger.metadata(project: external_id, user: user)
 
     case Tenants.get_user(external_id, user) do
-      {:ok, %User{db_password: pass, db_user_alias: db_alias}} ->
-        {:keep_state, %{data | tenant: external_id, user_alias: db_alias},
+      {:ok,
+       %User{
+         db_password: pass,
+         db_user_alias: db_alias,
+         mode_type: mode,
+         pool_checkout_timeout: timeout
+       }} ->
+        {:keep_state,
+         %{data | tenant: external_id, user_alias: db_alias, mode: mode, timeout: timeout},
          {:next_event, :internal, {:handle, fn -> pass end}}}
 
       {:error, reason} ->
@@ -107,9 +115,16 @@ defmodule Supavisor.ClientHandler do
            Supavisor.subscribe_global(node(tenant_sup), self(), tenant, db_alias),
          ps <-
            Manager.get_parameter_status(manager) do
+      db_pid =
+        if data.mode == :session do
+          db_checkout(pool, tenant, db_alias, data.timeout)
+        else
+          nil
+        end
+
       Process.monitor(manager)
       :ok = :gen_tcp.send(data.socket, Server.greetings(ps))
-      {:next_state, :idle, %{data | pool: pool, manager: manager}}
+      {:next_state, :idle, %{data | pool: pool, manager: manager, db_pid: db_pid}}
     else
       error ->
         Logger.error("Subscribe error: #{inspect(error)}")
@@ -127,11 +142,14 @@ defmodule Supavisor.ClientHandler do
     :keep_state_and_data
   end
 
-  def handle_event(:info, {:tcp, _, bin}, :idle, data) do
+  def handle_event(:info, {:tcp, _, bin}, :idle, %{mode: :session} = data) do
+    {:next_state, :busy, %{data | query_start: System.monotonic_time()},
+     {:next_event, :internal, {:tcp, nil, bin}}}
+  end
+
+  def handle_event(:info, {:tcp, _, bin}, :idle, %{mode: :transaction} = data) do
     ts = System.monotonic_time()
-    {time, db_pid} = :timer.tc(:poolboy, :checkout, [data.pool, true, 60_000])
-    Telem.pool_checkout_time(time, data.tenant, data.user_alias)
-    Process.link(db_pid)
+    db_pid = db_checkout(data.pool, data.tenant, data.user_alias, data.timeout)
 
     {:next_state, :busy, %{data | db_pid: db_pid, query_start: ts},
      {:next_event, :internal, {:tcp, nil, bin}}}
@@ -200,11 +218,18 @@ defmodule Supavisor.ClientHandler do
     if ready? do
       Logger.debug("Client is ready")
 
-      Process.unlink(data.db_pid)
-      :poolboy.checkin(data.pool, data.db_pid)
+      new_data =
+        if data.mode == :transaction do
+          Process.unlink(data.db_pid)
+          :poolboy.checkin(data.pool, data.db_pid)
+          %{data | db_pid: nil}
+        else
+          data
+        end
+
       Telem.network_usage(:client, data.socket, data.tenant, data.user_alias)
       Telem.client_query_time(data.query_start, data.tenant, data.user_alias)
-      {:next_state, :idle, %{data | db_pid: nil}, reply}
+      {:next_state, :idle, new_data, reply}
     else
       Logger.debug("Client is not ready")
       {:keep_state_and_data, reply}
@@ -223,6 +248,28 @@ defmodule Supavisor.ClientHandler do
 
     :keep_state_and_data
   end
+
+  @impl true
+  def terminate(
+        {:timeout, {_, _, [_, {:checkout, _, _}, _]}},
+        _,
+        data
+      ) do
+    msg =
+      case data.mode do
+        :session ->
+          "Too many clients already"
+
+        :transaction ->
+          "Unable to check out process from the pool due to timeout"
+      end
+
+    Logger.error(msg)
+    Server.send_error(data.socket, "XX000", msg)
+    :ok
+  end
+
+  def terminate(_reason, _state, _data), do: :ok
 
   ## Internal functions
 
@@ -308,5 +355,13 @@ defmodule Supavisor.ClientHandler do
       15_000 ->
         {:error, "Timeout while waiting for the first password message"}
     end
+  end
+
+  @spec db_checkout(pid(), String.t(), String.t(), integer()) :: pid()
+  defp db_checkout(pool, tenant, user_alias, timeout) do
+    {time, db_pid} = :timer.tc(:poolboy, :checkout, [pool, true, timeout])
+    Process.link(db_pid)
+    Telem.pool_checkout_time(time, tenant, user_alias)
+    db_pid
   end
 end

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -23,7 +23,7 @@ defmodule Supavisor.DbHandler do
   @impl true
   def init(args) do
     Process.flag(:trap_exit, true)
-    Logger.metadata(project: args.tenant)
+    Logger.metadata(project: args.tenant, user: args.user_alias)
 
     data = %{
       socket: nil,

--- a/lib/supavisor/manager.ex
+++ b/lib/supavisor/manager.ex
@@ -42,6 +42,7 @@ defmodule Supavisor.Manager do
       parameter_status: []
     }
 
+    Logger.metadata(project: args.tenant, user: args.user_alias)
     Registry.register(Supavisor.Registry.ManagerTables, {args.tenant, args.user_alias}, tid)
 
     {:ok, state}

--- a/lib/supavisor/tenant_supervisor.ex
+++ b/lib/supavisor/tenant_supervisor.ex
@@ -13,11 +13,17 @@ defmodule Supavisor.TenantSupervisor do
   def init(%{tenant: tenant, user_alias: user_alias, pool_size: pool_size} = args) do
     id = {tenant, user_alias}
 
+    {size, overflow} =
+      case args.mode do
+        :session -> {0, pool_size}
+        :transaction -> {pool_size, 0}
+      end
+
     pool_spec = [
       name: {:via, Registry, {Supavisor.Registry.Tenants, {:pool, id}}},
       worker_module: Supavisor.DbHandler,
-      size: pool_size,
-      max_overflow: 0
+      size: size,
+      max_overflow: overflow
     ]
 
     children = [

--- a/lib/supavisor/tenants/user.ex
+++ b/lib/supavisor/tenants/user.ex
@@ -13,8 +13,9 @@ defmodule Supavisor.Tenants.User do
     field(:db_user, :string)
     field(:db_password, Supavisor.Encrypted.Binary, source: :db_pass_encrypted)
     field(:is_manager, :boolean, default: false)
-    field(:mode_type, Ecto.Enum, values: [:transaction])
+    field(:mode_type, Ecto.Enum, values: [:transaction, :session])
     field(:pool_size, :integer)
+    field(:pool_checkout_timeout, :integer, default: 60000)
     belongs_to(:tenant, Supavisor.Tenants.Tenant, foreign_key: :tenant_external_id, type: :string)
     timestamps()
   end
@@ -35,7 +36,8 @@ defmodule Supavisor.Tenants.User do
       :db_password,
       :pool_size,
       :mode_type,
-      :is_manager
+      :is_manager,
+      :pool_checkout_timeout
     ])
     |> validate_required([
       :db_user_alias,

--- a/lib/supavisor/tenants/user.ex
+++ b/lib/supavisor/tenants/user.ex
@@ -15,7 +15,7 @@ defmodule Supavisor.Tenants.User do
     field(:is_manager, :boolean, default: false)
     field(:mode_type, Ecto.Enum, values: [:transaction, :session])
     field(:pool_size, :integer)
-    field(:pool_checkout_timeout, :integer, default: 60000)
+    field(:pool_checkout_timeout, :integer, default: 60_000)
     belongs_to(:tenant, Supavisor.Tenants.Tenant, foreign_key: :tenant_external_id, type: :string)
     timestamps()
   end

--- a/lib/supavisor_web/views/user_view.ex
+++ b/lib/supavisor_web/views/user_view.ex
@@ -7,7 +7,8 @@ defmodule SupavisorWeb.UserView do
       db_user: user.db_user,
       pool_size: user.pool_size,
       is_manager: user.is_manager,
-      mode_type: user.mode_type
+      mode_type: user.mode_type,
+      pool_checkout_timeout: user.pool_checkout_timeout
     }
   end
 end

--- a/priv/repo/migrations/20230502101623_add_timeout_to_users.exs
+++ b/priv/repo/migrations/20230502101623_add_timeout_to_users.exs
@@ -1,0 +1,15 @@
+defmodule Supavisor.Repo.Migrations.AddTimeoutToUsers do
+  use Ecto.Migration
+
+  def up do
+    alter table("users") do
+      add(:pool_checkout_timeout, :integer, default: 60_000)
+    end
+  end
+
+  def down do
+    alter table("users") do
+      remove(:pool_checkout_timeout)
+    end
+  end
+end

--- a/priv/repo/migrations/20230502101623_add_timeout_to_users.exs
+++ b/priv/repo/migrations/20230502101623_add_timeout_to_users.exs
@@ -3,7 +3,7 @@ defmodule Supavisor.Repo.Migrations.AddTimeoutToUsers do
 
   def up do
     alter table("users") do
-      add(:pool_checkout_timeout, :integer, default: 60_000)
+      add(:pool_checkout_timeout, :integer, default: 60_000, null: false)
     end
   end
 

--- a/priv/repo/seeds_after_migration.exs
+++ b/priv/repo/seeds_after_migration.exs
@@ -24,6 +24,14 @@ end
           "db_password" => db_conf[:password],
           "pool_size" => 3,
           "mode_type" => "transaction"
+        },
+        %{
+          "db_user_alias" => "session",
+          "db_user" => db_conf[:username],
+          "db_password" => db_conf[:password],
+          "pool_size" => 1,
+          "mode_type" => "session",
+          "pool_checkout_timeout" => 500
         }
       ]
     }


### PR DESCRIPTION
In this PR, session mode functionality is implemented, with each client connection initiating a direct link to the tenant's database. The primary work is done using poolboy's `max_overflow` parameter. 

For session mode, we start an empty pool and set a specific value for `max_overflow`, which represents the maximum number of workers created if the pool is empty.