### PR TITLE
feat: improved named prepared statements support

### DIFF
--- a/lib/supavisor/protocol/client.ex
+++ b/lib/supavisor/protocol/client.ex
@@ -116,8 +116,8 @@ defmodule Supavisor.Protocol.Client do
 
   def decode_payload(:parse_message, payload) do
     case :binary.split(payload, <<0>>, [:global, :trim_all]) do
-      [sql] -> sql
-      message -> message
+      [sql] -> %{str_name: "", sql: sql}
+      [name, sql | _] -> %{str_name: name, sql: sql}
     end
   end
 
@@ -135,9 +135,16 @@ defmodule Supavisor.Protocol.Client do
 
   def decode_payload(:termination_message, _payload), do: nil
 
-  def decode_payload(:bind_message, _payload), do: nil
+  def decode_payload(:bind_message, payload) do
+    [_portal_name, rest] = :binary.split(payload, <<0>>)
+    [statement_name, _rest] = :binary.split(rest, <<0>>)
 
-  def decode_payload(:execute_message, _payload), do: nil
+    %{str_name: statement_name}
+  end
+
+  def decode_payload(:execute_message, _payload) do
+    nil
+  end
 
   def decode_payload(_tag, ""), do: nil
 

--- a/lib/supavisor/protocol/prepared_statements.ex
+++ b/lib/supavisor/protocol/prepared_statements.ex
@@ -1,0 +1,164 @@
+defmodule Supavisor.Protocol.PreparedStatements do
+  @moduledoc """
+  This module handles prepared statements through the extended query protocol
+  for the client handler
+  """
+
+  alias Supavisor.Protocol.Client.Pkt
+  alias Supavisor.Protocol.PreparedStatements.PreparedStatement
+
+  # Unnamed prepared statements are sent untouched
+  def handle_pkt(
+        client_statements,
+        %Pkt{payload: %{str_name: ""}} = pkt
+      ) do
+    {client_statements, pkt}
+  end
+
+  def handle_pkt(
+        client_statements,
+        %Pkt{tag: :close_message, payload: %{char: "S"}} = pkt
+      ) do
+    client_side_name = pkt.payload.str_name
+
+    # If the prepared statement doesn't exist, no need to clean
+    # (some clients send this before preparing any statement)
+    {prepared_statement, client_statements} =
+      Map.pop(client_statements, client_side_name)
+
+    server_side_name =
+      case prepared_statement do
+        %PreparedStatement{name: name} -> name
+        nil -> "supavisor_none"
+      end
+
+    len = new_len(pkt, client_side_name, server_side_name)
+
+    new_bin =
+      <<?C, len::32, ?S, server_side_name::binary, 0>>
+
+    updated_payload = %{pkt.payload | str_name: server_side_name}
+
+    updated_pkt = %{
+      pkt
+      | bin: new_bin,
+        len: len + 1,
+        payload: updated_payload
+    }
+
+    {client_statements, updated_pkt}
+  end
+
+  def handle_pkt(client_statements, %Pkt{tag: :parse_message} = pkt) do
+    %{str_name: client_side_name} = pkt.payload
+
+    # TODO: if we generate a "per query" key here, we can reduce the number
+    # of duplicate prepared statements. We can achieve that with pg_parser, but
+    # lets do it as a future improvement
+    server_side_name = "supavisor_#{System.unique_integer()}"
+
+    <<_type, _len::32, _statement_name::binary-size(byte_size(client_side_name)), 0,
+      query_and_params::binary>> = pkt.bin
+
+    len = new_len(pkt, client_side_name, server_side_name)
+
+    new_bin =
+      <<?P, len::32, server_side_name::binary, 0, query_and_params::binary>>
+
+    updated_payload = %{pkt.payload | str_name: server_side_name}
+
+    updated_pkt = %{
+      pkt
+      | bin: new_bin,
+        len: len + 1,
+        payload: updated_payload
+    }
+
+    prepared_statement = %PreparedStatement{
+      name: server_side_name,
+      parse_pkt: updated_pkt
+    }
+
+    {Map.put(client_statements, client_side_name, prepared_statement), updated_pkt}
+  end
+
+  def handle_pkt(
+        client_statements,
+        %Pkt{tag: :bind_message} = pkt
+      ) do
+    %{str_name: client_side_name} = pkt.payload
+    prepared_statement = Map.get(client_statements, client_side_name)
+
+    <<_type, _len::32, rest::binary>> = pkt.bin
+    [_, rest] = :binary.split(rest, <<0>>)
+    [_, packet_after_server_side_name] = :binary.split(rest, <<0>>)
+
+    # TODO: should return error to client when the name is not known
+    {server_side_name, parse_pkt} =
+      case prepared_statement do
+        %PreparedStatement{name: name, parse_pkt: parse_pkt} -> {name, parse_pkt}
+        nil -> {"", nil}
+      end
+
+    len = new_len(pkt, client_side_name, server_side_name)
+
+    new_bin =
+      <<
+        ?B,
+        len::32,
+        0,
+        server_side_name::binary,
+        0,
+        packet_after_server_side_name::binary
+      >>
+
+    updated_payload =
+      pkt.payload
+      |> Map.put(:str_name, server_side_name)
+      |> Map.put(:parse_pkt, parse_pkt)
+
+    updated_pkt = %{
+      pkt
+      | bin: new_bin,
+        len: len + 1,
+        payload: updated_payload
+    }
+
+    {client_statements, updated_pkt}
+  end
+
+  def handle_pkt(client_statements, %Pkt{tag: :describe_message} = pkt) do
+    client_side_name = pkt.payload.str_name
+    prepared_statement = Map.get(client_statements, client_side_name)
+
+    server_side_name =
+      case prepared_statement do
+        %PreparedStatement{name: name} -> name
+        nil -> ""
+      end
+
+    len = new_len(pkt, client_side_name, server_side_name)
+
+    new_bin =
+      <<?D, len::32, ?S, server_side_name::binary, 0>>
+
+    updated_payload = %{pkt.payload | str_name: server_side_name}
+
+    updated_pkt = %{
+      pkt
+      | bin: new_bin,
+        len: len + 1,
+        payload: updated_payload
+    }
+
+    {client_statements, updated_pkt}
+  end
+
+  def handle_pkt(client_statements, pkt) do
+    {client_statements, pkt}
+  end
+
+  defp new_len(pkt, old_name, new_name) do
+    pkt.len + (byte_size(new_name) - byte_size(old_name)) - 1
+  end
+end

