### PR TITLE
fix(authn): when credential changes are detected, retry the auth request 

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -102,6 +102,7 @@ defmodule Supavisor.Application do
     children = [
       Supavisor.ErlSysMon,
       Supavisor.Health,
+      Supavisor.CacheRefreshLimiter,
       {Registry, keys: :unique, name: Supavisor.Registry.Tenants},
       {Registry, keys: :unique, name: Supavisor.Registry.ManagerTables},
       {Registry, keys: :unique, name: Supavisor.Registry.PoolPids},

--- a/lib/supavisor/cache_refresh_limiter.ex
+++ b/lib/supavisor/cache_refresh_limiter.ex
@@ -1,0 +1,37 @@
+defmodule Supavisor.CacheRefreshLimiter do
+  @moduledoc false
+
+  use GenServer
+
+  @table_name Module.concat(__MODULE__, Table)
+  @cleanup_interval :timer.minutes(1)
+  @cache_refresh_limit 3
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @spec cache_refresh_limited?(Supavisor.id()) :: boolean()
+  def cache_refresh_limited?(id) do
+    counter = :ets.update_counter(@table_name, id, {2, 1}, {id, 0})
+    counter > @cache_refresh_limit
+  end
+
+  @impl true
+  def init([]) do
+    :ets.new(@table_name, [:named_table, :public, :set])
+    schedule_cleanup()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:cleanup, state) do
+    :ets.delete_all_objects(@table_name)
+    schedule_cleanup()
+    {:noreply, state}
+  end
+
+  defp schedule_cleanup do
+    Process.send_after(self(), :cleanup, @cleanup_interval)
+  end
+end

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -302,7 +302,7 @@ defmodule Supavisor.ClientHandler do
 
             key = {:secrets, tenant_or_alias, user}
 
-            case auth_secrets(info, user, key, :timer.hours(24)) do
+            case cached_get_secrets(data.id, info, user, key, :timer.hours(24)) do
               {:ok, auth_secrets} ->
                 Logger.debug("ClientHandler: Authentication method: #{inspect(auth_secrets)}")
 
@@ -351,57 +351,14 @@ defmodule Supavisor.ClientHandler do
           "ClientHandler: Exchange error: #{inspect(reason)} when method #{inspect(method)}"
         )
 
-        key = {:secrets_check, data.tenant, data.user}
-
-        if method != :password and reason == :wrong_password and
-             Cachex.get(Supavisor.Cache, key) == {:ok, nil} do
-          case auth_secrets(info, data.user, key, 15_000) do
-            {:ok, {method2, secrets2}} = value ->
-              if method != method2 or Map.delete(secrets.(), :client_key) != secrets2.() do
-                Logger.warning("ClientHandler: Update secrets and terminate pool")
-
-                Cachex.update(
-                  Supavisor.Cache,
-                  {:secrets, data.tenant, data.user},
-                  {:cached, value}
-                )
-
-                Supavisor.stop(data.id)
-              else
-                Logger.debug("ClientHandler: Cache the same #{inspect(key)}")
-              end
-
-            other ->
-              Logger.error("ClientHandler: Auth secrets check error: #{inspect(other)}")
-          end
-        else
-          Logger.debug("ClientHandler: Cache hit for #{inspect(key)}")
+        # Try cache invalidation and retry if conditions are met
+        case maybe_retry_with_fresh_secrets(sock, {method, secrets}, reason, info, data) do
+          {:retry_success, auth_result} -> auth_result
+          :no_retry -> handle_auth_failure(sock, reason, data)
         end
 
-        msg = postgres_auth_error(reason, data.user)
-        HandlerHelpers.sock_send(sock, msg)
-        Telem.client_join(:fail, data.id)
-        {:stop, {:shutdown, :exchange_error}}
-
       {:ok, client_key} ->
-        secrets =
-          if client_key,
-            do: fn -> Map.put(secrets.(), :client_key, client_key) end,
-            else: secrets
-
-        Logger.debug("ClientHandler: Exchange success")
-        :ok = HandlerHelpers.sock_send(sock, Server.authentication_ok())
-        Telem.client_join(:ok, data.id)
-
-        auth = Map.merge(data.auth, %{secrets: secrets, method: method})
-
-        conn_type =
-          if data.mode == :proxy,
-            do: :connect_db,
-            else: :subscribe
-
-        {:keep_state, %{data | auth_secrets: {method, secrets}, auth: auth},
-         {:next_event, :internal, conn_type}}
+        handle_auth_success(sock, {method, secrets}, client_key, data)
     end
   end
 
@@ -712,6 +669,112 @@ defmodule Supavisor.ClientHandler do
 
   ## Internal functions
 
