### PR TITLE
test: do NOT trap exits in tests

### DIFF
--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -54,7 +54,6 @@ defmodule Supavisor.Integration.ProxyTest do
   end
 
   test "the wrong password" do
-    Process.flag(:trap_exit, true)
     db_conf = Application.get_env(:supavisor, Repo)
 
     url =
@@ -216,7 +215,6 @@ defmodule Supavisor.Integration.ProxyTest do
   end
 
   test "limit client connections" do
-    Process.flag(:trap_exit, true)
     db_conf = Application.get_env(:supavisor, Repo)
 
     connection_opts = [
@@ -240,7 +238,6 @@ defmodule Supavisor.Integration.ProxyTest do
   end
 
   test "change role password", %{origin: origin} do
-    Process.flag(:trap_exit, true)
     db_conf = Application.get_env(:supavisor, Repo)
 
     conn = fn pass ->
@@ -270,7 +267,6 @@ defmodule Supavisor.Integration.ProxyTest do
   end
 
   test "invalid characters in user or db_name" do
-    Process.flag(:trap_exit, true)
     db_conf = Application.get_env(:supavisor, Repo)
 
     url =
@@ -288,62 +284,7 @@ defmodule Supavisor.Integration.ProxyTest do
             }} = parse_uri(url) |> single_connection()
   end
 
-  # test "max_pools limit" do
-  #   Process.flag(:trap_exit, true)
-  #   db_conf = Application.get_env(:supavisor, Repo)
-  #   port = Application.get_env(:supavisor, :proxy_port_transaction)
-
-  #   tenant = "max_pool_tenant"
-
-  #   {:ok, pid1} =
-  #     Keyword.merge(db_conf,
-  #       username: "postgres.#{tenant}",
-  #       port: port
-  #     )
-  #     |> single_connection()
-
-  #   assert Supavisor.count_pools(tenant) == 1
-
-  #   {:ok, pid2} =
-  #     Keyword.merge(db_conf,
-  #       username: "session.#{tenant}",
-  #       port: port
-  #     )
-  #     |> single_connection()
-
-  #   assert Supavisor.count_pools(tenant) == 2
-
-  #   {:ok, pid3} =
-  #     Keyword.merge(db_conf,
-  #       username: "transaction.#{tenant}",
-  #       port: port
-  #     )
-  #     |> single_connection()
-
-  #   assert Supavisor.count_pools(tenant) == 3
-
-  #   connection_opts =
-  #     Keyword.merge(db_conf,
-  #       username: "max_clients.#{tenant}",
-  #       port: port
-  #     )
-
-  #   assert {:error,
-  #           %Postgrex.Error{
-  #             postgres: %{
-  #               code: :internal_error,
-  #               message: "Max pools count reached",
-  #               unknown: "FATAL",
-  #               severity: "FATAL",
-  #               pg_code: "XX000"
-  #             }
-  #           }} = single_connection(connection_opts)
-
-  #   for pid <- [pid1, pid2, pid3], do: :gen_statem.stop(pid)
-  # end
-
   test "active_count doesn't block" do
-    Process.flag(:trap_exit, true)
     db_conf = Application.get_env(:supavisor, Repo)
     port = Application.get_env(:supavisor, :proxy_port_session)
 


### PR DESCRIPTION
This make test more flaky, is harmful to the test, and in general is bad practice.
