### PR TITLE
feat: use microseconds for measuring pool checkouts

### DIFF
--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -37,23 +37,23 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
       :supavisor_tenant_client_event_metrics,
       [
         distribution(
-          [:supavisor, :pool, :checkout, :duration, :local],
+          [:supavisor, :pool, :checkout, :duration, :local, :us],
           event_name: [:supavisor, :pool, :checkout, :stop, :local],
           measurement: :duration,
           description: "Duration of the checkout local process in the tenant db pool.",
           tags: @tags,
-          unit: {:native, :millisecond},
+          unit: {:native, :microsecond},
           reporter_options: [
             peep_bucket_calculator: Buckets
           ]
         ),
         distribution(
-          [:supavisor, :pool, :checkout, :duration, :remote],
+          [:supavisor, :pool, :checkout, :duration, :remote, :us],
           event_name: [:supavisor, :pool, :checkout, :stop, :remote],
           measurement: :duration,
           description: "Duration of the checkout remote process in the tenant db pool.",
           tags: @tags,
-          unit: {:native, :millisecond},
+          unit: {:native, :microsecond},
           reporter_options: [
             peep_bucket_calculator: Buckets
           ]


### PR DESCRIPTION
## What is the current behavior?

Currently we measure pools checkouts in milliseconds, but these do not give us enough resolution and almost everything is crammed into `le="1"` bucket.

## What is the new behavior?

Change time unit used for measures to microsecond so all measurements are multiplied by factor of `1000` which should give us better insights into real distribution.
