### PR TITLE
feat: add ssl_request_message macro for pattern matching

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -153,7 +153,12 @@ defmodule Supavisor.ClientHandler do
     :keep_state_and_data
   end
 
-  def handle_event(:info, {:tcp, _, <<_::64>>}, :exchange, %{sock: sock} = data) do
+  def handle_event(
+        :info,
+        {:tcp, _, Server.ssl_request_message()},
+        :exchange,
+        %{sock: sock} = data
+      ) do
     Logger.metadata(state: :exchange)
     Logger.debug("ClientHandler: Client is trying to connect with SSL")
 

--- a/lib/supavisor/protocol/server.ex
+++ b/lib/supavisor/protocol/server.ex
@@ -36,6 +36,8 @@ defmodule Supavisor.Protocol.Server do
     end
   end
 
+  defmacro ssl_request_message, do: @ssl_request
+
   @spec decode(iodata()) :: [Pkt.t()]
   def decode(data), do: decode(data, [])
 

--- a/test/supavisor/protocol_test.exs
+++ b/test/supavisor/protocol_test.exs
@@ -122,6 +122,10 @@ defmodule Supavisor.ProtocolTest do
     assert @subject.ssl_request() == expected
   end
 
+  test "ssl_request_message/0" do
+    assert @subject.ssl_request_message == <<0, 0, 0, 8, 4, 210, 22, 47>>
+  end
+
   test "decode_pkt/1 with invalid packets" do
     assert @subject.decode_pkt(<<>>) == {:error, :bad_packet}
     assert @subject.decode_pkt(<<82, 0, 0, 0, 8, 0, 0>>) == {:error, :bad_packet}

--- a/test/supavisor/protocol_test.exs
+++ b/test/supavisor/protocol_test.exs
@@ -123,7 +123,7 @@ defmodule Supavisor.ProtocolTest do
   end
 
   test "ssl_request_message/0" do
-    assert @subject.ssl_request_message == <<0, 0, 0, 8, 4, 210, 22, 47>>
+    assert @subject.ssl_request_message() == <<0, 0, 0, 8, 4, 210, 22, 47>>
   end
 
   test "decode_pkt/1 with invalid packets" do


### PR DESCRIPTION
This PR enforces strict and explicit pattern matching by replacing the raw binary pattern `<<_::64>>` with the semantically meaningful `ssl_request_message` macro, reducing the risk of accidental matches and improving readability