### PR TITLE
feat: show availability_zone in logs metadata if it is available

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -19,7 +19,10 @@ defmodule Supavisor.Application do
       :logger.set_primary_config(
         :metadata,
         Enum.into(
-          [region: System.get_env("REGION"), instance_id: System.get_env("INSTANCE_ID")],
+          [
+            region: System.get_env("AVAILABILITY_ZONE") || System.get_env("REGION"),
+            instance_id: System.get_env("INSTANCE_ID")
+          ],
           primary_config.metadata
         )
       )


### PR DESCRIPTION
Since the AWS availability zone also includes the region, it can be more informative to show it in the logs metadata
```
region=ap-southeast-1b
```