### PR TITLE
Update faq.md | session mode doc update

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,10 +12,7 @@ subsequently should show up in your exception monitoring software.
 
 ## Does Supavisor support prepared statements?
 
-As of 1.0 Supavisor supports prepared statements. Supavisor will detect
-`prepare` statements and issue those to all database connections. All clients
-will then be able to address those prepared statements by name when issuing
-`execute` statements.
+It currently supports prepared statements only in session mode.
 
 ## Why do you route connections to a single Supavisor node when deployed as a cluster?
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

doc update

## What is the current behavior?

Supavisor in transaction mode does not support standard prepared statements, but the documentation claims otherwise.

## What is the new behavior?

Updated the FAQ

## Additional context

The docs state:

> As of 1.0 Supavisor supports prepared statements. Supavisor will detect
`prepare` statements and issue those to all database connections. All clients
will then be able to address those prepared statements by name when issuing
`execute` statements.

Prepared statements are not fully supported and this claim caused user confusion ([ticket](https://app.hubspot.com/live-messages/19953346/inbox/8310448973#email)). It's worthwhile to add more context or remove the claim.

It's also worth re-opening up issue #69 