### PR TITLE
feat: support manually written appups

### DIFF
--- a/lib/tasks/gen.appup.ex
+++ b/lib/tasks/gen.appup.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Supavisor.Gen.Appup do
     lib_path = Path.join(rel_dir, "lib")
     path_from = Path.join(lib_path, "#{app}-#{from_vsn}")
     path_to = Path.join(lib_path, "#{app}-#{to_vsn}")
-    appup_path = appup_path(app, parsed[:path], path_to)
+    appup_path = appup_path(app, parsed[:path], path_to, to_vsn)
 
     transforms =
       case app do
@@ -65,12 +65,12 @@ defmodule Mix.Tasks.Supavisor.Gen.Appup do
     end
   end
 
-  defp appup_path(app, nil, path_to), do: Path.join([path_to, "ebin", "#{app}.appup"])
+  defp appup_path(app, nil, path_to, _to_vsn), do: Path.join([path_to, "ebin", "#{app}.appup"])
 
-  defp appup_path(app, path, _path_to) do
+  defp appup_path(app, path, _path_to, to_vsn) do
     cond do
       File.dir?(path) ->
-        Path.join(path, "#{app}.appup")
+        Path.join(path, "#{app}-#{to_vsn}.appup")
 
       File.exists?(Path.dirname(path)) ->
         path

--- a/lib/tasks/gen.appup.ex
+++ b/lib/tasks/gen.appup.ex
@@ -2,11 +2,18 @@ defmodule Mix.Tasks.Supavisor.Gen.Appup do
   @moduledoc """
   Generates an appup file for a given release.
 
+  Takes 4 parameters:
+  - `:from` - The version from which the upgrade starts.
+  - `:to` - The version to which the upgrade ends.
+  - `:app` - The application name. Defaults to `"supavisor"`
+  - `:path` - The path where the appup file will be generated. Defaults to
+  the release directory for the application.
+
   ## Examples
 
       # Generate an appup from 0.0.1 to 0.0.2 versions
 
-      mix supavisor.gen.appup --from=0.0.1 --to=0.0.2
+      mix supavisor.gen.appup --app=supavisor --from=0.0.1 --to=0.0.2
   """
 
   use Mix.Task
@@ -14,7 +21,10 @@ defmodule Mix.Tasks.Supavisor.Gen.Appup do
 
   @impl true
   def run(args) do
-    {parsed, _, _} = OptionParser.parse(args, strict: [from: :string, to: :string])
+    {parsed, _, _} =
+      OptionParser.parse(args, strict: [from: :string, to: :string, app: :string, path: :string])
+
+    app = String.to_existing_atom(parsed[:app] || "supavisor")
 
     {from_vsn, to_vsn} =
       if !parsed[:from] || !parsed[:to] do
@@ -24,17 +34,21 @@ defmodule Mix.Tasks.Supavisor.Gen.Appup do
         {parsed[:from], parsed[:to]}
       end
 
-    Mix.shell().info("Generating appup from #{from_vsn} to #{to_vsn}...\n")
+    Mix.shell().info("Generating appup for #{app} from #{from_vsn} to #{to_vsn}...\n")
 
     rel_dir = Path.join([File.cwd!(), "_build", "#{Mix.env()}", "rel", "supavisor"])
     lib_path = Path.join(rel_dir, "lib")
-    path_from = Path.join(lib_path, "supavisor-#{from_vsn}")
-    path_to = Path.join(lib_path, "supavisor-#{to_vsn}")
-    appup_path = Path.join([path_to, "ebin", "supavisor.appup"])
+    path_from = Path.join(lib_path, "#{app}-#{from_vsn}")
+    path_to = Path.join(lib_path, "#{app}-#{to_vsn}")
+    appup_path = appup_path(app, parsed[:path], path_to)
 
-    transforms = [Supavisor.HotUpgrade]
+    transforms =
+      case app do
+        :supavisor -> [Supavisor.HotUpgrade]
+        _other -> []
+      end
 
-    case Appup.make(:supavisor, from_vsn, to_vsn, path_from, path_to, transforms) do
+    case Appup.make(app, from_vsn, to_vsn, path_from, path_to, transforms) do
       {:ok, appup} ->
         Mix.shell().info("Writing appup to #{appup_path}")
 
