### PR TITLE
feat: attempt to pre-compile NIFs to speed up CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,12 @@ COPY priv priv
 COPY lib lib
 COPY native native
 
+# As pgparser is less likely to change, we compile it first
+WORKDIR "/app/supavisor/native/pgparser"
+RUN cargo build --release
+WORKDIR "/app"
+
+
 # Compile the release
 RUN mix compile
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

TODO:
- Update [supavisor](https://github.com/supabase/supavisor/tree/main)/[.github](https://github.com/supabase/supavisor/tree/main/.github)/[workflows](https://github.com/supabase/supavisor/tree/main/.github/workflows)
/publish_docker.yml

to use Rust cache-actions and cache this: `supavisor/native/pgparser/Cargo.lock` or similar


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
