### PR TITLE
fix: cleanup Peep metrics

### DIFF
--- a/test/support/fixtures/single_connection.ex
+++ b/test/support/fixtures/single_connection.ex
@@ -5,6 +5,14 @@ defmodule SingleConnection do
 
   @behaviour P.SimpleConnection
 
+  def child_spec(conf) do
+    %{
+      id: {__MODULE__, System.unique_integer()},
+      start: {__MODULE__, :connect, [conf]},
+      restart: :temporary
+    }
+  end
+
   def connect(conf) do
     P.SimpleConnection.start_link(__MODULE__, [], conf)
   end


### PR DESCRIPTION
As we are depending on the undocumented internals of the Peep library, we accidentally were broken by recent update in Peep where they have added feature of stripped metrics storage. In this change there were no more named ETS tables and there may be more than one ETS table in case of striped tables. Now we are traversing all tables used by Peep to cleanup them all (even though we are currently using regular store, but this fix should work in case of striped tables as well).
