### PR TITLE
feat: change `Protocol.Server.cancel_message/2` function a macro

### DIFF
--- a/lib/supavisor/handler_helpers.ex
+++ b/lib/supavisor/handler_helpers.ex
@@ -2,7 +2,8 @@ defmodule Supavisor.HandlerHelpers do
   @moduledoc false
 
   alias Phoenix.PubSub
-  alias Supavisor.Protocol.Server
+
+  require Supavisor.Protocol.Server, as: Server
 
   @spec sock_send(Supavisor.sock(), iodata()) :: :ok | {:error, term()}
   def sock_send({mod, sock}, data) do

--- a/lib/supavisor/protocol/server.ex
+++ b/lib/supavisor/protocol/server.ex
@@ -28,6 +28,12 @@ defmodule Supavisor.Protocol.Server do
           }
   end
 
+  defmacro cancel_message(pid, key) do
+    quote do
+      <<unquote(@msg_cancel_header)::binary, unquote(pid)::32, unquote(key)::32>>
+    end
+  end
+
   @spec decode(iodata()) :: [Pkt.t()] | []
   def decode(data) do
     decode(data, [])
@@ -454,11 +460,6 @@ defmodule Supavisor.Protocol.Server do
       end)
 
     <<byte_size(bin) + 9::32, 0, 3, 0, 0, bin::binary, 0>>
-  end
-
-  @spec cancel_message(non_neg_integer, non_neg_integer) :: iodata
-  def cancel_message(pid, key) do
-    [@msg_cancel_header, <<pid::32, key::32>>]
   end
 
   @spec has_read_only_error?(list) :: boolean


### PR DESCRIPTION
This allows us to use this piece of code in function head in pattern
match. This reduces places where the magic value is required and make
the code a little bit neater and cleaner.
