### PR TITLE
feat: retrieve the tenant id from the server name indication

### DIFF
--- a/lib/supavisor/helpers.ex
+++ b/lib/supavisor/helpers.ex
@@ -93,7 +93,7 @@ defmodule Supavisor.Helpers do
 
       %{columns: [_, _], rows: []} ->
         {:error,
-         "There is no user #{user} in the database. Please create it or change the user in the config"}
+         "There is no user '#{user}' in the database. Please create it or change the user in the config"}
 
       %{columns: colums} ->
         {:error,

--- a/lib/supavisor/tenants.ex
+++ b/lib/supavisor/tenants.ex
@@ -43,10 +43,10 @@ defmodule Supavisor.Tenants do
     Tenant |> Repo.get_by(external_id: external_id) |> Repo.preload(:users)
   end
 
-  @spec get_user(String.t(), String.t() | nil) ::
+  @spec get_user(String.t(), String.t() | nil, String.t() | nil) ::
           {:ok, map()} | {:error, :not_found | :multiple_results}
-  def get_user(external_id, user) do
-    query = build_user_query(external_id, user)
+  def get_user(user, external_id, sni_hostname) do
+    query = build_user_query(user, external_id, sni_hostname)
 
     case Repo.all(query) do
       nil ->
@@ -56,21 +56,30 @@ defmodule Supavisor.Tenants do
         {:ok, %{user: user, tenant: tenant}}
 
       [] ->
-        get_auth_user(external_id)
+        get_auth_user(external_id, sni_hostname)
 
       _ ->
         {:error, :multiple_results}
     end
   end
 
-  def get_auth_user(external_id) do
+  def get_auth_user(external_id, sni_hostname) do
     query =
-      from(t in Tenant,
-        join: u in User,
-        on: u.tenant_external_id == t.external_id,
-        where: t.external_id == ^external_id and t.require_user == false,
-        select: {u, t}
-      )
+      if sni_hostname do
+        from(u in User,
+          join: t in Tenant,
+          on: u.tenant_external_id == t.external_id,
+          where: t.sni_hostname == ^sni_hostname and t.require_user == false,
+          select: {u, t}
+        )
+      else
+        from(t in Tenant,
+          join: u in User,
+          on: u.tenant_external_id == t.external_id,
+          where: t.external_id == ^external_id and t.require_user == false,
+          select: {u, t}
+        )
+      end
 
     case Repo.all(query) do
       [{%User{}, %Tenant{}} = {user, tenant}] ->
@@ -260,22 +269,32 @@ defmodule Supavisor.Tenants do
     User.changeset(user, attrs)
   end
 
-  @spec build_user_query(String.t(), String.t() | nil) :: Ecto.Queryable.t()
-  defp build_user_query(external_id, user) do
-    query =
-      from(u in User,
-        join: t in Tenant,
-        on: u.tenant_external_id == t.external_id,
-        where: u.tenant_external_id == ^external_id,
-        select: {u, t}
-      )
-
-    if user do
-      from(u in query,
-        where: u.db_user_alias == ^user
-      )
+  @spec build_user_query(String.t(), String.t() | nil, String.t() | nil) :: Ecto.Queryable.t()
+  defp build_user_query(user, external_id, sni_hostname) do
+    if sni_hostname do
+      query =
+        from(t in Tenant,
+          join: u in User,
+          on: u.tenant_external_id == t.external_id,
+          where: t.sni_hostname == ^sni_hostname,
+          select: {u, t}
+        )
     else
-      query
+      query =
+        from(u in User,
+          join: t in Tenant,
+          on: u.tenant_external_id == t.external_id,
+          where: u.tenant_external_id == ^external_id,
+          select: {u, t}
+        )
+
+      if user do
+        from(u in query,
+          where: u.db_user_alias == ^user
+        )
+      else
+        query
+      end
     end
   end
 end

--- a/lib/supavisor/tenants/tenant.ex
+++ b/lib/supavisor/tenants/tenant.ex
@@ -24,6 +24,7 @@ defmodule Supavisor.Tenants.Tenant do
     field(:require_user, :boolean, default: false)
     field(:auth_query, :string)
     field(:default_pool_size, :integer, default: 15)
+    field(:sni_hostname, :string)
 
     has_many(:users, User,
       foreign_key: :tenant_external_id,
@@ -51,7 +52,8 @@ defmodule Supavisor.Tenants.Tenant do
       :enforce_ssl,
       :require_user,
       :auth_query,
-      :default_pool_size
+      :default_pool_size,
+      :sni_hostname
     ])
     |> check_constraint(:upstream_ssl, name: :upstream_constraints, prefix: "_supavisor")
     |> check_constraint(:upstream_verify, name: :upstream_constraints, prefix: "_supavisor")

--- a/lib/supavisor_web/views/tenant_view.ex
+++ b/lib/supavisor_web/views/tenant_view.ex
@@ -24,6 +24,7 @@ defmodule SupavisorWeb.TenantView do
       enforce_ssl: tenant.enforce_ssl,
       require_user: tenant.require_user,
       auth_query: tenant.auth_query,
+      sni_hostname: tenant.sni_hostname,
       users: render_many(tenant.users, UserView, "user.json")
     }
   end

--- a/priv/repo/migrations/20230718175315_add_sni_host.exs
+++ b/priv/repo/migrations/20230718175315_add_sni_host.exs
@@ -1,15 +1,9 @@
 defmodule Supavisor.Repo.Migrations.AddSniHost do
   use Ecto.Migration
 
-  def up do
+  def change do
     alter table("tenants", prefix: "_supavisor") do
       add(:sni_hostname, :string, null: true)
-    end
-  end
-
-  def down do
-    alter table("tenants", prefix: "_supavisor") do
-      remove(:sni_hostname)
     end
   end
 end

--- a/priv/repo/migrations/20230718175315_add_sni_host.exs
+++ b/priv/repo/migrations/20230718175315_add_sni_host.exs
@@ -1,0 +1,15 @@
+defmodule Supavisor.Repo.Migrations.AddSniHost do
+  use Ecto.Migration
+
+  def up do
+    alter table("tenants", prefix: "_supavisor") do
+      add(:sni_hostname, :string, null: true)
+    end
+  end
+
+  def down do
+    alter table("tenants", prefix: "_supavisor") do
+      remove(:sni_hostname)
+    end
+  end
+end

--- a/test/supavisor/client_handler_test.exs
+++ b/test/supavisor/client_handler_test.exs
@@ -11,10 +11,10 @@ defmodule Supavisor.ClientHandlerTest do
       assert external_id == "external_id"
     end
 
-    test "username consists only of external_id" do
-      username = "external_id"
-      {nil, external_id} = ClientHandler.parse_user_info(username)
-      assert external_id == "external_id"
+    test "username consists only of username" do
+      username = "username"
+      {user, nil} = ClientHandler.parse_user_info(username)
+      assert username == "username"
     end
   end
 end


### PR DESCRIPTION
This PR introduces a new method to retrieve the tenant ID. If the client uses an SSL connection, we attempt to find the tenant by using `sni_hostname`