### PR TITLE
test: integration test for connection stats on other node

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -48,7 +48,7 @@ config :supavisor, Supavisor.Vault,
 
 # Print only warnings and errors during test
 config :logger, :console,
-  level: :error,
+  level: String.to_atom(System.get_env("LOGGER_LEVEL", "error")),
   metadata: [:error_code, :file, :line, :pid, :project, :user, :mode]
 
 # Initialize plugs at runtime for faster test compilation

--- a/test/supavisor/client_handler/stats_test.exs
+++ b/test/supavisor/client_handler/stats_test.exs
@@ -5,28 +5,32 @@ defmodule Supavisor.ClientHandler.StatsTest do
 
   # Listen on Telemetry events
   setup ctx do
+    ref = make_ref()
+
     :telemetry.attach(
       {ctx.test, :client},
       [:supavisor, :client, :network, :stat],
       &__MODULE__.handle_event/4,
-      self()
+      {self(), ref}
     )
 
     :telemetry.attach(
       {ctx.test, :db},
       [:supavisor, :db, :network, :stat],
       &__MODULE__.handle_event/4,
-      self()
+      {self(), ref}
     )
 
     on_exit(fn ->
       :telemetry.detach({ctx.test, :client})
       :telemetry.detach({ctx.test, :db})
     end)
+
+    {:ok, telemetry: ref}
   end
 
-  def handle_event([:supavisor, name, :network, :stat], measurement, meta, pid) do
-    send(pid, {:telemetry, {name, measurement, meta}, Node.self()})
+  def handle_event([:supavisor, name, :network, :stat], measurement, meta, {pid, ref}) do
+    send(pid, {ref, {name, measurement, meta}, Node.self()})
   end
 
   setup ctx do
@@ -53,35 +57,32 @@ defmodule Supavisor.ClientHandler.StatsTest do
   end
 
   describe "client network usage" do
-    test "increase on query", ctx do
-      external_id = ctx.external_id
+    test "increase on query", %{telemetry: telemetry, conn: conn, external_id: external_id} do
+      assert {:ok, _} = SingleConnection.query(conn, "SELECT 1")
 
-      assert {:ok, _} = SingleConnection.query(ctx.conn, "SELECT 1")
-
-      assert_receive {:telemetry,
+      assert_receive {^telemetry,
                       {:client, %{recv_oct: recv, send_oct: sent}, %{tenant: ^external_id}}, _}
 
       assert recv > 0
       assert sent > 0
     end
 
-    test "increase on just auth", ctx do
-      external_id = ctx.external_id
-
-      assert_receive {:telemetry,
+    test "increase on just auth", %{external_id: external_id, telemetry: telemetry} do
+      assert_receive {^telemetry,
                       {:client, %{recv_oct: recv, send_oct: sent}, %{tenant: ^external_id}}, _}
 
       assert recv > 0
       assert sent > 0
     end
 
-    test "do not not increase if other tenant is used", ctx do
-      external_id = ctx.external_id
-
+    test "do not not increase if other tenant is used", %{
+      external_id: external_id,
+      telemetry: telemetry
+    } do
       {:ok, other} = create_instance([__MODULE__, "another"])
 
       # Cleanup initial data related to sign in
-      assert_receive {:telemetry, {:client, _, %{tenant: ^external_id}}, _}
+      assert_receive {^telemetry, {:client, _, %{tenant: ^external_id}}, _}
 
       other_conn =
         start_supervised!(
@@ -96,11 +97,11 @@ defmodule Supavisor.ClientHandler.StatsTest do
 
       assert {:ok, _} = SingleConnection.query(other_conn, "SELECT 1")
 
-      refute_receive {:telemetry, {:client, _, %{tenant: ^external_id}}, _}
+      refute_receive {^telemetry, {:client, _, %{tenant: ^external_id}}, _}
     end
 
     @tag external_id: "proxy_tenant1"
-    test "another instance do not send events here", ctx do
+    test "another instance do not send events here", %{telemetry: telemetry} = ctx do
       assert {:ok, _pid, node} = Supavisor.Support.Cluster.start_node()
 
       :erpc.call(node, :telemetry, :attach, [
@@ -125,41 +126,41 @@ defmodule Supavisor.ClientHandler.StatsTest do
 
       this = Node.self()
 
-      refute_receive {:telemetry, {:client, _, %{tenant: "proxy_tenant1"}}, ^node}
-      assert_receive {:telemetry, {:client, _, %{tenant: "proxy_tenant1"}}, ^this}
+      refute_receive {^telemetry, {:client, _, %{tenant: "proxy_tenant1"}}, ^node}
+      assert_receive {^telemetry, {:client, _, %{tenant: "proxy_tenant1"}}, ^this}, 1000
     end
   end
 
   describe "server network usage" do
-    test "increase on query", ctx do
+    test "increase on query", %{telemetry: telemetry} = ctx do
       external_id = ctx.external_id
 
       assert {:ok, _} = SingleConnection.query(ctx.conn, "SELECT 1")
 
-      assert_receive {:telemetry,
+      assert_receive {^telemetry,
                       {:db, %{recv_oct: recv, send_oct: sent}, %{tenant: ^external_id}}, _}
 
       assert recv > 0
       assert sent > 0
     end
 
-    test "increase on just auth", ctx do
+    test "increase on just auth", %{telemetry: telemetry} = ctx do
       external_id = ctx.external_id
 
-      assert_receive {:telemetry,
+      assert_receive {^telemetry,
                       {:db, %{recv_oct: recv, send_oct: sent}, %{tenant: ^external_id}}, _}
 
       assert recv > 0
       assert sent > 0
     end
 
-    test "do not not increase if other tenant is used", ctx do
+    test "do not not increase if other tenant is used", %{telemetry: telemetry} = ctx do
       external_id = ctx.external_id
 
       {:ok, other} = create_instance([__MODULE__, "another"])
 
       # Cleanup initial data related to sign in
-      assert_receive {:telemetry, {:db, _, %{tenant: ^external_id}}, _}
+      assert_receive {^telemetry, {:db, _, %{tenant: ^external_id}}, _}
 
       other_conn =
         start_supervised!(
@@ -174,7 +175,7 @@ defmodule Supavisor.ClientHandler.StatsTest do
 
       assert {:ok, _} = SingleConnection.query(other_conn, "SELECT 1")
 
-      refute_receive {:telemetry, {:db, _, %{tenant: ^external_id}}, _}
+      refute_receive {^telemetry, {:db, _, %{tenant: ^external_id}}, _}
     end
   end
 end

--- a/test/support/fixtures/single_connection.ex
+++ b/test/support/fixtures/single_connection.ex
@@ -5,6 +5,13 @@ defmodule SingleConnection do
 
   @behaviour P.SimpleConnection
 
+  def query(pid, query) do
+    case P.SimpleConnection.call(pid, {:query, query}) do
+      [%P.Result{} = result] -> {:ok, result}
+      other -> {:error, other}
+    end
+  end
+
   def child_spec(conf) do
     %{
       id: {__MODULE__, System.unique_integer()},


### PR DESCRIPTION
When the connection is proxied from other node, then only one node
should report the usage stats. Proxy node should be silent.
