### PR TITLE
fix(client-handler): handle :cancel_query when state is :idle

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -149,6 +149,10 @@ defmodule Supavisor.ClientHandler do
     :keep_state_and_data
   end
 
+  def handle_event(:info, :cancel_query, :idle, _data) do
+    :keep_state_and_data
+  end
+
   def handle_event(:info, {:tcp, _, <<_::64>>}, :exchange, %{sock: sock} = data) do
     Logger.metadata(state: :exchange)
     Logger.debug("ClientHandler: Client is trying to connect with SSL")


### PR DESCRIPTION
Fixes
```
[error] ClientHandler: Undefined msg: [{"type", :info}, {"content", :cancel_query}]
```
I see it pretty often in the logs. It seems to me that it should be just a no-op (query cancel coming late, when the query was already completed). The current code already ignores it, so the patch effectively just removes the error log (and adds a dedicated code path for it)
