### PR TITLE
feat: refresh PromEx application metrics on soft deploy

### DIFF
--- a/lib/supavisor/hot_upgrade.ex
+++ b/lib/supavisor/hot_upgrade.ex
@@ -154,7 +154,10 @@ defmodule Supavisor.HotUpgrade do
   end
 
   def reinit_manual_metrics do
-    PromEx.ManualMetricsManager.refresh_metrics(PromEx.Plugins.Application)
+    spawn(fn ->
+      :timer.sleep(60_000)
+      PromEx.ManualMetricsManager.refresh_metrics(PromEx.Plugins.Application)
+    end)
   end
 
   @spec enc(term) :: fun

--- a/lib/supavisor/hot_upgrade.ex
+++ b/lib/supavisor/hot_upgrade.ex
@@ -94,6 +94,7 @@ defmodule Supavisor.HotUpgrade do
   def reint_funs do
     reinit_pool_args()
     reinit_auth_query()
+    reinit_manual_metrics()
   end
 
   def reinit_pool_args do
@@ -150,6 +151,10 @@ defmodule Supavisor.HotUpgrade do
           Logger.debug("Skipping:#{inspect(key)} #{inspect(other)}")
       end
     end)
+  end
+
+  def reinit_manual_metrics do
+    PromEx.ManualMetricsManager.refresh_metrics(PromEx.Plugins.Application)
   end
 
   @spec enc(term) :: fun


### PR DESCRIPTION
The PromEx application metrics are "manual", so they are only emitted on application start or upon calling
`PromEx.ManualMetricsManager.refresh_metrics/1`. Since we don't do a restart on soft deploys, the relevant metrics (most importantly, application version) stay outdated in Grafana until a restart happens. This commit adds a refresh in the update script.