### PR TITLE
feat: add metric for client connection lifetime

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -420,7 +420,7 @@ defmodule Supavisor.ClientHandler do
       db_pid = db_checkout(:both, :on_connect, data)
       data = %{data | manager: manager_ref, db_pid: db_pid, idle_timeout: opts.idle_timeout}
 
-      Registry.register(@clients_registry, data.id, [])
+      Registry.register(@clients_registry, data.id, started_at: System.monotonic_time())
 
       next =
         if opts.ps == [],

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -40,18 +40,31 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
 
     use Peep.Buckets.Custom,
       buckets: [
+        # 0.5 seconds
         500,
+        # 1 second
         1_000,
+        # 5 seconds
         5_000,
-        10_000,
+        # 20 seconds
+        20_000,
+        # 1 minute
         60_000,
+        # 5 minutes
         300_000,
+        # 30 minutes
         1_800_000,
+        # 2 hours
         7_200_000,
+        # 8 hours
         28_800_000,
+        # 1 day
         86_400_000,
+        # 3 days
         259_200_000,
+        # 1 week
         604_800_000,
+        # 30 days
         2_592_000_000
       ]
   end
@@ -251,7 +264,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
       {__MODULE__, :execute_client_connections_lifetime, []},
       [
         distribution(
-          [:supavisor, :client, :connection, :lifetime],
+          [:supavisor, :client, :connection, :lifetime, :ms],
           event_name: [:supavisor, :client, :connection, :lifetime],
           measurement: :lifetime,
           description: "How long the client connection has been alive.",
@@ -265,6 +278,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
     )
   end
 
+  @spec execute_client_connections_lifetime() :: :ok
   def execute_client_connections_lifetime do
     read_time = System.monotonic_time()
 
@@ -273,6 +287,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
     |> Enum.each(&emit_client_connection_lifetime(&1, read_time))
   end
 
+  @spec emit_client_connection_lifetime(Supavisor.id(), integer()) :: :ok | :noop
   def emit_client_connection_lifetime(
         {{{type, tenant}, user, mode, db_name, search_path}, meta},
         read_time

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -287,7 +287,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
     |> Enum.each(&emit_client_connection_lifetime(&1, read_time))
   end
 
-  @spec emit_client_connection_lifetime(Supavisor.id(), integer()) :: :ok | :noop
+  @spec emit_client_connection_lifetime({Supavisor.id(), keyword()}, integer()) :: :ok | :noop
   def emit_client_connection_lifetime(
         {{{type, tenant}, user, mode, db_name, search_path}, meta},
         read_time

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -36,6 +36,8 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
   end
 
   defmodule ClientConnectionAgeBuckets do
+    @moduledoc false
+
     use Peep.Buckets.Custom,
       buckets: [
         500,

--- a/test/supavisor/monitoring/tenant_test.exs
+++ b/test/supavisor/monitoring/tenant_test.exs
@@ -1,0 +1,92 @@
+defmodule Supavisor.PromEx.Plugins.TenantTest do
+  use Supavisor.E2ECase, async: false
+
+  alias Supavisor.PromEx.Plugins.Tenant
+
+  @moduletag telemetry: true
+
+  describe "polling_metrics/1" do
+    test "properly exports metric" do
+      for polling_metric <- Tenant.polling_metrics([]) do
+        assert %PromEx.MetricTypes.Polling{metrics: [_ | _]} = polling_metric
+        {m, f, a} = polling_metric.measurements_mfa
+        assert function_exported?(m, f, length(a))
+
+        for telemetry_metric <- polling_metric.metrics do
+          assert Enum.any?(
+                   [
+                     Telemetry.Metrics.Distribution,
+                     Telemetry.Metrics.Counter,
+                     Telemetry.Metrics.LastValue,
+                     Telemetry.Metrics.Sum
+                   ],
+                   fn struct -> is_struct(telemetry_metric, struct) end
+                 )
+
+          assert telemetry_metric.description
+        end
+      end
+    end
+
+    test "uses poll rate option" do
+      for polling_metric <- Tenant.polling_metrics(poll_rate: 1000) do
+        assert %{poll_rate: 1000} = polling_metric
+      end
+    end
+  end
+
+  describe "execute_client_connections_lifetime" do
+    setup ctx do
+      create_instance([__MODULE__, ctx.line])
+    end
+
+    test "emits event for active client connections", ctx do
+      start_supervised!(
+        {SingleConnection,
+         hostname: "localhost",
+         port: Application.fetch_env!(:supavisor, :proxy_port_transaction),
+         database: ctx.db,
+         username: ctx.user,
+         password: "postgres"}
+      )
+
+      ref = attach_handler([:supavisor, :client, :connection, :lifetime])
+      assert :ok = Tenant.execute_client_connections_lifetime()
+
+      assert_receive {^ref, {[:supavisor, :client, :connection, :lifetime], measurement, meta}}
+
+      assert %{lifetime: lifetime} = measurement
+      assert lifetime >= 0
+
+      assert meta == %{
+               tenant: ctx.db,
+               user: String.split(ctx.user, ".") |> List.first(),
+               mode: :transaction,
+               type: :single,
+               db_name: ctx.db,
+               search_path: nil
+             }
+    end
+  end
+
+  def handle_event(event_name, measurement, meta, {pid, ref}) do
+    send(pid, {ref, {event_name, measurement, meta}})
+  end
+
+  defp attach_handler(event) do
+    ref = make_ref()
+
+    :telemetry.attach(
+      {ref, :test},
+      event,
+      &__MODULE__.handle_event/4,
+      {self(), ref}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach({ref, :test})
+    end)
+
+    ref
+  end
+end


### PR DESCRIPTION
Store start_time in client connection registry, then periodically emit telemetry for active client connections.