+  defp maybe_retry_if_secrets_changed(
+         sock,
+         {method, secrets},
+         {method2, secrets2},
+         data
+       ) do
+    if method != method2 or Map.delete(secrets.(), :client_key) != secrets2.() do
+      Logger.warning("ClientHandler: Update secrets and retry authentication")
+
+      # Retry authentication with fresh secrets
+      case handle_exchange(sock, {method2, secrets2}) do
+        {:ok, client_key} ->
+          {:retry_success, handle_auth_success(sock, {method2, secrets2}, client_key, data)}
+
+        {:error, retry_reason} ->
+          Logger.error("ClientHandler: Authentication retry failed: #{inspect(retry_reason)}")
+          {:retry_success, handle_auth_failure(sock, retry_reason, data)}
+      end
+    else
+      Logger.debug("ClientHandler: Secrets are the same")
+      :no_retry
+    end
+  end
+
+  defp maybe_retry_with_fresh_secrets(sock, {method, secrets}, reason, info, data) do
+    if method != :password and reason == :wrong_password do
+      key = {:secrets_check, data.tenant, data.user}
+
+      if Supavisor.CacheRefreshLimiter.cache_refresh_limited?(data.id) do
+        retry_with_cached_secrets(sock, {method, secrets}, data, info, key)
+      else
+        retry_with_get_secrets(sock, {method, secrets}, data, info, key)
+      end
+    else
+      Logger.debug("ClientHandler: No retry condition met")
+      :no_retry
+    end
+  end
+
+  defp retry_with_cached_secrets(sock, {method, secrets}, data, info, key) do
+    case cached_get_secrets(data.id, info, data.user, key, 15000) do
+      {:ok, {method2, secrets2}} ->
+        maybe_retry_if_secrets_changed(sock, {method, secrets}, {method2, secrets2}, data)
+
+      {:error, reason} ->
+        Logger.error("ClientHandler: Auth secrets error: #{inspect(reason)}")
+        :no_retry
+    end
+  end
+
+  defp retry_with_get_secrets(sock, {method, secrets}, data, info, key) do
+    case get_secrets(data.id, info, data.user) do
+      {:ok, {method2, secrets2}} = value ->
+        result =
+          maybe_retry_if_secrets_changed(sock, {method, secrets}, {method2, secrets2}, data)
+
+        # Update cache only if we're retrying (secrets changed)
+        case result do
+          {:retry_success, _} ->
+            update_secrets_cache(key, value, data.tenant, data.user)
+
+          :no_retry ->
+            :ok
+        end
+
+        result
+
+      other ->
+        Logger.error("ClientHandler: Auth secrets check error: #{inspect(other)}")
+        :no_retry
+    end
+  end
+
+  defp update_secrets_cache(key, value, tenant, user) do
+    Cachex.put(Supavisor.Cache, key, {:cached, value}, ttl: 5_000)
+    Cachex.update(Supavisor.Cache, {:secrets, tenant, user}, {:cached, value})
+  end
+
+  defp handle_auth_success(sock, {method, secrets}, client_key, data) do
+    final_secrets =
+      if client_key,
+        do: fn -> Map.put(secrets.(), :client_key, client_key) end,
+        else: secrets
+
+    Logger.debug("ClientHandler: Exchange success")
+    :ok = HandlerHelpers.sock_send(sock, Server.authentication_ok())
+    Telem.client_join(:ok, data.id)
+
+    auth = Map.merge(data.auth, %{secrets: final_secrets, method: method})
+
+    conn_type =
+      if data.mode == :proxy,
+        do: :connect_db,
+        else: :subscribe
+
+    {:keep_state, %{data | auth_secrets: {method, final_secrets}, auth: auth},
+     {:next_event, :internal, conn_type}}
+  end
+
+  defp handle_auth_failure(sock, reason, data) do
+    msg = postgres_auth_error(reason, data.user)
+    HandlerHelpers.sock_send(sock, msg)
+    Telem.client_join(:fail, data.id)
+    {:stop, {:shutdown, :exchange_error}}
+  end
+
   @spec postgres_auth_error(
           :wrong_password | {:timeout, String.t()} | {:unexpected_message, term()},
           String.t()
@@ -905,83 +968,96 @@ defmodule Supavisor.ClientHandler do
     }
   end
 
-  @spec auth_secrets(map, String.t(), term(), non_neg_integer()) ::
+  @spec cached_get_secrets(Supavisor.id(), map, String.t(), term(), non_neg_integer()) ::
           {:ok, Supavisor.secrets()} | {:error, term()}
   ## password secrets
