### PR TITLE
feat: implement proxy handler

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,17 @@ config :supavisor, SupavisorWeb.Endpoint,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id, :project, :user, :region, :instance_id, :mode, :type]
+  metadata: [
+    :request_id,
+    :project,
+    :user,
+    :region,
+    :instance_id,
+    :mode,
+    :type,
+    :app_name,
+    :peer_ip
+  ]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -61,9 +61,9 @@ config :supavisor, SupavisorWeb.Endpoint,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time [$level] $message $metadata\n",
-  # level: :debug,
-  level: :notice,
-  metadata: [:error_code, :file, :line, :pid, :project, :user, :mode, :type]
+  level: :debug,
+  # level: :notice,
+  metadata: [:error_code, :file, :line, :pid, :project, :user, :mode, :type, :app_name, :peer_ip]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/lib/supavisor/handler_helpers.ex
+++ b/lib/supavisor/handler_helpers.ex
@@ -10,8 +10,9 @@ defmodule Supavisor.HandlerHelpers do
     mod.send(sock, data)
   end
 
-  @spec sock_close(nil | S.sock()) :: :ok | {:error, term()}
+  @spec sock_close(S.sock() | nil | {any(), nil}) :: :ok | {:error, term()}
   def sock_close(nil), do: :ok
+  def sock_close({_, nil}), do: :ok
 
   def sock_close({mod, sock}) do
     mod.close(sock)
@@ -23,14 +24,11 @@ defmodule Supavisor.HandlerHelpers do
     mod.setopts(sock, opts)
   end
 
-  @spec activate(S.sock()) :: :ok | {:error, term}
-  def activate({:gen_tcp, sock}) do
-    :inet.setopts(sock, active: true)
-  end
+  @spec active_once(S.sock()) :: :ok | {:error, term}
+  def active_once(sock), do: setopts(sock, active: :once)
 
-  def activate({:ssl, sock}) do
-    :ssl.setopts(sock, active: true)
-  end
+  @spec activate(S.sock()) :: :ok | {:error, term}
+  def activate(sock), do: setopts(sock, active: true)
 
   @spec try_ssl_handshake(S.tcp_sock(), boolean) ::
           {:ok, S.sock()} | {:error, term()}
@@ -106,12 +104,12 @@ defmodule Supavisor.HandlerHelpers do
     end
   end
 
-  @spec send_cancel_query(non_neg_integer, non_neg_integer) :: :ok | {:errr, term}
-  def send_cancel_query(pid, key) do
+  @spec send_cancel_query(non_neg_integer, non_neg_integer, term) :: :ok | {:errr, term}
+  def send_cancel_query(pid, key, msg \\ :cancel_query) do
     PubSub.broadcast(
       Supavisor.PubSub,
       "cancel_req:#{pid}_#{key}",
-      :cancel_query
+      msg
     )
   end
 

