### PR TITLE
ci: clean up old release before getting deps, clean deps too

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -22,15 +22,15 @@ jobs:
         id: beam
         uses: erlef/setup-beam@v1
         with:
-          otp-version: '27.2.1'
-          elixir-version: '1.18.2'
+          otp-version: "27.2.1"
+          elixir-version: "1.18.2"
       - name: Set upgrade variables
         run: |
-            elixir ./deploy/upgrade/handler.exs all_keys ./deploy/upgrade/staging.config
-            echo "RELEASE_FROM=$(elixir ./deploy/upgrade/handler.exs upgrade_from ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
-            echo "RELEASE_TO=$(elixir ./deploy/upgrade/handler.exs upgrade_to ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
-            echo "NAME=$(elixir ./deploy/upgrade/handler.exs name ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
-            echo "TYPE=$(elixir ./deploy/upgrade/handler.exs type ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
+          elixir ./deploy/upgrade/handler.exs all_keys ./deploy/upgrade/staging.config
+          echo "RELEASE_FROM=$(elixir ./deploy/upgrade/handler.exs upgrade_from ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
+          echo "RELEASE_TO=$(elixir ./deploy/upgrade/handler.exs upgrade_to ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
+          echo "NAME=$(elixir ./deploy/upgrade/handler.exs name ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
+          echo "TYPE=$(elixir ./deploy/upgrade/handler.exs type ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -59,6 +59,13 @@ jobs:
         run: mix release supavisor
       - name: Checkout RELEASE_TO
         run: git checkout v${{ env.RELEASE_TO }}
+      - name: Clean up old release(s)
+        if: env.TYPE == 'soft'
+        run: |
+          rm -rf ./_build/${{ env.MIX_ENV }}/lib/supavisor
+          rm -rf ./deps
+          rm ./_build/${{ env.MIX_ENV }}/rel/supavisor/releases/COOKIE
+          rm ./_build/${{ env.MIX_ENV }}/supavisor-${{ env.RELEASE_FROM }}.tar.gz
       - name: Cache Mix
         uses: actions/cache@v3
         with:
@@ -66,12 +73,6 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
           restore-keys: |
             ${{ runner.os }}-mix-
-      - name: Clean up old release(s)
-        if: env.TYPE == 'soft'
-        run: |
-          rm -rf ./_build/${{ env.MIX_ENV }}/lib/supavisor
-          rm ./_build/${{ env.MIX_ENV }}/rel/supavisor/releases/COOKIE
-          rm ./_build/${{ env.MIX_ENV }}/supavisor-${{ env.RELEASE_FROM }}.tar.gz
       - name: Install dependencies
         run: |
           mix local.hex --force


### PR DESCRIPTION
I'm getting an awkward dep resolution error in release_stage CI:

```
Resolving Hex dependencies...
Resolution completed in 0.518s
Unchanged:
  artificery 0.4.3
  backoff 1.1.6
  ...
  syn 3.3.0
  **telemetry 1.3.0** <-- 1.3.0 here
   ...
Dependencies have diverged:
* telemetry (Hex package)
  the dependency telemetry 1.2.1 <-- where does this come from?

  > In deps/finch/mix.exs:
    {:telemetry, "~> 0.4 or ~> 1.0", [app_properties: [description: ~c"Dynamic dispatching library for metrics and instrumentations", vsn: ~c"1.2.1", registered: [], mod: {:telemetry_app, []}, applications: [:kernel, :stdlib], env: [], modules: [:telemetry, :telemetry_app, :telemetry_handler_table, :telemetry_sup, :telemetry_test], licenses: [~c"Apache-2.0"], links: [{~c"Github", ~c"https://github.com/beam-telemetry/telemetry"}], doc: ~c"doc", include_files: [~c"mix.exs"]], env: :prod, hex: "telemetry", repo: "hexpm", optional: false]}

  does not match the requirement specified

  > In deps/libcluster/mix.exs:
    {:telemetry, "~> 1.3", [env: :prod, hex: "telemetry", repo: "hexpm", optional: false]}

  Ensure they match or specify one of the above in your deps and set "override: true"
```

~> 1.3 and ~> 1.0 requirements are fine, you just gotta use 1.3+, and the previous step says its using telemetry 1.3.0, yet the error comes up.