### PR TITLE
perf: constant number of ranch instances

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -159,6 +159,7 @@ if config_env() != :test do
     proxy_port_transaction:
       System.get_env("PROXY_PORT_TRANSACTION", "6543") |> String.to_integer(),
     proxy_port_session: System.get_env("PROXY_PORT_SESSION", "5432") |> String.to_integer(),
+    proxy_port_internal: System.get_env("PROXY_PORT_INTERNAL", "5413") |> String.to_integer(),
     proxy_port: System.get_env("PROXY_PORT", "5412") |> String.to_integer(),
     prom_poll_rate: System.get_env("PROM_POLL_RATE", "15000") |> String.to_integer(),
     global_upstream_ca: upstream_ca,

--- a/lib/supavisor.ex
+++ b/lib/supavisor.ex
@@ -410,31 +410,10 @@ defmodule Supavisor do
     end
   end
 
-  @spec start_local_server(map()) :: {:ok, map()} | {:error, any()}
-  def start_local_server(%{max_clients: max_clients} = args) do
-    # max_clients=-1 is used for testing the maximum allowed clients in ProxyTest
-    {acceptors, max_clients} =
-      if max_clients > 0,
-        do: {ceil(max_clients / 100), max_clients},
-        else: {1, 100}
-
-    opts = %{
-      max_connections: max_clients * Application.get_env(:supavisor, :local_proxy_multiplier),
-      num_acceptors: max(acceptors, 10),
-      socket_opts: [port: 0, keepalive: true]
-    }
-
-    handler = Supavisor.ClientHandler
-    args = Map.put(args, :local, true)
-
-    pid =
-      case :ranch.start_listener(args.id, :ranch_tcp, opts, handler, args) do
-        {:ok, pid} -> pid
-        {:error, {:already_started, pid}} -> pid
-      end
-
+  @spec get_local_server(atom) :: map()
+  def get_local_server(mode) do
     host = Application.get_env(:supavisor, :node_host)
-    {:ok, %{listener: pid, host: host, port: :ranch.get_port(args.id)}}
+    %{host: host, port: :ranch.get_port({:pg_proxy_internal, mode})}
   end
 
   @spec count_pools(String.t()) :: non_neg_integer()

--- a/lib/supavisor/syn_handler.ex
+++ b/lib/supavisor/syn_handler.ex
@@ -12,39 +12,16 @@ defmodule Supavisor.SynHandler do
         :tenants,
         {{type, tenant}, user, mode, db_name, _search_path} = id,
         _pid,
-        meta,
+        _meta,
         reason
       ) do
-    metadata = %{
+    Logger.debug("Process unregistered: #{inspect(id)} #{inspect(reason)}", %{
       project: tenant,
       user: user,
       mode: mode,
       db_name: db_name,
       type: type
-    }
-
-    Logger.debug("Process unregistered: #{inspect(id)} #{inspect(reason)}", metadata)
-
-    case meta do
-      %{port: port, listener: listener} ->
-        try do
-          :ranch.stop_listener(id)
-
-          Logger.notice(
-            "SynHandler: Stopped listener #{inspect(id)} on port #{inspect(port)} listener #{inspect(listener)}",
-            metadata
-          )
-        rescue
-          exception ->
-            Logger.notice(
-              "ListenerShutdownError: Failed to stop listener #{inspect(id)} #{Exception.message(exception)}",
-              metadata
-            )
-        end
-
-      _ ->
-        nil
-    end
+    })
   end
 
   @impl true

--- a/lib/supavisor/tenant_supervisor.ex
+++ b/lib/supavisor/tenant_supervisor.ex
@@ -6,10 +6,9 @@ defmodule Supavisor.TenantSupervisor do
   alias Supavisor.Manager
   alias Supavisor.SecretChecker
 
-  def start_link(%{replicas: [%{mode: mode} = single]} = args)
+  def start_link(%{replicas: [%{mode: mode}]} = args)
       when mode in [:transaction, :session] do
-    {:ok, meta} = Supavisor.start_local_server(single)
-    Logger.info("Starting ranch instance #{inspect(meta)} for #{inspect(args.id)}")
+    meta = Supavisor.get_local_server(mode)
     name = {:via, :syn, {:tenants, args.id, meta}}
     Supervisor.start_link(__MODULE__, args, name: name)
   end


### PR DESCRIPTION
Instead of starting one ranch instance per pool, use the same two ranch instances for all pools.

Each ranch was starting a minimum of 10 acceptors (and consequently, 10 connection supervisors). With 10_000 pools, these are 200_000 processes, which consume a sizeable amount of memory and resources. They also added complexity in managing the separate ranch instances (need to start and finish them at appropriate times, specially because they weren't linked to the pool).

The ranch acceptors/connection supervisors aren't a bottleneck, and if they were, we can control the number of acceptors/supervisors through configuration. In synthesis, there's no benefit in starting bringing multiple ranch instances, only the resource consumption drawback.
