### PR TITLE
chore: v2.1.3 -> 2.1.6 soft release attempt

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,18 +1,8 @@
 [
     {upgrade_from, "2.1.3"},
-    {upgrade_to, "2.1.4"},
+    {upgrade_to, "2.1.6"},
     % list() | [<<"all">>]
-    {regions, [
-               <<"ap-south-1">>,
-               <<"ap-northeast-1">>,
-               <<"ap-northeast-2">>,
-               <<"eu-west-1">>,
-               <<"eu-west-3">>,
-               <<"us-east-2">>,
-               <<"ca-central-1">>,
-               <<"eu-north-1">>,
-               <<"eu-central-2">>
-              ]},
+    {regions, [ <<"eu-west-1">> ]},
     % :soft | :hard
     {type, soft}
 ].


### PR DESCRIPTION
Since v2.1.3 can't be built due to depending on a ref that ceased to exist, I re-tagged `v2.1.3` removing this ref. `v2.1.6` also doesn't refer to this ref. I found no good alternative other than recreating the tag. Going with 1 region first to see if it works.