### PR TITLE
ft: gather metrics with low priority

### DIFF
--- a/lib/supavisor/tenants_metrics.ex
+++ b/lib/supavisor/tenants_metrics.ex
@@ -8,7 +8,12 @@ defmodule Supavisor.TenantsMetrics do
   @check_timeout 10_000
 
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+    GenServer.start_link(__MODULE__, args,
+      name: __MODULE__,
+      spawn_opt: [
+        priority: :low
+      ]
+    )
   end
 
   ## Callbacks

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -192,7 +192,7 @@ defmodule Supavisor.DbHandlerTest do
       :meck.new(:inet, [:unstick, :passthrough])
 
       :meck.expect(:prim_inet, :getstat, fn _, _ ->
-        {:ok, %{}}
+        {:ok, [{:recv_oct, 21}, {:send_oct, 37}]}
       end)
 
       :meck.expect(:inet, :setopts, fn _, _ -> :ok end)
@@ -224,7 +224,7 @@ defmodule Supavisor.DbHandlerTest do
       :meck.new(:inet, [:unstick, :passthrough])
 
       :meck.expect(:prim_inet, :getstat, fn _, _ ->
-        {:ok, %{}}
+        {:ok, [{:recv_oct, 21}, {:send_oct, 37}]}
       end)
 
       :meck.expect(:inet, :setopts, fn _, _ -> :ok end)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Performance improvement.

## What is the current behavior?

Metrics are gathered with normal priority. That can have performance impact on core of the application.

## What is the new behavior?

Lower priority of the metrics gathering process to not interfere with core of the application. This may cause some irregularities in gathered metrics, but at the same time it should reduce performance fluctuations of Supabase core.
