### PR TITLE
test: change tags: integration + docker -> integration_docker

### DIFF
--- a/test/integration/postgres_switching_test.exs
+++ b/test/integration/postgres_switching_test.exs
@@ -3,8 +3,7 @@ defmodule Supavisor.Integration.PostgresSwitchingTest do
 
   alias Supavisor.Jwt.Token
 
-  @moduletag integration: true
-  @moduletag docker: true
+  @moduletag integration_docker: true
 
   @postgres_port 7432
   @postgres_user "postgres"

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,7 +22,7 @@ ExUnit.start(
   exclude: [
     flaky: true,
     integration: true,
-    docker: true
+    integration_docker: true
   ]
 )
 


### PR DESCRIPTION
`[include: [:integration], exclude: [:docker]]` runs tests with both tags (inclusion overrides exclusion). So we need to use a different tag.