### PR TITLE
feat: check database and erpc capabilities on health check

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -87,6 +87,7 @@ defmodule Supavisor.Application do
 
     children = [
       Supavisor.ErlSysMon,
+      Supavisor.Health,
       {Registry, keys: :unique, name: Supavisor.Registry.Tenants},
       {Registry, keys: :unique, name: Supavisor.Registry.ManagerTables},
       {Registry, keys: :unique, name: Supavisor.Registry.PoolPids},

--- a/lib/supavisor/health.ex
+++ b/lib/supavisor/health.ex
@@ -73,17 +73,15 @@ defmodule Supavisor.Health do
   @doc false
   @spec database_reachable?() :: boolean()
   def database_reachable? do
-    try do
-      case Supavisor.Repo.query("SELECT 1") do
-        {:ok, %Postgrex.Result{rows: [[1]]}} ->
-          true
+    case Supavisor.Repo.query("SELECT 1") do
+      {:ok, %Postgrex.Result{rows: [[1]]}} ->
+        true
 
-        _ ->
-          false
-      end
-    catch
-      _, _ -> false
+      _ ->
+        false
     end
+  catch
+    _, _ -> false
   end
 
   @doc false

--- a/lib/supavisor/health.ex
+++ b/lib/supavisor/health.ex
@@ -60,10 +60,11 @@ defmodule Supavisor.Health do
         true
 
       nodes ->
-        # If **any** other node returns replies within the timeout, we are good.
         results = :erpc.multicall(nodes, fn -> :ok end, acceptable_erpc_latency)
 
-        Enum.zip(nodes, results)
+        # If **any** other node returns replies within the timeout, we are good.
+        nodes
+        |> Enum.zip(results)
         |> Enum.reduce(false, fn {node, result}, acc ->
           case result do
             {:ok, _} ->

--- a/lib/supavisor/health.ex
+++ b/lib/supavisor/health.ex
@@ -20,7 +20,7 @@ defmodule Supavisor.Health do
   @doc """
   The main API for checking the health of a Supavisor node.
   """
-  @spec health_check([Keyword.t()]) :: :ok | {:error, :failed_checks, [atom()]}
+  @spec health_check(Keyword.t()) :: :ok | {:error, :failed_checks, [atom()]}
   def health_check(checks \\ @checks) do
     successful_checks =
       @task_supervisor

--- a/lib/supavisor/health.ex
+++ b/lib/supavisor/health.ex
@@ -58,8 +58,7 @@ defmodule Supavisor.Health do
         true
 
       nodes ->
-        # If **any** other node returns :ok or replies within 500ms,
-        # we are good.
+        # If **any** other node returns replies within 500ms, we are good.
         Enum.any?(nodes, fn node ->
           start_time = System.monotonic_time(:millisecond)
 

--- a/lib/supavisor/health.ex
+++ b/lib/supavisor/health.ex
@@ -60,21 +60,11 @@ defmodule Supavisor.Health do
       nodes ->
         # If **any** other node returns replies within 500ms, we are good.
         Enum.any?(nodes, fn node ->
-          start_time = System.monotonic_time(:millisecond)
-
-          status =
-            try do
-              :ok = :erpc.call(node, fn -> :ok end, 5_000)
-            catch
-              _, _ -> :error
-            end
-
-          end_time = System.monotonic_time(:millisecond)
-          latency_ms = end_time - start_time
-
-          case status do
-            :error -> false
-            :ok -> latency_ms <= 500
+          try do
+            :ok = :erpc.call(node, fn -> :ok end, 500)
+            true
+          catch
+            _, _ -> false
           end
         end)
     end

--- a/lib/supavisor/health.ex
+++ b/lib/supavisor/health.ex
@@ -65,15 +65,13 @@ defmodule Supavisor.Health do
         # If **any** other node returns replies within the timeout, we are good.
         nodes
         |> Enum.zip(results)
-        |> Enum.reduce(false, fn {node, result}, acc ->
-          case result do
-            {:ok, _} ->
-              true
+        |> Enum.reduce(false, fn
+          {_node, {:ok, _}}, _acc ->
+            true
 
-            error ->
-              Logger.warning("Failed :erpc call to #{inspect(node)} with #{inspect(error)}")
-              acc
-          end
+          {node, error}, acc ->
+            Logger.warning("Failed :erpc call to #{inspect(node)} with #{inspect(error)}")
+            acc
         end)
     end
   end

--- a/lib/supavisor/health.ex
+++ b/lib/supavisor/health.ex
@@ -1,0 +1,104 @@
+defmodule Supavisor.Health do
+  @moduledoc """
+  Health checking functionality
+
+  Current checks:
+  - Acceptable ERPC latencies: fails if a node has high latency to all
+  other nodes through :erpc.
+  - Database reachable: fails if can't run a simple query in the database.
+  """
+
+  require Logger
+
+  @checks [
+    acceptable_erpc_latencies: {__MODULE__, :acceptable_erpc_latencies?, []},
+    database_reachable: {__MODULE__, :database_reachable?, []}
+  ]
+
+  @task_supervisor __MODULE__.TaskSupervisor
+
+  @doc """
+  The main API for checking the health of a Supavisor node.
+  """
+  @spec health_check([Keyword.t()]) :: :ok | {:error, :failed_checks, [atom()]}
+  def health_check(checks \\ @checks) do
+    successful_checks =
+      @task_supervisor
+      |> Task.Supervisor.async_stream_nolink(checks, fn {check, {m, f, a}} ->
+        result = apply(m, f, a)
+        {check, result}
+      end)
+      |> Enum.reduce([], fn result, acc ->
+        case result do
+          {:ok, {check, true}} -> [check | acc]
+          {:ok, {_check, false}} -> acc
+          {:exit, _} -> acc
+        end
+      end)
+
+    case Keyword.keys(checks) -- successful_checks do
+      [] ->
+        :ok
+
+      failed_checks ->
+        Logger.critical("Failing health checks: #{inspect(failed_checks)}")
+        {:error, :failed_checks, failed_checks}
+    end
+  end
+
+  @doc false
+  @spec acceptable_erpc_latencies?() :: boolean()
+  def acceptable_erpc_latencies? do
+    case Node.list() do
+      [] ->
+        true
+
+      # Results with a single clustered node may be too volatile to be considered
+      [_] ->
+        true
+
+      nodes ->
+        # If **any** other node returns :ok or replies within 500ms,
+        # we are good.
+        Enum.any?(nodes, fn node ->
+          start_time = System.monotonic_time(:millisecond)
+
+          status =
+            try do
+              :ok = :erpc.call(node, fn -> :ok end, 5_000)
+            catch
+              _, _ -> :error
+            end
+
+          end_time = System.monotonic_time(:millisecond)
+          latency_ms = end_time - start_time
+
+          case status do
+            :error -> false
+            :ok -> latency_ms <= 500
+          end
+        end)
+    end
+  end
+
+  @doc false
+  @spec database_reachable?() :: boolean()
+  def database_reachable? do
+    try do
+      case Supavisor.Repo.query("SELECT 1") do
+        {:ok, %Postgrex.Result{rows: [[1]]}} ->
+          true
+
+        _ ->
+          false
+      end
+    catch
+      _, _ -> false
+    end
+  end
+
+  @doc false
+  def child_spec(_opts) do
+    Task.Supervisor.child_spec(name: @task_supervisor)
+  end
+end

--- a/lib/supavisor_web/controllers/tenant_controller.ex
+++ b/lib/supavisor_web/controllers/tenant_controller.ex
@@ -209,11 +209,18 @@ defmodule SupavisorWeb.TenantController do
     summary: "Health check",
     parameters: [],
     responses: %{
-      204 => Empty.response()
+      204 => Empty.response(),
+      503 => Empty.response()
     }
   )
 
   def health(conn, _) do
-    send_resp(conn, 204, "")
+    case Supavisor.Health.health_check() do
+      :ok ->
+        send_resp(conn, 204, "")
+
+      {:error, :failed_checks, _failed_checks} ->
+        send_resp(conn, 503, "")
+    end
   end
 end

--- a/lib/supavisor_web/open_api_schemas.ex
+++ b/lib/supavisor_web/open_api_schemas.ex
@@ -210,4 +210,32 @@ defmodule SupavisorWeb.OpenApiSchemas do
 
     def response, do: {"Not found", "application/json", __MODULE__}
   end
+
+  defmodule ServiceUnavailable do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        status: %Schema{
+          type: :string,
+          description: "Supavisor health status",
+          default: "unhealthy"
+        },
+        timestamp: %Schema{
+          type: :string,
+          format: :date_time,
+          description: "Timestamp of the health check"
+        },
+        failed_checks: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "List of failed health check names"
+        }
+      }
+    })
+
+    def response, do: {"Service Unavailable", "application/json", __MODULE__}
+  end
 end