--- a/lib/supavisor/protocol/prepared_statements/prepared_statement.ex
+++ b/lib/supavisor/protocol/prepared_statements/prepared_statement.ex
@@ -1,0 +1,12 @@
+defmodule Supavisor.Protocol.PreparedStatements.PreparedStatement do
+  @moduledoc """
+  Represents a prepared statement.
+  """
+
+  defstruct [:parse_pkt, :name]
+
+  @type t() :: %__MODULE__{
+          parse_pkt: Supavisor.Protocol.Client.Pkt.t(),
+          name: String.t()
+        }
+end

--- a/lib/supavisor/protocol/server.ex
+++ b/lib/supavisor/protocol/server.ex
@@ -45,22 +45,8 @@ defmodule Supavisor.Protocol.Server do
   @spec decode(iodata()) :: {:ok, [Pkt.t()], rest :: binary()}
   def decode(data), do: decode(data, [])
 
-  # @spec decode_pkt(binary()) :: {:ok, Pkt.t(), binary()} | {:error, :bad_packet}
-  # def decode_pkt(<<char::integer-8, pkt_len::integer-32, rest::binary>>) do
-  #  payload_len = pkt_len - 4
-
-  #  case rest do
-  #    <<bin_payload::binary-size(payload_len), rest2::binary>> ->
-  #      tag = tag(char)
-  #      payload = decode_payload(tag, bin_payload)
-  #      {:ok, %Pkt{tag: tag, len: pkt_len + 1, payload: payload}, rest2}
-
-  #    _ ->
-  #      {:error, :incomplete}
-  #  end
-  # end
-
-  @spec decode_pkt(binary()) :: {:ok, Pkt.t(), binary()} | {:error, :bad_packet}
+  @spec decode_pkt(binary()) ::
+          {:ok, Pkt.t(), binary()} | {:error, :bad_packet} | {:error, :incomplete}
   def decode_pkt(<<char::integer-8, pkt_len::integer-32, rest::binary>>) do
     payload_len = pkt_len - 4
 