@@ -48,6 +62,21 @@ defmodule Mix.Tasks.Supavisor.Gen.Appup do
 
       {:error, reason} ->
         Mix.raise("Failed to generate appup file: #{inspect(reason)}")
+    end
+  end
+
+  defp appup_path(app, nil, path_to), do: Path.join([path_to, "ebin", "#{app}.appup"])
+
+  defp appup_path(app, path, _path_to) do
+    cond do
+      File.dir?(path) ->
+        Path.join(path, "#{app}.appup")
+
+      File.exists?(Path.dirname(path)) ->
+        path
+
+      true ->
+        raise ArgumentError, "invalid path: #{path}"
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -134,7 +134,7 @@ defmodule Supavisor.MixProject do
       rel_content = File.read!(Path.join(release.version_path, "supavisor.rel"))
       :ok = File.write!(path, rel_content)
 
-      # If appups directory exists manually, don't run the tasks, and instead
+      # If appups directory exist, don't run the task to generate, and instead
       # use the existing appups.
       appups_path = Path.join(["relups", "#{from}-#{vsn}", "appups"])
 

--- a/mix.exs
+++ b/mix.exs
@@ -126,15 +126,47 @@ defmodule Supavisor.MixProject do
   end
 
   defp upgrade(release) do
-    from = System.get_env("UPGRADE_FROM")
+    from = System.get_env("UPGRADE_FROM", "")
 
-    if from && from != "" do
+    if from != "" do
       vsn = release.version
       path = Path.join([release.path, "releases", "supavisor-#{vsn}.rel"])
       rel_content = File.read!(Path.join(release.version_path, "supavisor.rel"))
-
-      Mix.Task.run("supavisor.gen.appup", ["--from=" <> from, "--to=" <> vsn])
       :ok = File.write!(path, rel_content)
+
+      # If appups directory exists manually, don't run the tasks, and instead
+      # use the existing appups.
+      appups_path = Path.join(["relups", "#{from}-#{vsn}", "appups"])
+
+      if appups_path do
+        IO.puts("Using existing appups from #{appups_path}")
+
+        appups_path
+        |> File.ls!()
+        |> Enum.each(fn appup ->
+          [app, version] =
+            appup
+            |> String.trim_trailing(".appup")
+            |> String.split("-")
+
+          file_path = Path.join(appups_path, appup)
+
+          destination =
+            Path.join([
+              release.path,
+              "lib",
+              "#{app}-#{version}",
+              "ebin",
+              "#{app}.appup"
+            ])
+
+          IO.puts("Copying #{file_path} to #{destination}")
+          File.copy(file_path, destination)
+        end)
+      else
+        Mix.Task.run("supavisor.gen.appup", ["--from=" <> from, "--to=" <> vsn])
+      end
+
       Mix.Task.run("supavisor.gen.relup", ["--from=" <> from, "--to=" <> vsn])
     end
 


### PR DESCRIPTION
This change allows us to write (and version) appups instead of using distillery to gen Supavisor's appups.

It's something that we may need in some cases, e.g.: the update from v2.0.21 to v2.1.x requires a few dependency bumps. If we write the appups for these dependencies, we can run a soft deploy.

### Expected flow

**Whenever you can, use the auto-generated appup**, with `UPGRADE_FROM=x.y.z mix release`. When you can't, you may use manual appups:

1. Determine the supavisor version upgrade path. E.g.: `2.0.21-2.1.3`. Create a directory for this upgrade path on `relups`. Inside it, create an `appups` directory.
2. Generate the necessary appups with `mix supavisor.gen.appup`. For example, `mix supavisor.gen.appup --app=phoenix_live_view --from=0.20.17 --to=1.0.2 --path=relups/2.0.21-2.1.3/appups`. At this point, the directory structure will look somewhat like this:
```
relups
└── 2.0.21-2.1.3
    └── appups
        ├── libcluster-3.5.0.appup
        ├── meck-1.0.0.appup
        ├── phoenix_live_view-1.0.2.appup
        ├── supavisor-2.1.3.appup
        └── telemetry_metrics-1.1.0.appup
```
3. Run `UPGRADE_FROM=x.y.z mix release` as usual. The assembled release will use the appups from the directory above. If you missed some appup, it will complain here.
4. **Review/test the upgrade process extensively**. A broken relup can cause issues, and since the rollback is part of the relup, chances are that if the upgrade is broken, the downgrade is broken as well.
5. Commit the appups and soft deploy.