### PR TITLE
feat: handle MD5 authentication

### DIFF
--- a/dev/postgres/md5/etc/postgresql/pg_hba.conf
+++ b/dev/postgres/md5/etc/postgresql/pg_hba.conf
@@ -1,0 +1,91 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local         DATABASE  USER  METHOD  [OPTIONS]
+# host          DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl     DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostgssenc    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnogssenc  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# non-SSL TCP/IP socket.  Similarly, "hostgssenc" uses a
+# GSSAPI-encrypted TCP/IP socket, while "hostnogssenc" uses a
+# non-GSSAPI socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
+# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
+# Note that "password" sends passwords in clear text; "md5" or
+# "scram-sha-256" are preferred since they send encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the server receives a
+# SIGHUP signal.  If you edit the file on a running system, you have to
+# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
+# or execute "SELECT pg_reload_conf()".
+#
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# trust local connections
+local all  supabase_admin     md5
+local all  all                peer map=supabase_map
+host  all  all  127.0.0.1/32  trust
+host  all  all  ::1/128       trust
+
+# IPv4 external connections
+host  all  all  10.0.0.0/8  md5
+host  all  all  172.16.0.0/12  md5
+host  all  all  192.168.0.0/16  md5
+host  all  all  0.0.0.0/0     md5

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -8,7 +8,11 @@ services:
       - "6432:5432"
     volumes:
       - ./dev/postgres:/docker-entrypoint-initdb.d/
+      # Uncomment to set MD5 authentication method on unitialized databases
+      # - ./dev/postgres/md5/etc/postgresql/pg_hba.conf:/etc/postgresql/pg_hba.conf
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       POSTGRES_HOST: /var/run/postgresql
       POSTGRES_PASSWORD: postgres
+      # Uncomment to set MD5 authentication method on unitialized databases
+      # POSTGRES_INITDB_ARGS: --auth-host=md5

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -138,6 +138,20 @@ defmodule Supavisor.DbHandler do
         %{payload: {:authentication_server_final_message, _server_final}}, acc ->
           acc
 
+        %{payload: {:authentication_md5_password, salt}}, {ps, _} ->
+          password = data.auth.password
+          user = data.auth.user
+
+          digest = [password.(), user] |> :erlang.md5() |> Base.encode16(case: :lower)
+          digest = [digest, salt] |> :erlang.md5() |> Base.encode16(case: :lower)
+          payload = ["md5", digest, 0]
+
+          bin = [?p, <<IO.iodata_length(payload) + 4::signed-32>>, payload]
+
+          :gen_tcp.send(data.socket, bin)
+
+          {ps, :authentication_md5}
+
         _e, acc ->
           acc
       end)
@@ -148,6 +162,9 @@ defmodule Supavisor.DbHandler do
 
       {_, :authentication_server_first_message, server_proof} ->
         {:keep_state, %{data | server_proof: server_proof}}
+
+      {_, :authentication_md5} ->
+        {:keep_state, data}
 
       {ps, db_state} ->
         Logger.debug("DB ready_for_query: #{inspect(db_state)} #{inspect(ps, pretty: true)}")

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -102,4 +102,43 @@ defmodule Supavisor.DbHandlerTest do
     assert new_data.caller == self()
     assert new_data.buffer == ["test_data"]
   end
+
+  describe "handle_event/4 info tcp authentication authentication_md5_password payload events" do
+    test "keeps state while sending the digested md5" do
+      # `82` is `?R`, which identifies the payload tag as `:authentication`
+      # `0, 0, 0, 12` is the packet length
+      # `0, 0, 0, 5` is the authentication type, identified as `:authentication_md5_password`
+      # `100, 100, 100, 100` is the md5 salt from db, a random 4 bytes value
+      bin = <<82, 0, 0, 0, 12, 0, 0, 0, 5, 100, 100, 100, 100>>
+
+      # The incoming port (#Port<0.00>), unused
+      tcp_port = Enum.random(1..999_999)
+
+      content = {:tcp, tcp_port, bin}
+
+      # The outgoing port (#Port<0.00>), used to send message to the db, meck overrides it
+      socket_port = Enum.random(1..999_999)
+
+      data = %{
+        auth: %{
+          password: fn -> "some_password" end,
+          user: "some_user"
+        },
+        socket: socket_port
+      }
+
+      :meck.new(:gen_tcp, [:unstick, :passthrough])
+
+      :meck.expect(:gen_tcp, :send, fn port, message ->
+        assert port == socket_port
+        assert message == [?p, <<40::integer-32>>, ["md5", "ae5546ff52734a18d0277977f626946c", 0]]
+
+        :ok
+      end)
+
+      assert {:keep_state, ^data} = Db.handle_event(:info, content, :authentication, data)
+
+      :meck.unload(:gen_tcp)
+    end
+  end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow tenants to authenticate using [MD5 method](https://www.postgresql.org/docs/current/auth-password.html).

## What is the current behavior?

Simply ignores `:authentication_md5_password` messages from server.

## What is the new behavior?

Handles `:authentication_md5_password` messages from server, proper replying the digested hash.

## Additional context

Based on [Postgrex implementation](https://github.com/elixir-ecto/postgrex/blob/v0.17.1/lib/postgrex/protocol.ex#L805-L812).

Currently working on local docker postgres instance and on private AWS RDS instance.

Available to improve the code and to generate unit tests and/or integration tests.