### PR TITLE
chore: fix nix development environment missing libclang

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
                   pkgs.protobuf
                   pkgs.cargo-outdated
                   pkgs.prom2json
-                  pkgs.llvmPackages_16.libclang
+                  pkgs.libclang
                 ]
                 ++ lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk; [
                   frameworks.System
@@ -143,7 +143,7 @@
                   libs.libDER
                 ]);
 
-              env.LIBCLANG_PATH = "${pkgs.llvmPackages_16.libclang.lib}/lib";
+              env.LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
 
               # Workaround for https://github.com/rust-lang/cargo/issues/5376
               env.RUSTFLAGS = lib.mkForce (lib.optionals pkgs.stdenv.isDarwin [

--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,7 @@
                   pkgs.protobuf
                   pkgs.cargo-outdated
                   pkgs.prom2json
+                  pkgs.llvmPackages_16.libclang
                 ]
                 ++ lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk; [
                   frameworks.System
@@ -141,6 +142,8 @@
                   frameworks.Security
                   libs.libDER
                 ]);
+
+              env.LIBCLANG_PATH = "${pkgs.llvmPackages_16.libclang.lib}/lib";
 
               # Workaround for https://github.com/rust-lang/cargo/issues/5376
               env.RUSTFLAGS = lib.mkForce (lib.optionals pkgs.stdenv.isDarwin [


### PR DESCRIPTION
## What kind of change does this PR introduce?

Explicitly list `libclang` dependency for the flake setup and configure the `LIBCLANG_PATH` variable to use that dependency for development using nix flake environment. I originally fixed it using `llvmPackages_16.libclang`, but it also works with `pkgs.libclang` so I am changing to this one in the last pushed commit. 

## What is the current behavior?

<img width="1851" height="694" alt="image" src="https://github.com/user-attachments/assets/d12041dc-b1cb-446a-8b97-361ee03377ab" />

