### PR TITLE
feat: add cluster metrics promex plugin

### DIFF
--- a/lib/supavisor/monitoring/cluster.ex
+++ b/lib/supavisor/monitoring/cluster.ex
@@ -1,0 +1,66 @@
+defmodule Supavisor.PromEx.Plugins.Cluster do
+  @moduledoc """
+  Polls cluster metrics.
+  """
+
+  use PromEx.Plugin
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate)
+
+    [
+      Polling.build(
+        :supavisor_cluster_size_events,
+        poll_rate,
+        {__MODULE__, :emit_cluster_size, []},
+        [
+          last_value(
+            [:supavisor, :prom_ex, :cluster, :size],
+            event_name: [:supavisor, :prom_ex, :cluster],
+            measurement: :size,
+            description: "The total number of nodes connected to the cluster."
+          )
+        ]
+      ),
+      Polling.build(
+        :supavisor_cluster_erpc_events,
+        poll_rate,
+        {__MODULE__, :emit_erpc_latency, []},
+        [
+          distribution(
+            [:supavisor, :prom_ex, :cluster, :erpc_ping, :duration, :ms],
+            event_name: [:supavisor, :prom_ex, :cluster, :erpc_ping, :stop],
+            measurement: :duration,
+            description: "Latency of ERPC ping requests to cluster nodes in milliseconds.",
+            tags: [:target_node, :result],
+            unit: {:native, :millisecond}
+          )
+        ]
+      )
+    ]
+  end
+
+  @spec emit_cluster_size() :: :ok
+  def emit_cluster_size do
+    connected_nodes = Node.list()
+    cluster_size = length(connected_nodes) + 1
+    :telemetry.execute([:supavisor, :prom_ex, :cluster], %{size: cluster_size})
+  end
+
+  @spec emit_erpc_latency() :: :ok
+  def emit_erpc_latency do
+    [Node.self() | Node.list()]
+    |> Enum.each(fn node ->
+      :telemetry.span([:supavisor, :prom_ex, :cluster, :erpc_ping], %{target_node: node}, fn ->
+        try do
+          :erpc.call(node, fn -> :ok end, 30_000)
+          {:ok, %{result: :success, target_node: node}}
+        catch
+          _, _ ->
+            {:ok, %{result: :failure, target_node: node}}
+        end
+      end)
+    end)
+  end
+end

--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -10,7 +10,7 @@ defmodule Supavisor.Monitoring.PromEx do
 
   alias Peep.Storage
   alias PromEx.Plugins
-  alias Supavisor.PromEx.Plugins.{OsMon, Tenant}
+  alias Supavisor.PromEx.Plugins.{Cluster, OsMon, Tenant}
   alias Telemetry.Metrics
 
   defmodule Store do
@@ -65,7 +65,8 @@ defmodule Supavisor.Monitoring.PromEx do
 
       # Custom PromEx metrics plugins
       {OsMon, poll_rate: poll_rate},
-      {Tenant, poll_rate: poll_rate}
+      {Tenant, poll_rate: poll_rate},
+      {Cluster, poll_rate: poll_rate}
     ]
   end
 

--- a/test/supavisor/monitoring/cluster_test.exs
+++ b/test/supavisor/monitoring/cluster_test.exs
@@ -1,0 +1,92 @@
+defmodule Supavisor.PromEx.Plugins.ClusterTest do
+  use Supavisor.E2ECase, async: false
+
+  alias Supavisor.PromEx.Plugins.Cluster
+
+  @moduletag telemetry: true
+
+  describe "polling_metrics/1" do
+    test "properly exports metrics" do
+      for polling_metric <- Cluster.polling_metrics([]) do
+        assert %PromEx.MetricTypes.Polling{metrics: [_ | _]} = polling_metric
+        {m, f, a} = polling_metric.measurements_mfa
+        assert function_exported?(m, f, length(a))
+
+        for telemetry_metric <- polling_metric.metrics do
+          assert Enum.any?(
+                   [
+                     Telemetry.Metrics.Distribution,
+                     Telemetry.Metrics.Counter,
+                     Telemetry.Metrics.LastValue,
+                     Telemetry.Metrics.Sum
+                   ],
+                   fn struct -> is_struct(telemetry_metric, struct) end
+                 )
+
+          assert telemetry_metric.description
+        end
+      end
+    end
+
+    test "uses poll rate option" do
+      for polling_metric <- Cluster.polling_metrics(poll_rate: 1000) do
+        assert %{poll_rate: 1000} = polling_metric
+      end
+    end
+  end
+
+  describe "emit_cluster_size/0" do
+    test "emits cluster size event" do
+      ref = attach_handler([:supavisor, :prom_ex, :cluster])
+      assert :ok = Cluster.emit_cluster_size()
+
+      assert_receive {^ref, {[:supavisor, :prom_ex, :cluster], measurement, meta}}
+
+      assert %{size: size} = measurement
+      assert is_integer(size)
+      assert size >= 1
+      assert meta == %{}
+    end
+  end
+
+  describe "emit_erpc_latency/0" do
+    test "emits ERPC latency events for all nodes" do
+      ref = attach_handler([:supavisor, :prom_ex, :cluster, :erpc_ping, :stop])
+
+      assert :ok = Cluster.emit_erpc_latency()
+
+      # Should receive at least one event for the current node
+      assert_receive {^ref,
+                      {[:supavisor, :prom_ex, :cluster, :erpc_ping, :stop], measurement, meta}}
+
+      assert %{duration: duration} = measurement
+      assert is_integer(duration)
+      assert duration >= 0
+
+      assert %{target_node: target_node, result: result} = meta
+      assert is_atom(target_node)
+      assert result in [:success, :failure]
+    end
+  end
+
+  def handle_event(event_name, measurement, meta, {pid, ref}) do
+    send(pid, {ref, {event_name, measurement, meta}})
+  end
+
+  defp attach_handler(event) do
+    ref = make_ref()
+
+    :telemetry.attach(
+      {ref, :test},
+      event,
+      &__MODULE__.handle_event/4,
+      {self(), ref}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach({ref, :test})
+    end)
+
+    ref
+  end
+end


### PR DESCRIPTION
This is coming from a situation where we had a bad node in the cluster causing problems to the others. The goal is to be able to see such situations in Grafana, and detect them early.