--- a/test/supavisor/health_test.exs
+++ b/test/supavisor/health_test.exs
@@ -3,7 +3,7 @@ defmodule Supavisor.HealthTest do
 
   alias Supavisor.Health
 
-  describe "health_check?/1" do
+  describe "health_check/1" do
     test "returns :ok when all health checks pass" do
       assert :ok = Health.health_check()
     end

--- a/test/supavisor/health_test.exs
+++ b/test/supavisor/health_test.exs
@@ -1,0 +1,49 @@
+defmodule Supavisor.HealthTest do
+  use ExUnit.Case, async: true
+
+  alias Supavisor.Health
+
+  describe "health_check?/1" do
+    test "returns :ok when all health checks pass" do
+      assert :ok = Health.health_check()
+    end
+
+    test "returns failing checks" do
+      assert {:error, :failed_checks, [:failing_check]} =
+               Health.health_check(failing_check: {__MODULE__, :failing_check, []})
+    end
+
+    test "returns checks raising exceptions" do
+      assert {:error, :failed_checks, [:exception_check]} =
+               Health.health_check(exception_check: {__MODULE__, :exception_check, []})
+    end
+
+    test "returns checks exiting" do
+      assert {:error, :failed_checks, [:exit_check]} =
+               Health.health_check(exit_check: {__MODULE__, :exit_check, []})
+    end
+
+    test "returns checks with invalid responses" do
+      assert {:error, :failed_checks, [:invalid_response_check]} =
+               Health.health_check(
+                 invalid_response_check: {__MODULE__, :invalid_response_check, []}
+               )
+    end
+  end
+
+  def failing_check(_args) do
+    false
+  end
+
+  def exception_check(_args) do
+    raise "exception"
+  end
+
+  def exit_check(_args) do
+    exit(:whoops)
+  end
+
+  def invalid_response_check(_args) do
+    {:error, :invalid_response}
+  end
+end

