### PR TITLE
fix: `DbHandler.stop/1` should exit with normal reason

### DIFF
--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -44,7 +44,7 @@ defmodule Supavisor.DbHandler do
   @spec stop(pid()) :: :ok
   def stop(pid) do
     Logger.debug("DbHandler: Stop pid #{inspect(pid)}")
-    :gen_statem.stop(pid, :client_termination, 5_000)
+    :gen_statem.stop(pid, {:shutdown, :client_termination}, 5_000)
   end
 
   @impl true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small fix to reduce noise during `DbHandler` exits.

## What is the current behavior?

It exits with abnormal reason, which causes noisy message to be printed in the log.

## What is the new behavior?

Exit with normal reason, which will print only our logs, no system logs.
