### PR TITLE
chore: hard deploy for v2.5.3 in staging

### DIFF
--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -4,7 +4,7 @@
     % list() | [<<"all">>]
     {regions, [<<"all">>]},
     % :soft | :hard
-    {type, soft}
+    {type, hard}
 ].
 % supavisor_soft_all-1_1.1.13_1.1.39
 % vi: ft=erlang


### PR DESCRIPTION
We have some clusters using v2.5.1 and some using v2.5.2, plus having issues building soft upgrades on CI, failing at deps stage. This doesn't seem to be new. 