--- a/lib/supavisor/handlers/proxy/client.ex
+++ b/lib/supavisor/handlers/proxy/client.ex
@@ -1,0 +1,662 @@
+defmodule Supavisor.Handlers.Proxy.Client do
+  @moduledoc false
+
+  require Logger
+
+  alias Supavisor, as: S
+  alias Supavisor.ProxyDb, as: Db
+  alias Supavisor.Helpers, as: H
+  alias Supavisor.HandlerHelpers, as: HH
+
+  alias Supavisor.{
+    Tenants,
+    ProxyHandlerDb,
+    Monitoring.Telem,
+    Protocol.Client,
+    Protocol.Server
+  }
+
+  alias Supavisor.Handlers.Proxy.Db, as: ProxyDb
+
+  @cancel_query_msg <<16::32, 1234::16, 5678::16>>
+  @sock_closed [:tcp_closed, :ssl_closed]
+  @proto [:tcp, :ssl]
+
+  def handle_event(:info, {_proto, _, <<"GET", _::binary>>}, :exchange, data) do
+    Logger.debug("ProxyClient: Client is trying to request HTTP")
+    HH.sock_send(data.sock, "HTTP/1.1 204 OK\r\nx-app-version: #{data.version}\r\n\r\n")
+    {:stop, {:shutdown, :http_request}}
+  end
+
+  # cancel request
+  def handle_event(:info, {_, _, <<@cancel_query_msg, pid::32, key::32>>}, _, _) do
+    Logger.debug("ProxyClient: Got cancel query for #{inspect({pid, key})}")
+    :ok = HH.send_cancel_query(pid, key, {:client, :cancel_query})
+    {:stop, {:shutdown, :cancel_query}}
+  end
+
+  def handle_event(:info, {:client, :cancel_query}, _, %{
+        auth: auth,
+        backend_key_data: b
+      }) do
+    :ok = HH.cancel_query(~c"#{auth.host}", auth.port, auth.ip_ver, b.pid, b.key)
+    :keep_state_and_data
+  end
+
+  # # ssl request from client
+  def handle_event(:info, {:tcp, _, <<_::64>>}, :exchange, %{sock: sock} = data) do
+    Logger.debug("ProxyClient: Client is trying to connect with SSL")
+
+    downstream_cert = H.downstream_cert()
+    downstream_key = H.downstream_key()
+
+    # SSL negotiation, S/N/Error
+    if !!downstream_cert and !!downstream_key do
+      :ok = HH.setopts(sock, active: false)
+      :ok = HH.sock_send(sock, "S")
+
+      opts = [
+        certfile: downstream_cert,
+        keyfile: downstream_key
+      ]
+
+      case :ssl.handshake(elem(sock, 1), opts) do
+        {:ok, ssl_sock} ->
+          socket = {:ssl, ssl_sock}
+          :ok = HH.setopts(socket, active: true)
+          {:keep_state, %{data | sock: socket, ssl: true}}
+
+        error ->
+          Logger.error("ProxyClient: SSL handshake error: #{inspect(error)}")
+          Telem.client_join(:fail, data.id)
+          {:stop, {:shutdown, :ssl_handshake_error}}
+      end
+    else
+      Logger.error("ProxyClient: User requested SSL connection but no downstream cert/key found")
+
+      :ok = HH.sock_send(data.sock, "N")
+      :keep_state_and_data
+    end
+  end
+
+  def handle_event(:info, {_, _, bin}, :exchange, data) do
+    case Server.decode_startup_packet(bin) do
+      {:ok, hello} ->
+        Logger.debug("ProxyClient: Client startup message: #{inspect(hello)}")
+        {type, {user, tenant_or_alias, db_name}} = HH.parse_user_info(hello.payload)
+
+        # Validate user and db_name according to PostgreSQL rules.
+        # The rules are: 1-63 characters, alphanumeric, underscore and $
+        # TODO: spaces are allowed in db_name, but we don't support it yet
+        rule = ~r/^[a-z_][a-z0-9_$]*$/
+
+        if user =~ rule and db_name =~ rule do
+          log_level = maybe_change_log(hello)
+          event = {:hello, {type, {user, tenant_or_alias, db_name}}}
+          app_name = app_name(hello.payload["application_name"])
+
+          {:keep_state, %{data | log_level: log_level, app_name: app_name},
+           {:next_event, :internal, {:client, event}}}
+        else
+          reason = "Invalid format for user or db_name"
+          Logger.error("ProxyClient: #{inspect(reason)}")
+          Telem.client_join(:fail, tenant_or_alias)
+          HH.send_error(data.sock, "XX000", "Authentication error, reason: #{inspect(reason)}")
+          {:stop, {:shutdown, :invalid_format}}
+        end
+
+      {:error, error} ->
+        Logger.error("ProxyClient: Client startup message error: #{inspect(error)}")
+        Telem.client_join(:fail, data.id)
+        {:stop, {:shutdown, :startup_packet_error}}
+    end
+  end
+
+  def handle_event(
+        :internal,
+        {:client, {:hello, {type, {user, tenant_or_alias, db_name}}}},
+        :exchange,
+        %{sock: sock} = data
+      ) do
+    sni_hostname = HH.try_get_sni(sock)
+
+    case Tenants.get_user_cache(type, user, tenant_or_alias, sni_hostname) do
+      {:ok, info} ->
+        db_name = if(db_name != nil, do: db_name, else: info.tenant.db_database)
+
+        id =
+          Supavisor.id(
+            {type, tenant_or_alias},
+            user,
+            data.mode,
+            info.user.mode_type,
+            db_name
+          )
+
+        mode = S.mode(id)
+
+        Logger.metadata(
+          project: tenant_or_alias,
+          user: user,
+          mode: mode,
+          type: type,
+          db_name: db_name,
+          app_name: data.app_name,
+          peer_ip: data.peer_ip
+        )
+
+        Registry.register(Supavisor.Registry.TenantClients, id, [])
+
+        {:ok, addr} = HH.addr_from_sock(sock)
+
+        cond do
+          info.tenant.enforce_ssl and !data.ssl ->
+            Logger.error(
+              "ProxyClient: Tenant is not allowed to connect without SSL, user #{user}"
+            )
+
+            :ok = HH.send_error(sock, "XX000", "SSL connection is required")
+            Telem.client_join(:fail, id)
+            {:stop, {:shutdown, :ssl_required}}
+
+          HH.filter_cidrs(info.tenant.allow_list, addr) == [] ->
+            message = "Address not in tenant allow_list: " <> inspect(addr)
+            Logger.error("ProxyClient: #{message}")
+            :ok = HH.send_error(sock, "XX000", message)
+
+            Telem.client_join(:fail, id)
+            {:stop, {:shutdown, :address_not_allowed}}
+
+          true ->
+            new_data = update_user_data(data, info, user, id, db_name, mode)
+
+            key = {:secrets, tenant_or_alias, user}
+
+            case auth_secrets(info, user, key, :timer.hours(24)) do
+              {:ok, auth_secrets} ->
+                Logger.debug("ProxyClient: Authentication method: #{inspect(auth_secrets)}")
+
+                event = {:handle, auth_secrets, info}
+                {:keep_state, new_data, {:next_event, :internal, {:client, event}}}
+
+              {:error, reason} ->
+                Logger.error("ProxyClient: Authentication auth_secrets error: #{inspect(reason)}")
+
+                :ok =
+                  HH.send_error(sock, "XX000", "Authentication error, reason: #{inspect(reason)}")
+
+                Telem.client_join(:fail, id)
+                {:stop, {:shutdown, :auth_secrets_error}}
+            end
+        end
+
+      {:error, reason} ->
+        Logger.error(
+          "ProxyClient: User not found: #{inspect(reason)} #{inspect({type, user, tenant_or_alias})}"
+        )
+
+        :ok = HH.send_error(sock, "XX000", "Tenant or user not found")
+        Telem.client_join(:fail, data.id)
+        {:stop, {:shutdown, :user_not_found}}
+    end
+  end
+
+  def handle_event(
+        :internal,
+        {:client, {:handle, {method, secrets}, info}},
+        _,
+        %{sock: sock} = data
+      ) do
+    Logger.debug("ProxyClient: Handle exchange, auth method: #{inspect(method)}")
+
+    case handle_exchange(sock, {method, secrets}) do
+      {:error, reason} ->
+        Logger.error(
+          "ProxyClient: Exchange error: #{inspect(reason)} when method #{inspect(method)}"
+        )
+
+        msg =
+          if method == :auth_query_md5,
+            do: Server.error_message("XX000", reason),
+            else: Server.exchange_message(:final, "e=#{reason}")
+
+        key = {:secrets_check, data.tenant, data.user}
+
+        if method != :password and reason == "Wrong password" and
+             Cachex.get(Supavisor.Cache, key) == {:ok, nil} do
+          case auth_secrets(info, data.user, key, 15_000) do
+            {:ok, {method2, secrets2}} = value ->
+              if method != method2 or Map.delete(secrets.(), :client_key) != secrets2.() do
+                Logger.warning("ProxyClient: Update secrets and terminate pool")
+
+                Cachex.update(
+                  Supavisor.Cache,
+                  {:secrets, data.tenant, data.user},
+                  {:cached, value}
+                )
+
+                Supavisor.stop(data.id)
+              else
+                Logger.debug("ProxyClient: Cache the same #{inspect(key)}")
+              end
+
+            other ->
+              Logger.error("ProxyClient: Auth secrets check error: #{inspect(other)}")
+          end
+        else
+          Logger.debug("ProxyClient: Cache hit for #{inspect(key)}")
+        end
+
+        HH.sock_send(sock, msg)
+        Telem.client_join(:fail, data.id)
+        {:stop, {:shutdown, :exchange_error}}
+
+      {:ok, client_key} ->
+        secrets =
+          if client_key do
+            fn ->
+              Map.put(secrets.(), :client_key, client_key)
+            end
+          else
+            secrets
+          end
+
+        Logger.debug("ProxyClient: Exchange success")
+        :ok = HH.sock_send(sock, Server.authentication_ok())
+        Telem.client_join(:ok, data.id)
+
+        auth = Map.merge(data.auth, %{secrets: secrets, method: method})
+
+        {:keep_state, %{data | auth_secrets: {method, secrets}, auth: auth},
+         {:next_event, :internal, {:client, :connect_db}}}
+    end
+  end
+
+  def handle_event(:internal, {:client, :connect_db}, _, %{auth: auth} = data) do
+    Logger.debug("Try to connect to DB")
+    Telem.handler_action(:db_handler, :db_connection, data.id)
+    ip_ver = H.ip_version(auth.ip_version, auth.host)
+
+    sock_opts = [
+      :binary,
+      {:packet, :raw},
+      {:active, false},
+      {:nodelay, true},
+      ip_ver
+    ]
+
+    case :gen_tcp.connect(~c"#{auth.host}", auth.port, sock_opts) do
+      {:ok, sock} ->
+        Logger.debug("ProxyClient: auth #{inspect(auth, pretty: true)}")
+
+        case ProxyDb.try_ssl_handshake({:gen_tcp, sock}, auth) do
+          {:ok, sock} ->
+            case ProxyDb.send_startup(sock, auth) do
+              :ok ->
+                HH.active_once(sock)
+                auth = Map.put(auth, :ip_ver, ip_ver)
+                {:next_state, :db_authentication, %{data | db_sock: sock, auth: auth}}
+
+              {:error, reason} ->
+                Logger.error("ProxyClient: Send startup error #{inspect(reason)}")
+                {:stop, {:shutdown, :startup_error}}
+            end
+
+          {:error, error} ->
+            Logger.error("ProxyClient: Handshake error #{inspect(error)}")
+            {:stop, {:shutdown, :handshake_error}}
+        end
+
+      other ->
+        Logger.error(
+          "ProxyClient: Connection failed #{inspect(other)} to #{inspect(auth.host)}:#{inspect(auth.port)}"
+        )
+
+        {:stop, {:shutdown, :connection_failed}}
+    end
+  end
+
+  def handle_event(:internal, {:client, {:greetings, ps}}, _, %{sock: sock} = data) do
+    {header, <<pid::32, key::32>> = payload} = Server.backend_key_data()
+    msg = [ps, [header, payload], Server.ready_for_query()]
+    :ok = HH.listen_cancel_query(pid, key)
+    :ok = HH.sock_send(sock, msg)
+    HH.active_once(sock)
+    Telem.client_connection_time(data.connection_start, data.id)
+    {:next_state, :idle, data, handle_actions(data)}
+  end
+
+  def handle_event(:timeout, :subscribe, _, _) do
+    {:keep_state_and_data, {:next_event, :internal, {:client, :connect_db}}}
+  end
+
+  def handle_event(:timeout, :wait_ps, _, data) do
+    Logger.error("ProxyClient: Wait parameter status timeout, send default #{inspect(data.ps)}}")
+
+    ps = Server.encode_parameter_status(data.ps)
+    {:keep_state_and_data, {:next_event, :internal, {:client, {:greetings, ps}}}}
+  end
+
+  def handle_event(:timeout, :idle_terminate, _, data) do
+    Logger.warning("ProxyClient: Terminate an idle connection by #{data.idle_timeout} timeout")
+    {:stop, {:shutdown, :idle_terminate}}
+  end
+
+  def handle_event(:timeout, :heartbeat_check, _, data) do
+    Logger.debug("ProxyClient: Send heartbeat to client")
+    HH.sock_send(data.sock, Server.application_name())
+    {:keep_state_and_data, {:timeout, data.heartbeat_interval, :heartbeat_check}}
+  end
+
+  # forwards the message to the db
+  def handle_event(:info, {proto, _, bin}, _, data) when proto in @proto do
+    HH.sock_send(data.db_sock, bin)
+    HH.active_once(data.sock)
+    :keep_state_and_data
+  end
+
+  def handle_event(:info, {:parameter_status, ps}, :exchange, _),
+    do: {:keep_state_and_data, {:next_event, :internal, {:client, {:greetings, ps}}}}
+
+  # client closed connection
+  def handle_event(_, {closed, _}, _, data)
+      when closed in [:tcp_closed, :ssl_closed] do
+    Logger.debug("ProxyClient: #{closed} socket closed for #{inspect(data.tenant)}")
+    {:stop, {:shutdown, :socket_closed}}
+  end
+
+  ## Internal functions
+
+  @spec handle_exchange(S.sock(), {atom(), fun()}) :: {:ok, binary() | nil} | {:error, String.t()}
+  def handle_exchange({_, socket} = sock, {:auth_query_md5 = method, secrets}) do
+    salt = :crypto.strong_rand_bytes(4)
+    :ok = HH.sock_send(sock, Server.md5_request(salt))
+
+    with {:ok,
+          %{
+            tag: :password_message,
+            payload: {:md5, client_md5}
+          }, _} <- receive_next(socket, "Timeout while waiting for the md5 exchange"),
+         {:ok, key} <- authenticate_exchange(method, client_md5, secrets.().secret, salt) do
+      {:ok, key}
+    else
+      {:error, message} -> {:error, message}
+      other -> {:error, "Unexpected message #{inspect(other)}"}
+    end
+  end
+
+  def handle_exchange({_, socket} = sock, {method, secrets}) do
+    :ok = HH.sock_send(sock, Server.scram_request())
+
+    with {:ok,
+          %{
+            tag: :password_message,
+            payload: {:scram_sha_256, %{"n" => user, "r" => nonce, "c" => channel}}
+          },
+          _} <-
+           receive_next(
+             socket,
+             "Timeout while waiting for the first password message"
+           ),
+         {:ok, signatures} = reply_first_exchange(sock, method, secrets, channel, nonce, user),
+         {:ok,
+          %{
+            tag: :password_message,
+            payload: {:first_msg_response, %{"p" => p}}
+          },
+          _} <-
+           receive_next(
+             socket,
+             "Timeout while waiting for the second password message"
+           ),
+         {:ok, key} <- authenticate_exchange(method, secrets, signatures, p) do
+      message = "v=#{Base.encode64(signatures.server)}"
+      :ok = HH.sock_send(sock, Server.exchange_message(:final, message))
+      {:ok, key}
+    else
+      {:error, message} -> {:error, message}
+      other -> {:error, "Unexpected message #{inspect(other)}"}
+    end
+  end
+
+  def receive_next(socket, timeout_message) do
+    receive do
+      {_proto, ^socket, bin} -> Server.decode_pkt(bin)
+      other -> {:error, "Unexpected message in receive_next/2 #{inspect(other)}"}
+    after
+      15_000 -> {:error, timeout_message}
+    end
+  end
+
+  def reply_first_exchange(sock, method, secrets, channel, nonce, user) do
+    {message, signatures} = exchange_first(method, secrets, nonce, user, channel)
+    :ok = HH.sock_send(sock, Server.exchange_message(:first, message))
+    {:ok, signatures}
+  end
+
+  def authenticate_exchange(:password, _secrets, signatures, p) do
+    if p == signatures.client,
+      do: {:ok, nil},
+      else: {:error, "Wrong password"}
+  end
+
+  def authenticate_exchange(:auth_query, secrets, signatures, p) do
+    client_key = :crypto.exor(Base.decode64!(p), signatures.client)
+
+    if H.hash(client_key) == secrets.().stored_key,
+      do: {:ok, client_key},
+      else: {:error, "Wrong password"}
+  end
+
+  def authenticate_exchange(:auth_query_md5, client_hash, server_hash, salt) do
+    if "md5" <> H.md5([server_hash, salt]) == client_hash,
+      do: {:ok, nil},
+      else: {:error, "Wrong password"}
+  end
+
+  @spec update_user_data(map(), map(), String.t(), S.id(), String.t(), S.mode()) :: map()
+  def update_user_data(data, info, user, id, db_name, mode) do
+    proxy_type = if info.tenant.require_user, do: :password, else: :auth_query
+
+    auth = %{
+      application_name: data.app_name,
+      database: info.tenant.db_database,
+      host: info.tenant.db_host,
+      sni_host: info.tenant.sni_hostname,
+      ip_version: info.tenant.ip_version,
+      port: info.tenant.db_port,
+      user: user,
+      password: info.user.db_password,
+      require_user: info.tenant.require_user,
+      upstream_ssl: info.tenant.upstream_ssl,
+      upstream_tls_ca: info.tenant.upstream_tls_ca,
+      upstream_verify: info.tenant.upstream_verify
+    }
+
+    %{
+      data
+      | tenant: info.tenant.external_id,
+        user: user,
+        timeout: info.user.pool_checkout_timeout,
+        ps: info.tenant.default_parameter_status,
+        proxy_type: proxy_type,
+        id: id,
+        heartbeat_interval: info.tenant.client_heartbeat_interval * 1000,
+        db_name: db_name,
+        mode: mode,
+        auth: auth
+    }
+  end
+
+  @spec auth_secrets(map, String.t(), term(), non_neg_integer()) ::
+          {:ok, S.secrets()} | {:error, term()}
+  ## password secrets
+  def auth_secrets(%{user: user, tenant: %{require_user: true}}, _, _, _) do
+    secrets = %{db_user: user.db_user, password: user.db_password, alias: user.db_user_alias}
+    {:ok, {:password, fn -> secrets end}}
+  end
+
+  ## auth_query secrets
+  def auth_secrets(info, db_user, key, ttl) do
+    fetch = fn _key ->
+      case get_secrets(info, db_user) do
+        {:ok, _} = resp -> {:commit, {:cached, resp}, ttl: ttl}
+        {:error, _} = resp -> {:ignore, resp}
+      end
+    end
+
+    case Cachex.fetch(Supavisor.Cache, key, fetch) do
+      {:ok, {:cached, value}} -> value
+      {:commit, {:cached, value}, _opts} -> value
+      {:ignore, resp} -> resp
+    end
+  end
+
+  @spec get_secrets(map, String.t()) :: {:ok, {:auth_query, fun()}} | {:error, term()}
+  def get_secrets(%{user: user, tenant: tenant}, db_user) do
+    ssl_opts =
+      if tenant.upstream_ssl and tenant.upstream_verify == "peer" do
+        [
+          {:verify, :verify_peer},
+          {:cacerts, [H.upstream_cert(tenant.upstream_tls_ca)]},
+          {:server_name_indication, String.to_charlist(tenant.db_host)},
+          {:customize_hostname_check, [{:match_fun, fn _, _ -> true end}]}
+        ]
+      end
+
+    {:ok, conn} =
+      Postgrex.start_link(
+        hostname: tenant.db_host,
+        port: tenant.db_port,
+        database: tenant.db_database,
+        password: user.db_password,
+        username: user.db_user,
+        parameters: [application_name: "Supavisor auth_query"],
+        ssl: tenant.upstream_ssl,
+        socket_options: [
+          H.ip_version(tenant.ip_version, tenant.db_host)
+        ],
+        queue_target: 1_000,
+        queue_interval: 5_000,
+        ssl_opts: ssl_opts || []
+      )
+
+    # kill the postgrex connection if the current process exits unexpectedly
+    Process.link(conn)
+
+    Logger.debug(
+      "ProxyClient: Connected to db #{tenant.db_host} #{tenant.db_port} #{tenant.db_database} #{user.db_user}"
+    )
+
+    resp =
+      with {:ok, secret} <- H.get_user_secret(conn, tenant.auth_query, db_user) do
+        t = if secret.digest == :md5, do: :auth_query_md5, else: :auth_query
+        {:ok, {t, fn -> Map.put(secret, :alias, user.db_user_alias) end}}
+      end
+
+    GenServer.stop(conn, :normal, 5_000)
+    Logger.info("ProxyClient: Get secrets finished")
+    resp
+  end
+
+  @spec exchange_first(:password | :auth_query, fun(), binary(), binary(), binary()) ::
+          {binary(), map()}
+  def exchange_first(:password, secret, nonce, user, channel) do
+    message = Server.exchange_first_message(nonce)
+    server_first_parts = H.parse_server_first(message, nonce)
+
+    {client_final_message, server_proof} =
+      H.get_client_final(
+        :password,
+        secret.().password,
+        server_first_parts,
+        nonce,
+        user,
+        channel
+      )
+
+    sings = %{
+      client: List.last(client_final_message),
+      server: server_proof
+    }
+
+    {message, sings}
+  end
+
+  def exchange_first(:auth_query, secret, nonce, user, channel) do
+    secret = secret.()
+    message = Server.exchange_first_message(nonce, secret.salt)
+    server_first_parts = H.parse_server_first(message, nonce)
+
+    sings =
+      H.signatures(
+        secret.stored_key,
+        secret.server_key,
+        server_first_parts,
+        nonce,
+        user,
+        channel
+      )
+
+    {message, sings}
+  end
+
+  defp db_pid_meta({_, {_, pid}} = _key) do
+    rkey = Supavisor.Registry.PoolPids
+    fnode = node(pid)
+
+    if fnode == node(),
+      do: Registry.lookup(rkey, pid),
+      else: :erpc.call(fnode, Registry, :lookup, [rkey, pid], 15_000)
+  end
+
+  @spec timeout_check(atom, non_neg_integer) :: {:timeout, non_neg_integer, atom}
+  def timeout_check(key, timeout) do
+    {:timeout, timeout, key}
+  end
+
+  @spec handle_actions(map) :: [{:timeout, non_neg_integer, atom}]
+  defp handle_actions(%{} = data) do
+    heartbeat =
+      if data.heartbeat_interval > 0,
+        do: [{:timeout, data.heartbeat_interval, :heartbeat_check}],
+        else: []
+
+    idle =
+      if data.idle_timeout > 0, do: [{:timeout, data.idle_timeout, :idle_timeout}], else: []
+
+    idle ++ heartbeat
+  end
+
+  @spec app_name(any()) :: String.t()
+  def app_name(name) when is_binary(name) do
+    suffix = " via Supavisor"
+    # https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-APPLICATION-NAME
+    max_len = 64
+    suffix_len = 14
+
+    if String.length(name) <= max_len - suffix_len do
+      name <> suffix
+    else
+      truncated_name = String.slice(name, 0, max_len - suffix_len - 3)
+      truncated_name <> "..." <> suffix
+    end
+  end
+
+  def app_name(name) do
+    Logger.error("ProxyClient: Invalid application name #{inspect(name)}")
+    "via Supavisor"
+  end
+
+  @spec maybe_change_log(map()) :: atom() | nil
+  def maybe_change_log(%{"payload" => %{"options" => options}}) do
+    level = options["log_level"] && String.to_existing_atom(options["log_level"])
+
+    if level in [:debug, :info, :notice, :warning, :error] do
+      H.set_log_level(level)
+      level
+    end
+  end
+
+  def maybe_change_log(_), do: :ok
+end

