### PR TITLE
Validate startup packets

### DIFF
--- a/test/supavisor/client_handler_test.exs
+++ b/test/supavisor/client_handler_test.exs
@@ -17,4 +17,28 @@ defmodule Supavisor.ClientHandlerTest do
       assert external_id == "external_id"
     end
   end
+
+  describe "decode_startup_packet/1" do
+    test "handles bad startup packets" do
+      packet = <<0, 0, 0, 8, 0, 0, 0, 0, 3>>
+      assert {:error, _} = ClientHandler.decode_startup_packet(packet)
+    end
+
+    test "handles valid startup packets" do
+      payload = %{
+        "DateStyle" => "ISO",
+        "TimeZone" => "Asia/Tokyo",
+        "client_encoding" => "UTF8",
+        "database" => "mydbname",
+        "extra_float_digits" => "2",
+        "user" => "tenant.mytenant"
+      }
+
+      fields = Enum.reduce(payload, [], fn {k, v}, acc -> [k, v | acc] end) |> Enum.join(<<0>>)
+      len = String.length(fields) + 4
+      packet = <<len::integer-32, "prot"::binary, fields::binary>>
+      assert {:ok, hello} = ClientHandler.decode_startup_packet(packet)
+      assert hello[:payload]["user"] == "tenant.mytenant"
+    end
+  end
 end


### PR DESCRIPTION
We get a lot of log messages about `function_clause` errors etc that are actually just a result of bots sending packets to Supavisor.

This change filters out the noise from unserious clients (like bots/scrapers) sending requests. It does so by validating the startup packet is in the rough shape we're expecting.