--- a/lib/supavisor/tenant_supervisor.ex
+++ b/lib/supavisor/tenant_supervisor.ex
@@ -21,6 +21,8 @@ defmodule Supavisor.TenantSupervisor do
 
   @impl true
   def init(%{replicas: replicas} = args) do
+    {{type, tenant}, user, mode, db_name, search_path} = args.id
+
     pools =
       replicas
       |> Enum.with_index()
@@ -36,7 +38,6 @@ defmodule Supavisor.TenantSupervisor do
 
     children = [{Manager, args}, {SecretChecker, args} | pools]
 
-    {{type, tenant}, user, mode, db_name, search_path} = args.id
     map_id = %{user: user, mode: mode, type: type, db_name: db_name, search_path: search_path}
     Registry.register(Supavisor.Registry.TenantSups, tenant, map_id)
 

--- a/test/integration/prepared_statements_test.exs
+++ b/test/integration/prepared_statements_test.exs
@@ -1,0 +1,82 @@
+defmodule Supavisor.Integration.PreparedStatementsTest do
+  use Supavisor.DataCase, async: false
+
+  require Logger
+
+  @tenant "proxy_tenant1"
+
+  @moduletag integration: true
+
+  setup do
+    db_conf = Application.get_env(:supavisor, Repo)
+
+    conns =
+      for _i <- 1..10 do
+        {:ok, conn} =
+          Postgrex.start_link(
+            hostname: db_conf[:hostname],
+            port: Application.get_env(:supavisor, :proxy_port_transaction),
+            database: db_conf[:database],
+            password: db_conf[:password],
+            username: db_conf[:username] <> "." <> @tenant
+          )
+
+        conn
+      end
+
+    {:ok, %{conns: conns}}
+  end
+
+  test "prepare once, run twice (concurrent processes)", %{conns: conns} do
+    test_pid = self()
+    process_count = 200
+
+    processes =
+      for _ <- 0..process_count do
+        conn = Enum.random(conns)
+
+        spawn_link(fn ->
+          name =
+            :crypto.strong_rand_bytes(16)
+            |> Base.encode16(case: :lower)
+
+          receive do
+            :q1 -> :ok
+          end
+
+          query =
+            Postgrex.prepare!(conn, name, """
+            SELECT schemaname, tablename, tableowner, hasindexes
+            FROM pg_tables
+            WHERE schemaname = $1
+            ORDER BY tablename;
+            """)
+
+          assert {:ok, q1, %{rows: _}} =
+                   Postgrex.execute(conn, query, ["public"])
+
+          assert q1.ref == query.ref
+
+          receive do
+            :q2 -> :ok
+          end
+
+          assert {:ok, q2, %{rows: _}} = Postgrex.execute(conn, query, ["private"])
+          assert q2.ref == query.ref
+          send(test_pid, :done)
+        end)
+      end
+
+    for p <- processes do
+      send(p, :q1)
+    end
+
+    for p <- processes do
+      send(p, :q2)
+    end
+
+    for _ <- 1..process_count do
+      assert_receive :done, 1000
+    end
+  end
+end