--- a/test/supavisor_web/controllers/tenant_controller_test.exs
+++ b/test/supavisor_web/controllers/tenant_controller_test.exs
@@ -153,6 +153,27 @@ defmodule SupavisorWeb.TenantControllerTest do
     end
   end
 
+  describe "health endpoint" do
+    test "returns 204 when all health checks pass", %{conn: conn} do
+      conn = get(conn, Routes.tenant_path(conn, :health))
+      assert response(conn, 204) == ""
+    end
+
+    test "returns 503 with failed checks when both health checks fail", %{conn: conn} do
+      :meck.expect(Supavisor.Health, :database_reachable?, fn -> false end)
+      on_exit(fn -> :meck.unload(Supavisor.Health) end)
+
+      conn = get(conn, Routes.tenant_path(conn, :health))
+
+      assert conn.status == 503
+      response_body = json_response(conn, 503)
+
+      assert response_body["status"] == "unhealthy"
+      assert response_body["failed_checks"] == ["database_reachable"]
+      assert {:ok, _datetime, _offset} = DateTime.from_iso8601(response_body["timestamp"])
+    end
+  end
+
   defp create_tenant(_) do
     tenant = tenant_fixture()
     %{tenant: tenant}

--- a/test/supavisor_web/controllers/tenant_controller_test.exs
+++ b/test/supavisor_web/controllers/tenant_controller_test.exs
@@ -159,7 +159,7 @@ defmodule SupavisorWeb.TenantControllerTest do
       assert response(conn, 204) == ""
     end
 
-    test "returns 503 with failed checks when both health checks fail", %{conn: conn} do
+    test "returns 503 with failed checks when health checks fail", %{conn: conn} do
       :meck.expect(Supavisor.Health, :database_reachable?, fn -> false end)
       on_exit(fn -> :meck.unload(Supavisor.Health) end)
 


### PR DESCRIPTION
Introduces `Supavisor.Health`, which provides a function that runs health checks.

Added two checks:
- Acceptable ERPC latencies: fails if a node has high latency to all other nodes through :erpc. Doesn't run if in a 1 or 2 node cluster. Fails if **all requests** have latency over 500ms or fail.
- Database reachable: fails if can't run a simple query in the database.

Calls this function on the health check endpoint, and return 503 if health checks are failing. After some time, if the condition persists, the infrastructure should restart the instance.
