### PR TITLE
chore: use `or` instead of `||`

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -297,7 +297,7 @@ defmodule Supavisor.ClientHandler do
              Cachex.get(Supavisor.Cache, key) == {:ok, nil} do
           case auth_secrets(info, data.user, key, 15_000) do
             {:ok, {method2, secrets2}} = value ->
-              if method != method2 || Map.delete(secrets.(), :client_key) != secrets2.() do
+              if method != method2 or Map.delete(secrets.(), :client_key) != secrets2.() do
                 Logger.warning("ClientHandler: Update secrets and terminate pool")
 
                 Cachex.update(
@@ -632,7 +632,7 @@ defmodule Supavisor.ClientHandler do
     db_info =
       case Db.get_state_and_mode(pid) do
         {:ok, {state, mode} = resp} ->
-          if state == :busy || mode == :session, do: Db.stop(pid)
+          if state == :busy or mode == :session, do: Db.stop(pid)
           resp
 
         error ->

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -451,7 +451,7 @@ defmodule Supavisor.DbHandler do
       )
     end
 
-    if state == :busy || data.mode == :session do
+    if state == :busy or data.mode == :session do
       :ok = sock_send(data.sock, <<?X, 4::32>>)
       :gen_tcp.close(elem(data.sock, 1))
       {:stop, {:client_handler_down, data.mode}}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Replace uses of `||` with `or` in cases where both sides of operator are for
sure boolean.

Reason for that is that `||` works on other values than boolean, which mean that
`a || b` is translated to:

```elixir
case a do
  val when val in [nil, false] -> b
  _ -> a
end
```

Which needs to perform more tests and cannot be optimised that easily by the
compiler. New code should be easier for compiler to optimise.
