### PR TITLE
feat: Allow infinite reconnect retries with -1 setting

### DIFF
--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -110,7 +110,7 @@ defmodule Supavisor.DbHandler do
       ]
 
     maybe_reconnect_callback = fn reason ->
-      if data.reconnect_retries > @reconnect_retries and data.client_sock != nil,
+      if @reconnect_retries != -1 and data.reconnect_retries > @reconnect_retries and data.client_sock != nil,
         do: {:stop, {:failed_to_connect, reason}},
         else: {:keep_state_and_data, {:state_timeout, reconnect_timeout(data), :connect}}
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces a feature that enables Supavisor to allow infinite reconnect retries when @reconnect_retries is set to -1.

## What is the current behavior?

Currently, the reconnect logic has a hard limit. Once the number of retries exceeds @reconnect_retries, Supavisor stops attempting to reconnect if the database is unavailable.

## What is the new behavior?

With this change, if @reconnect_retries is set to -1, Supavisor will never stop retrying to connect to the database. 
## Additional context

This supports environments that use dynamic scaling or “scale to zero” strategies where the database may be intentionally down but needs to be brought online seamlessly when connections are attempted again.
Makes “infinite” reconnection behavior a conscious user choice, helping in scenarios where the DB is scaled down and then scaled back up based on metrics.