### PR TITLE
fix: properly compute socket usage

### DIFF
--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -81,25 +81,19 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
             peep_bucket_calculator: Buckets
           ]
         ),
-        last_value(
+        sum(
           [:supavisor, :client, :network, :recv],
           event_name: [:supavisor, :client, :network, :stat],
           measurement: :recv_oct,
           description: "The total number of bytes received by clients.",
-          tags: @tags,
-          reporter_options: [
-            prometheus_type: :sum
-          ]
+          tags: @tags
         ),
-        last_value(
+        sum(
           [:supavisor, :client, :network, :send],
           event_name: [:supavisor, :client, :network, :stat],
           measurement: :send_oct,
           description: "The total number of bytes sent by clients.",
-          tags: @tags,
-          reporter_options: [
-            prometheus_type: :sum
-          ]
+          tags: @tags
         ),
         counter(
           [:supavisor, :client, :queries, :count],


### PR DESCRIPTION
This partially reverts commit 4b498871ed54b726748d95808a2a840e8a51735c.

The change was not properly implementing previous behaviour in presence of multiple sockets reporting to the same set of attributes. Instead of summing their usage it was reporting only the latest one.