--- a/test/supavisor/protocol/prepared_statements_test.exs
+++ b/test/supavisor/protocol/prepared_statements_test.exs
@@ -1,0 +1,205 @@
+defmodule Supavisor.Protocol.PreparedStatementsTest do
+  use ExUnit.Case, async: true
+
+  alias Supavisor.Protocol.PreparedStatements
+  alias Supavisor.Protocol.PreparedStatements.PreparedStatement
+  alias Supavisor.Protocol.Client
+
+  setup do
+    client_statements = %{}
+
+    {:ok, client_statements: client_statements}
+  end
+
+  describe "handle_pkt/2" do
+    test "unnamed prepared statements are passed through unchanged", %{
+      client_statements: client_statements
+    } do
+      original_bin = <<80, 0, 0, 0, 16, 0, 115, 101, 108, 101, 99, 116, 32, 49, 0, 0, 0>>
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should return unchanged
+      assert new_client_statements == client_statements
+      assert result_pkt == pkt
+      assert result_pkt.bin == original_bin
+      assert result_pkt.payload.str_name == ""
+    end
+
+    test "close message updates statement name and binary" do
+      parse_pkt = %{tag: :parse_message, payload: %{str_name: "server_stmt"}}
+      prepared_statement = %PreparedStatement{name: "server_stmt", parse_pkt: parse_pkt}
+      client_statements = %{"test_stmt" => prepared_statement}
+
+      # Close message for prepared statement
+      original_bin = <<67, 0, 0, 0, 15, 83, 116, 101, 115, 116, 95, 115, 116, 109, 116, 0>>
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should remove from client_statements
+      assert new_client_statements == %{}
+
+      # Should update the packet
+      assert result_pkt.tag == :close_message
+      assert result_pkt.payload.str_name == "server_stmt"
+      assert result_pkt.payload.char == "S"
+
+      # Verify binary can be decoded
+      {:ok, [decoded_pkt], _} = Client.decode(result_pkt.bin)
+      assert decoded_pkt == result_pkt
+    end
+
+    test "parse message generates new server-side name", %{
+      client_statements: client_statements
+    } do
+      # Parse message with named statement
+      original_bin =
+        <<80, 0, 0, 0, 25, 116, 101, 115, 116, 95, 115, 116, 109, 116, 0, 115, 101, 108, 101, 99,
+          116, 32, 49, 0, 0, 0>>
+
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should add mapping to client_statements
+      assert map_size(new_client_statements) == 1
+      assert Map.has_key?(new_client_statements, "test_stmt")
+
+      prepared_statement = Map.get(new_client_statements, "test_stmt")
+      assert %PreparedStatement{} = prepared_statement
+      assert String.starts_with?(prepared_statement.name, "supavisor_")
+      assert prepared_statement.parse_pkt == result_pkt
+
+      # Should update the packet
+      assert result_pkt.tag == :parse_message
+      assert result_pkt.payload.str_name == prepared_statement.name
+
+      # Verify binary can be decoded
+      {:ok, [decoded_pkt], _} = Client.decode(result_pkt.bin)
+      assert decoded_pkt == result_pkt
+    end
+
+    test "bind message updates statement name" do
+      parse_pkt = %{tag: :parse_message, payload: %{str_name: "server_stmt"}}
+      prepared_statement = %PreparedStatement{name: "server_stmt", parse_pkt: parse_pkt}
+      client_statements = %{"test_stmt" => prepared_statement}
+
+      # Bind message referencing prepared statement
+      original_bin =
+        <<66, 0, 0, 0, 21, 0, 116, 101, 115, 116, 95, 115, 116, 109, 116, 0, 0, 0, 0, 0, 0, 0>>
+
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should not change client_statements
+      assert new_client_statements == client_statements
+
+      # Should update the packet
+      assert result_pkt.tag == :bind_message
+      assert result_pkt.payload.str_name == "server_stmt"
+      assert result_pkt.payload.parse_pkt == parse_pkt
+
+      # Verify binary can be decoded
+      {:ok, [decoded_pkt], _} = Client.decode(result_pkt.bin)
+      assert decoded_pkt == Map.update!(result_pkt, :payload, &Map.delete(&1, :parse_pkt))
+    end
+
+    test "describe message updates statement name" do
+      parse_pkt = %{tag: :parse_message, payload: %{str_name: "server_stmt"}}
+      prepared_statement = %PreparedStatement{name: "server_stmt", parse_pkt: parse_pkt}
+      client_statements = %{"test_stmt" => prepared_statement}
+
+      # Describe message for prepared statement
+      original_bin = <<68, 0, 0, 0, 15, 83, 116, 101, 115, 116, 95, 115, 116, 109, 116, 0>>
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should not change client_statements
+      assert new_client_statements == client_statements
+
+      # Should update the packet
+      assert result_pkt.tag == :describe_message
+      assert result_pkt.payload.str_name == "server_stmt"
+
+      # Verify binary can be decoded
+      {:ok, [decoded_pkt], _} = Client.decode(result_pkt.bin)
+      assert decoded_pkt == result_pkt
+    end
+
+    test "passthrough for message types we ignore", %{
+      client_statements: client_statements
+    } do
+      # Execute message (should pass through)
+      original_bin = <<69, 0, 0, 0, 9, 0, 0, 0, 0, 200>>
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should return unchanged
+      assert new_client_statements == client_statements
+      assert result_pkt == pkt
+      assert result_pkt.bin == original_bin
+
+      # Verify binary can be decoded
+      {:ok, [decoded_pkt], _} = Client.decode(result_pkt.bin)
+      assert decoded_pkt == result_pkt
+    end
+
+    test "bind message with unknown statement name" do
+      client_statements = %{}
+
+      # Bind message referencing unknown statement
+      original_bin =
+        <<66, 0, 0, 0, 21, 0, 116, 101, 115, 116, 95, 115, 116, 109, 116, 0, 0, 0, 0, 0, 0, 0>>
+
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should not change client_statements
+      assert new_client_statements == client_statements
+
+      # Should update the packet with nil server name
+      assert result_pkt.tag == :bind_message
+      assert result_pkt.payload.str_name == ""
+      assert result_pkt.payload.parse_pkt == nil
+
+      # Verify binary can be decoded
+      {:ok, [decoded_pkt], _} = Client.decode(result_pkt.bin)
+      assert decoded_pkt == Map.update!(result_pkt, :payload, &Map.delete(&1, :parse_pkt))
+    end
+
+    test "describe message with unknown statement name" do
+      client_statements = %{}
+
+      # Describe message for unknown statement
+      original_bin = <<68, 0, 0, 0, 15, 83, 116, 101, 115, 116, 95, 115, 116, 109, 116, 0>>
+      {:ok, [pkt], _} = Client.decode(original_bin)
+
+      {new_client_statements, result_pkt} =
+        PreparedStatements.handle_pkt(client_statements, pkt)
+
+      # Should not change client_statements
+      assert new_client_statements == client_statements
+
+      # Should update the packet with nil server name
+      assert result_pkt.tag == :describe_message
+      assert result_pkt.payload.str_name == ""
+
+      # Verify binary can be decoded
+      {:ok, [decoded_pkt], _} = Client.decode(result_pkt.bin)
+      assert decoded_pkt == result_pkt
+    end
+  end
+end


