### PR TITLE
chore: check if lockfile is up to date

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-
       - name: Install dependencies
-        run: mix deps.get
+        run: mix deps.get --check-locked
 
   format:
     name: Formatting checks


### PR DESCRIPTION
This will raise if there are some pending changes to the `mix.lock`. This is to ensure, that `mix.lock` was uploaded after dependency changes.
