### PR TITLE
test: mark PromEx test as flaky

### DIFF
--- a/test/supavisor/prom_ex_test.exs
+++ b/test/supavisor/prom_ex_test.exs
@@ -8,6 +8,12 @@ defmodule Supavisor.PromExTest do
 
   @tenant "prom_tenant"
 
+  # These tests are known to be flaky, and while these do not affect users
+  # directly we can run them independently when needed. In future we probably
+  # should make them pass "regularly", but for now that is easier to filter them
+  # out.
+  @moduletag flaky: true
+
   setup do
     db_conf = Application.get_env(:supavisor, Repo)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,5 +2,9 @@
 
 Cachex.start_link(name: Supavisor.Cache)
 
-ExUnit.start(capture_log: true)
+ExUnit.start(
+  capture_log: true,
+  exclude: [flaky: true]
+)
+
 Ecto.Adapters.SQL.Sandbox.mode(Supavisor.Repo, :auto)


### PR DESCRIPTION
That tests are constantly causing us problems in CI, but as it is test for internal functionality that do not affect users directly. So to streamline testing disable running these tests in default run. To run them one can use

    mix test --include flaky