### PR DESCRIPTION
**Disclaimer: this is a first draft, and the code is rough at places, there's missing functionality, etc**

### Concept
This PR implements the following architecture:
- ClientHandlers keep track of the prepared statements sent on them
- ClientHandlers update the prepared statement packets changing the statement names to "internal names" (this is necessary because clients may reuse the names in different connections)
- Prepared statement packets aren't sent directly to the db socket, but instead are sent to the DbHandler. Whenever the ClientHandler sends a `bind` packet to the DbHandler, it should also send the respective `parse` (which it has stored)
- DbHandler decides whether it needs to run "parse" or just "bind"
- DbHandler must intercept "parse" responses when the client didn't request them/it was made due to necessity

### Parsing/decoding
- To be able to handle the prepared statement packets, ClientHandlers need to decode every client packet (at least on transaction mode)
- To be able to intercept parse (and soon, close) responses, DbHandler needs to decode every server packet. 
- For both of them, we can avoid decoding the whole payload/decode only what's necessary (generally, we only need tagging, except for the prepared statement payloads from which we need more data).
- The decoding means more CPU usage, and it could also mean that we will need to optimize the decoding routines a bit further.

### Next steps
- Benchmarking/performance improvements
- Prepared statement limit client_handler side (hard limit)
- Prepared statement limit db_handler side (LRU)
- Make it work with read replicas too
- Improved error handling/ensure we conform to what client libraries (and Postgres) expect.
- Deterministic internal name -- right now I'm using `System.unique_integer`, but if we use pg_parser to give a name to the statement, we can reduce the number of unnecessary prepares.