### PR TITLE
feat: add `location_key` to global metadata

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -21,11 +21,14 @@ defmodule Supavisor.Application do
         _ -> nil
       end
 
+    region = Application.get_env(:supavisor, :region)
+
     global_metadata =
       %{
         host: host,
         az: Application.get_env(:supavisor, :availability_zone),
-        region: Application.get_env(:supavisor, :region),
+        region: region,
+        location: System.get_env("LOCATION_KEY") || region,
         instance_id: System.get_env("INSTANCE_ID")
       }
 


### PR DESCRIPTION
To differentiate between different clusters we have added `LOCATION_KEY` which should denote different working cluster. If that variable is not set, then it defaults to `REGION` value.
