### PR TITLE
feat: Add OTEL Support

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -8,6 +8,11 @@ defmodule Supavisor.Application do
 
   @impl true
   def start(_type, _args) do
+    # OpenTelemetry setup
+    :opentelemetry_cowboy.setup()
+    OpentelemetryPhoenix.setup(adapter: :cowboy2)
+    OpentelemetryEcto.setup([:supavisor, :repo])
+
     :ok =
       :gen_event.swap_sup_handler(
         :erl_signal_server,
@@ -60,6 +65,8 @@ defmodule Supavisor.Application do
       },
       Supavisor.Vault
     ]
+
+
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,13 @@ defmodule Supavisor.MixProject do
       # pooller
       {:poolboy, "~> 1.5.2"},
       {:syn, "~> 3.3"},
-      {:pgo, "~> 0.13"}
+      {:pgo, "~> 0.13"},
+
+      {:opentelemetry, "~> 1.3"},
+      {:opentelemetry_api, "~> 1.2"},
+      {:opentelemetry_exporter, "~> 1.4"},
+      {:opentelemetry_phoenix, "~> 1.1"},
+      {:opentelemetry_cowboy, "~> 0.2"}
       # TODO: add ranch deps
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,8 @@ defmodule Supavisor.MixProject do
       {:opentelemetry_api, "~> 1.2"},
       {:opentelemetry_exporter, "~> 1.4"},
       {:opentelemetry_phoenix, "~> 1.1"},
-      {:opentelemetry_cowboy, "~> 0.2"}
+      {:opentelemetry_cowboy, "~> 0.2"},
+      {:opentelemetry_ecto, "~> 1.1.1"}
       # TODO: add ranch deps
     ]
   end
@@ -75,7 +76,8 @@ defmodule Supavisor.MixProject do
   def releases do
     [
       supavisor: [
-        include_erts: System.get_env("INCLUDE_ERTS", "true") == "true"
+        include_erts: System.get_env("INCLUDE_ERTS", "true") == "true",
+        applications: [opentelemetry: :temporary]
       ],
       supavisor_bin: [
         steps: [:assemble, &Burrito.wrap/1],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Aims to address #93 by adding an initial setup with OTEL as as well as how to connect to a monitoring solution (in this case SigNoz) . Need to properly do dependency resolution and add instructions on how to connect to a generic provider

## What is the current behavior?

It seems like have telemetry but not OTEL support

## What is the new behavior?

Can send basic spans to an external provider - it looks like this on SigNoz:
<img width="1244" alt="CleanShot 2023-05-31 at 23 45 51@2x" src="https://github.com/supabase/supavisor/assets/8011761/6bb2688e-3880-4855-8915-9735b75872cd">



## Additional context

Followed the [guide](https://opentelemetry.io/docs/instrumentation/erlang/getting-started/) to set up OTEL. 
[This SigNoz article](https://signoz.io/blog/opentelemetry-elixir/) was also used