### PR TITLE
fix: remove compromised github action

### DIFF
--- a/.github/workflows/version_updated.yml
+++ b/.github/workflows/version_updated.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify Versions Updated
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files@v45
         id: verify_changed_files
         with:
           files: |


### PR DESCRIPTION
Not verified to be working, given the version changes involved