### PR TITLE
Remove required fields from OpenAPI schema that don’t exist

### DIFF
--- a/lib/supavisor_web/open_api_schemas.ex
+++ b/lib/supavisor_web/open_api_schemas.ex
@@ -28,10 +28,7 @@ defmodule SupavisorWeb.OpenApiSchemas do
         updated_at: %Schema{type: :string, format: :date_time, readOnly: true}
       },
       required: [
-        :db_host,
-        :db_port,
         :db_user,
-        :db_database,
         :db_password,
         :pool_size
       ],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - Corrects the OpenAPI schema definition by removing invalid required field specifications.

## What is the current behavior?

I used `swagger2openapi` to generate an OpenAPI yml from the swagger endpoint. The OpenAPI schema in `lib/supavisor_web/open_api_schemas.ex` incorrectly lists some fields as required that don't actually exist in the schema definition, which makes client side OpenAPI validation fail. 

## What is the new behavior?

The schema's required fields list has been updated to only include fields that actually exist in the schema definition.