-  def auth_secrets(%{user: user, tenant: %{require_user: true}}, _, _, _) do
+  defp cached_get_secrets(_id, %{user: user, tenant: %{require_user: true}}, _, _, _) do
     secrets = %{db_user: user.db_user, password: user.db_password, alias: user.db_user_alias}
 
     {:ok, {:password, fn -> secrets end}}
   end
 
   ## auth_query secrets
-  def auth_secrets(info, db_user, key, ttl) do
+  defp cached_get_secrets(id, info, db_user, key, ttl) do
     fetch = fn _key ->
-      case get_secrets(info, db_user) do
+      case get_secrets(id, info, db_user) do
         {:ok, _} = resp -> {:commit, {:cached, resp}, ttl: ttl}
         {:error, _} = resp -> {:ignore, resp}
       end
     end
 
     case Cachex.fetch(Supavisor.Cache, key, fetch) do
-      {:ok, {:cached, value}} -> value
-      {:commit, {:cached, value}, _opts} -> value
-      {:ignore, resp} -> resp
+      {:ok, {:cached, value}} ->
+        value
+
+      {:commit, {:cached, value}, _opts} ->
+        value
+
+      {:ignore, resp} ->
+        resp
     end
   end
 
-  @spec get_secrets(map, String.t()) :: {:ok, {:auth_query, fun()}} | {:error, term()}
-  def get_secrets(%{user: user, tenant: tenant}, db_user) do
-    ssl_opts =
-      if tenant.upstream_ssl and tenant.upstream_verify == :peer do
-        [
-          verify: :verify_peer,
-          cacerts: [Helpers.upstream_cert(tenant.upstream_tls_ca)],
-          server_name_indication: String.to_charlist(tenant.db_host),
-          customize_hostname_check: [{:match_fun, fn _, _ -> true end}]
-        ]
-      else
-        [
-          verify: :verify_none
-        ]
-      end
+  @spec get_secrets(Supavisor.id(), map, String.t()) ::
+          {:ok, {:auth_query, fun()}} | {:error, term()}
+  defp get_secrets(id, %{user: user, tenant: tenant}, db_user) do
+    case Supavisor.SecretChecker.get_secrets(id) do
+      {:error, :not_started} ->
+        ssl_opts =
+          if tenant.upstream_ssl and tenant.upstream_verify == :peer do
+            [
+              verify: :verify_peer,
+              cacerts: [Helpers.upstream_cert(tenant.upstream_tls_ca)],
+              server_name_indication: String.to_charlist(tenant.db_host),
+              customize_hostname_check: [{:match_fun, fn _, _ -> true end}]
+            ]
+          else
+            [
+              verify: :verify_none
+            ]
+          end
 
-    {:ok, conn} =
-      Postgrex.start_link(
-        hostname: tenant.db_host,
-        port: tenant.db_port,
-        database: tenant.db_database,
-        password: user.db_password,
-        username: user.db_user,
-        parameters: [application_name: "Supavisor auth_query"],
-        ssl: tenant.upstream_ssl,
-        socket_options: [
-          Helpers.ip_version(tenant.ip_version, tenant.db_host)
-        ],
-        queue_target: 1_000,
-        queue_interval: 5_000,
-        ssl_opts: ssl_opts
-      )
+        {:ok, conn} =
+          Postgrex.start_link(
+            hostname: tenant.db_host,
+            port: tenant.db_port,
+            database: tenant.db_database,
+            password: user.db_password,
+            username: user.db_user,
+            parameters: [application_name: "Supavisor auth_query"],
+            ssl: tenant.upstream_ssl,
+            socket_options: [
+              Helpers.ip_version(tenant.ip_version, tenant.db_host)
+            ],
+            queue_target: 1_000,
+            queue_interval: 5_000,
+            ssl_opts: ssl_opts
+          )
 
-    try do
-      Logger.debug(
-        "ClientHandler: Connected to db #{tenant.db_host} #{tenant.db_port} #{tenant.db_database} #{user.db_user}"
-      )
+        try do
+          Logger.debug(
+            "ClientHandler: Connected to db #{tenant.db_host} #{tenant.db_port} #{tenant.db_database} #{user.db_user}"
+          )
 
-      resp =
-        with {:ok, secret} <- Helpers.get_user_secret(conn, tenant.auth_query, db_user) do
-          t = if secret.digest == :md5, do: :auth_query_md5, else: :auth_query
-          {:ok, {t, fn -> Map.put(secret, :alias, user.db_user_alias) end}}
+          resp =
+            with {:ok, secret} <- Helpers.get_user_secret(conn, tenant.auth_query, db_user) do
+              t = if secret.digest == :md5, do: :auth_query_md5, else: :auth_query
+              {:ok, {t, fn -> Map.put(secret, :alias, user.db_user_alias) end}}
+            end
+
+          Logger.info("ClientHandler: Get secrets finished")
+          resp
+        rescue
+          exception ->
+            Logger.error("ClientHandler: Couldn't fetch user secrets from #{tenant.db_host}")
+            reraise exception, __STACKTRACE__
+        after
+          Process.unlink(conn)
+          GenServer.stop(conn, :normal, 5_000)
         end
 
