### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ supported ([todo](#future-work)).
   - Easy drop-in replacement for `PgBouncer`
 - Pool mode support per tenant
   - Transaction
+  - Session
+  - Native
 - Cloud-native
   - Cluster-able
   - Resilient during cluster resizing
@@ -120,8 +122,6 @@ supported ([todo](#future-work)).
 - Query caching
   - Query results are optionally cached in the pool cluster and returned before
     hitting the tenant database
-- Session pooling
-  - Like `PgBouncer`
 - Multi-protocol Postgres query interface
   - Postgres binary
   - HTTPS


### PR DESCRIPTION
This PR updates the README.md to remove session pooling as a todo item. 

It seems like session pooling was added in commit #79 but the README.md was never updated.