### PR TITLE
feat: handling of named prepared statements

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -367,6 +367,7 @@ defmodule Supavisor.ClientHandler do
      {:next_event, :internal, {proto, nil, bin}}}
   end
 
+  # forward query to db
   def handle_event(_, {proto, _, bin}, :busy, data)
       when proto in [:tcp, :ssl] do
     {_, db_pid} = data.db_pid

--- a/lib/supavisor/manager.ex
+++ b/lib/supavisor/manager.ex
@@ -124,6 +124,11 @@ defmodule Supavisor.Manager do
     end
   end
 
+  def handle_info(msg, state) do
+    Logger.warning("Undefined msg: #{inspect(msg, pretty: true)}")
+    {:noreply, state}
+  end
+
   ## Internal functions
 
   defp check_subscribers() do

--- a/priv/repo/seeds_after_migration.exs
+++ b/priv/repo/seeds_after_migration.exs
@@ -30,7 +30,7 @@ end
         %{
           "db_user" => db_conf[:username],
           "db_password" => db_conf[:password],
-          "pool_size" => 3,
+          "pool_size" => 9,
           "mode_type" => "transaction"
         },
         %{

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -28,6 +28,26 @@ defmodule Supavisor.Integration.ProxyTest do
     %{proxy: proxy, origin: origin, user: db_conf[:username]}
   end
 
+  test "prepared statement", %{proxy: proxy} do
+    db_conf = Application.get_env(:supavisor, Repo)
+
+    url = """
+    postgresql://#{db_conf[:username] <> "." <> @tenant}:#{db_conf[:password]}\
+    @#{db_conf[:hostname]}:#{Application.get_env(:supavisor, :proxy_port_transaction)}/postgres
+    """
+
+    prepare_sql =
+      "PREPARE tenant (text) AS SELECT id, external_id FROM _supavisor.tenants WHERE external_id = $1;"
+
+    {result, _} = System.cmd("psql", [url, "-c", prepare_sql], stderr_to_stdout: true)
+    assert result =~ "PREPARE"
+
+    {result, _} =
+      System.cmd("psql", [url, "-c", "EXECUTE tenant('#{@tenant}');"], stderr_to_stdout: true)
+
+    assert result =~ "#{@tenant}\n(1 row)"
+  end
+
   test "the wrong password" do
     db_conf = Application.get_env(:supavisor, Repo)
 


### PR DESCRIPTION
This PR introduces support for prepared named statements in transaction mode. 

[Supavisor attempts to decode all incoming queries](https://github.com/supabase/supavisor/blob/493c6deac161fa13780e54d8eeb8528ca9dd7965/lib/supavisor/client_handler.ex#L807) from connected users and retrieves the SQL statement by parsing the decoded queries through an [existing Rustler wrapper](https://github.com/supabase/supavisor/blob/feat/named_ps/native/pgparser/src/lib.rs) around `libpg_query`. When the parsed query contains `PrepareStmt` or `DeallocateStmt` (which requires removing an existing named statement), the `ClientHandler` [broadcasts](https://github.com/supabase/supavisor/blob/493c6deac161fa13780e54d8eeb8528ca9dd7965/lib/supavisor/client_handler.ex#L813-L825) it to all other `DbHandlers` in the pool.

In `DbHandler`, these queries [accumulate in the `anon_buffer` list](https://github.com/supabase/supavisor/blob/5a1a860ee7abf68bed61978bd4fa237d6129b453/lib/supavisor/db_handler.ex#L327) and will be applied when [`data.caller` is `nil`](https://github.com/supabase/supavisor/blob/5a1a860ee7abf68bed61978bd4fa237d6129b453/lib/supavisor/db_handler.ex#L248-L257). They will wait [until the current PID is unlinked](https://github.com/supabase/supavisor/blob/5a1a860ee7abf68bed61978bd4fa237d6129b453/lib/supavisor/db_handler.ex#L313-L317) in cases where the process is reserved by another client

<img width="1423" alt="Screenshot 2023-12-07 at 11 02 40" src="https://github.com/supabase/supavisor/assets/1172600/c812d9d5-ac64-44ce-a31a-22628ae8e232">

