### PR TITLE
Move from `ct_slave` to `peer`

### DIFF
--- a/test/supavisor/prom_ex_test.exs
+++ b/test/supavisor/prom_ex_test.exs
@@ -28,10 +28,10 @@ defmodule Supavisor.PromExTest do
   test "remove tenant tag upon termination", %{proxy: proxy, user: user, db_name: db_name} do
     assert PromEx.get_metrics() =~ "tenant=\"#{@tenant}\""
 
-    GenServer.stop(proxy)
-    Supavisor.stop({{:single, @tenant}, user, :transaction, db_name})
+    :ok = GenServer.stop(proxy)
+    :ok = Supavisor.stop({{:single, @tenant}, user, :transaction, db_name})
 
-    Process.sleep(500)
+    Process.sleep(1000)
 
     refute PromEx.get_metrics() =~ "tenant=\"#{@tenant}\""
   end

--- a/test/supavisor/syn_handler_test.exs
+++ b/test/supavisor/syn_handler_test.exs
@@ -7,7 +7,7 @@ defmodule Supavisor.SynHandlerTest do
   @id {{:single, "syn_tenant"}, "postgres", :session, "postgres"}
 
   test "resolving conflict" do
-    node2 = :"secondary@127.0.0.1"
+    {:ok, _pid, node2} = Supavisor.Support.Cluster.start_node()
 
     secret = %{alias: "postgres"}
     auth_secret = {:password, fn -> secret end}
@@ -16,7 +16,7 @@ defmodule Supavisor.SynHandlerTest do
     assert pid2 == Supavisor.get_global_sup(@id)
     assert node(pid2) == node2
     true = Node.disconnect(node2)
-    Process.sleep(500)
+    Process.sleep(1000)
 
     assert nil == Supavisor.get_global_sup(@id)
     {:ok, pid1} = Supavisor.start(@id, auth_secret)
@@ -28,7 +28,7 @@ defmodule Supavisor.SynHandlerTest do
 
     msg = "Resolving syn_tenant conflict, stop local pid"
 
-    assert capture_log(fn -> Logger.warn(msg) end) =~
+    assert capture_log(fn -> Logger.warning(msg) end) =~
              msg
 
     assert pid2 == Supavisor.get_global_sup(@id)

--- a/test/supavisor_web/controllers/metrics_controller_test.exs
+++ b/test/supavisor_web/controllers/metrics_controller_test.exs
@@ -13,6 +13,10 @@ defmodule SupavisorWeb.MetricsControllerTest do
   end
 
   test "exporting metrics", %{conn: conn} do
+    {:ok, _pid, node2} = Supavisor.Support.Cluster.start_node()
+
+    Node.connect(node2)
+
     :meck.expect(Supavisor.Jwt, :authorize, fn _token, _secret -> {:ok, %{}} end)
     conn = get(conn, Routes.metrics_path(conn, :index))
     assert conn.status == 200

--- a/test/support/cluster.ex
+++ b/test/support/cluster.ex
@@ -3,7 +3,24 @@ defmodule Supavisor.Support.Cluster do
   This module provides functionality to help handle distributive mode for testing.
   """
 
-  def apply_config(node) do
+  def start_node(name \\ :peer.random_name()) do
+    {:ok, pid, node} =
+      :peer.start_link(%{
+        name: name,
+        host: ~c"127.0.0.1",
+        longnames: true,
+        connection: :standard_io
+      })
+
+    :peer.call(pid, :logger, :set_primary_config, [:level, :none])
+    true = :peer.call(pid, :code, :set_path, [:code.get_path()])
+    apply_config(pid)
+    :peer.call(pid, Application, :ensure_all_started, [:supavisor])
+
+    {:ok, pid, node}
+  end
+
+  defp apply_config(pid) do
     for {app_name, _, _} <- Application.loaded_applications() do
       for {key, val} <- Application.get_all_env(app_name) do
         val =
@@ -27,9 +44,10 @@ defmodule Supavisor.Support.Cluster do
               val
           end
 
-        :rpc.call(node, Application, :put_env, [app_name, key, val, [persistent: true]])
-        :rpc.call(node, Supavisor.Monitoring.PromEx, :set_metrics_tags, [])
+        :peer.call(pid, Application, :put_env, [app_name, key, val])
       end
     end
+
+    :peer.call(pid, Supavisor.Monitoring.PromEx, :set_metrics_tags, [])
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,11 +1,4 @@
 {:ok, _} = Node.start(:"primary@127.0.0.1", :longnames)
-node2 = :"secondary@127.0.0.1"
-:ct_slave.start(node2)
-true = :erpc.call(node2, :code, :set_path, [:code.get_path()])
-
-Supavisor.Support.Cluster.apply_config(node2)
-
-{:ok, _} = :erpc.call(node2, :application, :ensure_all_started, [:supavisor])
 
 Cachex.start_link(name: Supavisor.Cache)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Replace deprecated `ct_slave` module with new `peer` module.

## Additional context

This also changes the sub-nodes to start only when needed instead of starting always for whole suite.