--- a/lib/supavisor/handlers/proxy/db.ex
+++ b/lib/supavisor/handlers/proxy/db.ex
@@ -1,0 +1,260 @@
+defmodule Supavisor.Handlers.Proxy.Db do
+  @moduledoc false
+
+  require Logger
+
+  alias Supavisor, as: S
+  alias Supavisor.Helpers, as: H
+  alias Supavisor.HandlerHelpers, as: HH
+  alias Supavisor.{Monitoring.Telem, Protocol.Server}
+
+  @type state :: :connect | :authentication | :idle | :busy
+
+  @sock_closed [:tcp_closed, :ssl_closed]
+  @proto [:tcp, :ssl]
+
+  def handle_event(:info, {proto, _, bin}, :db_authentication, data) when proto in @proto do
+    dec_pkt = Server.decode(bin)
+    Logger.debug("ProxyDb: dec_pkt, #{inspect(dec_pkt, pretty: true)}")
+    HH.active_once(data.db_sock)
+
+    resp = Enum.reduce(dec_pkt, %{}, &handle_auth_pkts(&1, &2, data))
+
+    case resp do
+      {:authentication_sasl, nonce} ->
+        {:keep_state, %{data | nonce: nonce}}
+
+      {:authentication_server_first_message, server_proof} ->
+        {:keep_state, %{data | server_proof: server_proof}}
+
+      :authentication_md5 ->
+        {:keep_state, data}
+
+      {:error_response, ["SFATAL", "VFATAL", "C28P01", reason, _, _, _]} ->
+        Logger.error("ProxyDb: Auth error #{inspect(reason)}")
+        {:stop, :invalid_password, data}
+
+      {:error_response, error} ->
+        Logger.error("ProxyDb: Error auth response #{inspect(error)}")
+        {:keep_state, data}
+
+      {:ready_for_query, acc} ->
+        ps = acc.ps
+        backend_key_data = acc.backend_key_data
+        msg = "ProxyDb: DB ready_for_query: #{inspect(acc.db_state)} #{inspect(ps, pretty: true)}"
+        Logger.debug(msg)
+        ps_encoded = Server.encode_parameter_status(ps)
+
+        {:next_state, :idle, %{data | parameter_status: ps, backend_key_data: backend_key_data},
+         {:next_event, :internal, {:client, {:greetings, ps_encoded}}}}
+
+      other ->
+        Logger.error("ProxyDb: Undefined auth response #{inspect(other)}")
+        {:stop, :auth_error, data}
+    end
+  end
+
+  # forwards the message to the client
+  def handle_event(:info, {proto, _, bin}, _, data) when proto in @proto do
+    HH.sock_send(data.sock, bin)
+    HH.active_once(data.db_sock)
+
+    data =
+      if String.ends_with?(bin, Server.ready_for_query()) do
+        Logger.debug("ProxyDb: collected network usage")
+        {_, stats} = Telem.network_usage(:client, data.sock, data.id, data.stats)
+        {_, db_stats} = Telem.network_usage(:db, data.db_sock, data.id, data.db_stats)
+        %{data | stats: stats, db_stats: db_stats}
+      else
+        data
+      end
+
+    {:keep_state, data}
+  end
+
+  def handle_event(_, {closed, _}, state, data) when closed in @sock_closed do
+    Logger.error("ProxyDb: Connection closed when state was #{state}")
+    Telem.handler_action(:db_handler, :stopped, data.id)
+    HH.sock_send(data.sock, Server.error_message("XX000", "Database connection closed"))
+    HH.sock_close(data.sock)
+    {:stop, :db_socket_closed, data}
+  end
+
+  ## Internal functions
+
+  @spec handle_auth_pkts(map(), map(), map()) :: any()
+  defp handle_auth_pkts(%{tag: :parameter_status, payload: {k, v}}, acc, _),
+    do: update_in(acc, [:ps], fn ps -> Map.put(ps || %{}, k, v) end)
+
+  defp handle_auth_pkts(%{tag: :ready_for_query, payload: db_state}, acc, _),
+    do: {:ready_for_query, Map.put(acc, :db_state, db_state)}
+
+  defp handle_auth_pkts(%{tag: :backend_key_data, payload: payload}, acc, _),
+    do: Map.put(acc, :backend_key_data, payload)
+
+  defp handle_auth_pkts(%{payload: {:authentication_sasl_password, methods_b}}, _, data) do
+    nonce =
+      case Server.decode_string(methods_b) do
+        {:ok, req_method, _} ->
+          Logger.debug("ProxyDb: SASL method #{inspect(req_method)}")
+          nonce = :pgo_scram.get_nonce(16)
+          user = get_user(data.auth)
+          client_first = :pgo_scram.get_client_first(user, nonce)
+          client_first_size = IO.iodata_length(client_first)
+
+          sasl_initial_response = [
+            "SCRAM-SHA-256",
+            0,
+            <<client_first_size::32-integer>>,
+            client_first
+          ]
+
+          bin = :pgo_protocol.encode_scram_response_message(sasl_initial_response)
+          :ok = HH.sock_send(data.db_sock, bin)
+          nonce
+
+        other ->
+          Logger.error("ProxyDb: Undefined sasl method #{inspect(other)}")
+          nil
+      end
+
+    {:authentication_sasl, nonce}
+  end
+
+  defp handle_auth_pkts(
+         %{payload: {:authentication_server_first_message, server_first}},
+         _,
+         data
+       )
+       when data.auth.require_user == false do
+    nonce = data.nonce
+    server_first_parts = H.parse_server_first(server_first, nonce)
+
+    {client_final_message, server_proof} =
+      H.get_client_final(
+        :auth_query,
+        data.auth.secrets.(),
+        server_first_parts,
+        nonce,
+        data.auth.secrets.().user,
+        "biws"
+      )
+
+    bin = :pgo_protocol.encode_scram_response_message(client_final_message)
+    :ok = HH.sock_send(data.db_sock, bin)
+
+    {:authentication_server_first_message, server_proof}
+  end
+
+  defp handle_auth_pkts(
+         %{payload: {:authentication_server_first_message, server_first}},
+         _,
+         data
+       ) do
+    nonce = data.nonce
+    server_first_parts = :pgo_scram.parse_server_first(server_first, nonce)
+
+    {client_final_message, server_proof} =
+      :pgo_scram.get_client_final(
+        server_first_parts,
+        nonce,
+        data.auth.user,
+        data.auth.password.()
+      )
+
+    bin = :pgo_protocol.encode_scram_response_message(client_final_message)
+    :ok = HH.sock_send(data.db_sock, bin)
+
+    {:authentication_server_first_message, server_proof}
+  end
+
+  defp handle_auth_pkts(
+         %{payload: {:authentication_server_final_message, _server_final}},
+         acc,
+         _data
+       ),
+       do: acc
+
+  defp handle_auth_pkts(%{payload: {:authentication_md5_password, salt}} = dec_pkt, _, data) do
+    Logger.debug("ProxyDb: dec_pkt, #{inspect(dec_pkt, pretty: true)}")
+
+    digest =
+      if data.auth.method == :password do
+        H.md5([data.auth.password.(), data.auth.user])
+      else
+        data.auth.secrets.().secret
+      end
+
+    payload = ["md5", H.md5([digest, salt]), 0]
+    bin = [?p, <<IO.iodata_length(payload) + 4::signed-32>>, payload]
+    :ok = HH.sock_send(data.db_sock, bin)
+    :authentication_md5
+  end
+
+  defp handle_auth_pkts(%{tag: :error_response, payload: error}, _acc, _data),
+    do: {:error_response, error}
+
+  defp handle_auth_pkts(_e, acc, _data), do: acc
+
+  @spec try_ssl_handshake(S.tcp_sock(), map()) :: {:ok, S.sock()} | {:error, term()}
+  def try_ssl_handshake(sock, %{upstream_ssl: true} = auth) do
+    with :ok <- HH.sock_send(sock, Server.ssl_request()) do
+      ssl_recv(sock, auth)
+    end
+  end
+
+  def try_ssl_handshake(sock, _), do: {:ok, sock}
+
+  @spec ssl_recv(S.tcp_sock(), map) :: {:ok, S.ssl_sock()} | {:error, term}
+  def ssl_recv({:gen_tcp, sock} = s, auth) do
+    case :gen_tcp.recv(sock, 1, 15_000) do
+      {:ok, <<?S>>} -> ssl_connect(s, auth)
+      {:ok, <<?N>>} -> {:error, :ssl_not_available}
+      {:error, _} = error -> error
+    end
+  end
+
+  @spec ssl_connect(S.tcp_sock(), map, pos_integer) :: {:ok, S.ssl_sock()} | {:error, term}
+  def ssl_connect({:gen_tcp, sock}, auth, timeout \\ 5000) do
+    opts =
+      case auth.upstream_verify do
+        :peer ->
+          [
+            verify: :verify_peer,
+            cacerts: [auth.upstream_tls_ca],
+            # unclear behavior on pg14
+            server_name_indication: auth.sni_host || auth.host,
+            customize_hostname_check: [{:match_fun, fn _, _ -> true end}]
+          ]
+
+        :none ->
+          [verify: :verify_none]
+      end
+
+    case :ssl.connect(sock, opts, timeout) do
+      {:ok, ssl_sock} -> {:ok, {:ssl, ssl_sock}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec send_startup(S.sock(), map()) :: :ok | {:error, term}
+  def send_startup(sock, auth) do
+    user = get_user(auth)
+
+    msg =
+      :pgo_protocol.encode_startup_message([
+        {"user", user},
+        {"database", auth.database},
+        {"application_name", auth.application_name}
+      ])
+
+    HH.sock_send(sock, msg)
+  end
+
+  @spec get_user(map) :: String.t()
+  def get_user(auth) do
+    if auth.require_user,
+      do: auth.secrets.().db_user,
+      else: auth.secrets.().user
+  end
+end

--- a/lib/supavisor/handlers/proxy/handler.ex
+++ b/lib/supavisor/handlers/proxy/handler.ex
@@ -1,0 +1,155 @@
+defmodule Supavisor.Handlers.Proxy.Handler do
+  @moduledoc false
+
+  require Logger
+
+  @behaviour :ranch_protocol
+  @behaviour :gen_statem
+
+  alias Supavisor.{
+    Helpers,
+    Protocol.Server,
+    Monitoring.PromEx,
+    Handlers.Proxy.Db,
+    Handlers.Proxy.Client
+  }
+
+  alias Supavisor.HandlerHelpers, as: HH
+
+  @sock_closed [:tcp_closed, :ssl_closed]
+  @proto [:tcp, :ssl]
+
+  @impl true
+  def start_link(ref, transport, opts) do
+    pid = :proc_lib.spawn_link(__MODULE__, :init, [ref, transport, opts])
+    {:ok, pid}
+  end
+
+  @impl true
+  def callback_mode, do: [:handle_event_function]
+
+  @impl true
+  def init(_), do: :ignore
+
+  def init(ref, trans, opts) do
+    Process.flag(:trap_exit, true)
+    Helpers.set_max_heap_size(90)
+
+    {:ok, sock} = :ranch.handshake(ref)
+    :ok = trans.setopts(sock, active: true)
+    Logger.debug("ClientHandler is: #{inspect(self())}")
+
+    data = %{
+      id: nil,
+      sock: {:gen_tcp, sock},
+      db_sock: {:gen_tcp, nil},
+      trans: trans,
+      db_pid: nil,
+      tenant: nil,
+      user: nil,
+      pool: nil,
+      manager: nil,
+      query_start: nil,
+      timeout: nil,
+      ps: nil,
+      ssl: false,
+      auth_secrets: nil,
+      proxy_type: nil,
+      mode: opts.mode,
+      stats: %{},
+      db_stats: %{},
+      idle_timeout: 0,
+      db_name: nil,
+      last_query: nil,
+      heartbeat_interval: 0,
+      connection_start: System.monotonic_time(),
+      log_level: nil,
+      version: Application.spec(:supavisor, :vsn),
+      auth: nil,
+      nonce: nil,
+      server_proof: nil,
+      parameter_status: %{},
+      app_name: nil,
+      peer_ip: Helpers.peer_ip(sock),
+      auth: %{},
+      backend_key_data: %{}
+    }
+
+    :gen_statem.enter_loop(__MODULE__, [hibernate_after: 5_000], :exchange, data)
+  end
+
+  @impl true
+  def handle_event(e, {:client, _} = msg, state, data) do
+    Client.handle_event(e, msg, state, data)
+  end
+
+  def handle_event(:timeout = e, msg, state, data) do
+    Client.handle_event(e, msg, state, data)
+  end
+
+  def handle_event(event, {proto, sock, _payload} = msg, state, %{sock: {_, sock}} = data)
+      when proto in @proto do
+    Client.handle_event(event, msg, state, data)
+  end
+
+  def handle_event(event, {proto, sock, _payload} = msg, state, %{db_sock: {_, sock}} = data)
+      when proto in @proto do
+    Db.handle_event(event, msg, state, data)
+  end
+
+  def handle_event(event, {closed, sock} = msg, state, %{sock: {_, sock}} = data)
+      when closed in @sock_closed do
+    Client.handle_event(event, msg, state, data)
+  end
+
+  def handle_event(event, {closed, sock} = msg, state, %{db_sock: {_, sock}} = data)
+      when closed in @sock_closed do
+    Db.handle_event(event, msg, state, data)
+  end
+
+  def handle_event(type, content, state, data) do
+    msg = [
+      {"type", type},
+      {"content", content},
+      {"state", state},
+      {"data", data}
+    ]
+
+    Logger.debug("ProxyHandler: Undefined msg: #{inspect(msg, pretty: true)}")
+
+    :keep_state_and_data
+  end
+
+  @impl true
+  def terminate({:shutdown, reason}, state, data) do
+    HH.sock_send(data.sock, Server.error_message("XX000", "#{inspect(reason)}"))
+    clean_up(data)
+
+    Logger.info(
+      "ProxyHandler: Terminating with reason: #{inspect(reason)} when state was #{state}"
+    )
+
+    :ok
+  end
+
+  def terminate(reason, state, data) do
+    clean_up(data)
+
+    Logger.info(
+      "ProxyHandler: Terminating with reason: #{inspect(reason)} when state was #{state}"
+    )
+  end
+
+  ## Internal functions
+
+  @spec clean_up(map()) :: any()
+  defp clean_up(data) do
+    HH.sock_close(data.sock)
+    HH.sock_close(data.db_sock)
+
+    case Registry.lookup(Supavisor.Registry.TenantClients, data.id) do
+      clients when clients in [[{self(), []}], []] -> PromEx.remove_metrics(data.id)
+      _ -> :ok
+    end
+  end
+end

--- a/lib/supavisor/handlers/proxy/handler.ex
+++ b/lib/supavisor/handlers/proxy/handler.ex
@@ -147,7 +147,7 @@ defmodule Supavisor.Handlers.Proxy.Handler do
     HH.sock_close(data.db_sock)
 
     case Registry.lookup(Supavisor.Registry.TenantClients, data.id) do
-      clients when clients in [[{self(), []}], []] -> PromEx.remove_metrics(data.id)
+      clients when clients == [{self(), []}] or clients == [] -> PromEx.remove_metrics(data.id)
       _ -> :ok
     end
   end

--- a/lib/supavisor/handlers/proxy/handler.ex
+++ b/lib/supavisor/handlers/proxy/handler.ex
@@ -65,7 +65,6 @@ defmodule Supavisor.Handlers.Proxy.Handler do
       connection_start: System.monotonic_time(),
       log_level: nil,
       version: Application.spec(:supavisor, :vsn),
-      auth: nil,
       nonce: nil,
       server_proof: nil,
       parameter_status: %{},

--- a/lib/supavisor/helpers.ex
+++ b/lib/supavisor/helpers.ex
@@ -357,4 +357,12 @@ defmodule Supavisor.Helpers do
     Logger.notice("Setting log level to #{inspect(level)}")
     Logger.put_process_level(self(), level)
   end
+
+  @spec peer_ip(:gen_tcp.socket()) :: String.t()
+  def peer_ip(socket) do
+    case :inet.peername(socket) do
+      {:ok, {ip, _port}} -> List.to_string(:inet.ntoa(ip))
+      _error -> "undefined"
+    end
+  end
 end

--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -30,7 +30,8 @@ defmodule Supavisor.Monitoring.PromEx do
   end
 
   @spec remove_metrics(S.id()) :: non_neg_integer
-  def remove_metrics({{type, tenant}, user, mode, db_name}) do
+  def remove_metrics({{type, tenant}, user, mode, db_name} = id) do
+    Logger.debug("Removing metrics for #{inspect(id)}")
     meta = %{tenant: tenant, user: user, mode: mode, type: type, db_name: db_name}
 
     Supavisor.Monitoring.PromEx.Metrics


### PR DESCRIPTION
The current PR introduces a new handler that will replace session mode. It authenticates incoming connections via auth queries, establishes a TCP connection to the tenant's database, and then simply forwards data between the client and the database, functioning primarily as a proxy

- [x] cancel query
- [x] terminate auth_query connection
- [x] active once
- [x] application_name with "via supavisor"
- [x] handle client disconnect
- [x] handle DB disconnect
- [x] auth_query conn is terminated if the client is killed
- [x] telemetry
- [x] delete metrics  
- [x] tests