-      Logger.info("ClientHandler: Get secrets finished")
-      resp
-    rescue
-      exception ->
-        Logger.error("ClientHandler: Couldn't fetch user secrets from #{tenant.db_host}")
-        reraise exception, __STACKTRACE__
-    after
-      GenServer.stop(conn, :normal, 5_000)
+      secrets ->
+        secrets
     end
   end
 

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -1053,7 +1053,14 @@ defmodule Supavisor.ClientHandler do
             reraise exception, __STACKTRACE__
         after
           Process.unlink(conn)
-          GenServer.stop(conn, :normal, 5_000)
+
+          spawn(fn ->
+            try do
+              GenServer.stop(conn, :normal, 5_000)
+            catch
+              :exit, _ -> Process.exit(conn, :kill)
+            end
+          end)
         end
 
       secrets ->

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -709,7 +709,7 @@ defmodule Supavisor.ClientHandler do
   end
 
   defp retry_with_cached_secrets(sock, {method, secrets}, data, info, key) do
-    case cached_get_secrets(data.id, info, data.user, key, 15000) do
+    case cached_get_secrets(data.id, info, data.user, key, 15_000) do
       {:ok, {method2, secrets2}} ->
         maybe_retry_if_secrets_changed(sock, {method, secrets}, {method2, secrets2}, data)
 

--- a/lib/supavisor/secret_checker.ex
+++ b/lib/supavisor/secret_checker.ex
@@ -84,7 +84,7 @@ defmodule Supavisor.SecretChecker do
 
   def handle_info(:check, state) do
     check_secrets(state.user, state)
-    {:noreply, %{state | check_ref: check(), counter: 0}}
+    {:noreply, %{state | check_ref: check()}}
   end
 
   def handle_info(msg, state) do

--- a/lib/supavisor/secret_checker.ex
+++ b/lib/supavisor/secret_checker.ex
@@ -10,8 +10,19 @@ defmodule Supavisor.SecretChecker do
 
   def start_link(args) do
     name = {:via, Registry, {Supavisor.Registry.Tenants, {:secret_checker, args.id}}}
-
     GenServer.start_link(__MODULE__, args, name: name)
+  end
+
+  @spec get_secrets(Supavisor.id()) ::
+          {:ok, {method :: atom(), Supavisor.secrets()}} | {:error, :not_started}
+  def get_secrets(id) do
+    case Registry.lookup(Supavisor.Registry.Tenants, {:secret_checker, id}) do
+      [] ->
+        {:error, :not_started}
+
+      [{pid, _}] ->
+        GenServer.call(pid, :get_secrets)
+    end
   end
 
   def init(args) do
@@ -72,8 +83,8 @@ defmodule Supavisor.SecretChecker do
   end
 
   def handle_info(:check, state) do
-    check_secrets(state)
-    {:noreply, %{state | check_ref: check()}}
+    check_secrets(state.user, state)
+    {:noreply, %{state | check_ref: check(), counter: 0}}
   end
 
   def handle_info(msg, state) do
@@ -89,7 +100,7 @@ defmodule Supavisor.SecretChecker do
   def check(interval \\ @interval),
     do: Process.send_after(self(), :check, interval)
 
-  def check_secrets(%{auth: auth, user: user, conn: conn} = state) do
+  def check_secrets(user, %{auth: auth, conn: conn} = state) do
     case Helpers.get_user_secret(conn, auth.auth_query, user) do
       {:ok, secret} ->
         method = if secret.digest == :md5, do: :auth_query_md5, else: :auth_query
@@ -111,8 +122,14 @@ defmodule Supavisor.SecretChecker do
           Cachex.put(Supavisor.Cache, state.key, {:cached, value}, expire: :timer.hours(24))
         end
 
+        {:ok, {method, fn -> secret end}}
+
       other ->
         Logger.error("Failed to get secret: #{inspect(other)}")
     end
+  end
+
+  def handle_call(:get_secrets, _from, state) do
+    {:reply, check_secrets(state.user, state), state}
   end
 end


### PR DESCRIPTION
- Fixes an issue where the first authn request after a credential change always would fail.
- Adds a cache refresh limit of 3 per minute per pool (triggered every time the password is wrong). Previosuly, limited to once every 15s. This is mostly due to tests. In tests, if we don't have this, the hard limit of once per 15s causes the test to flak.
- Adds an optimization where we use the existing SecretsChecker connection instead of opening a new one to refresh the cache.