### PR TITLE
fix: always terminate db_handler when owner client_handler terminates

### DIFF
--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -360,20 +360,16 @@ defmodule Supavisor.DbHandler do
   end
 
   # linked client_handler went down
-  def handle_event(_, {:EXIT, pid, reason}, state, data) do
+  def handle_event(_, {:EXIT, pid, reason}, _, data) do
     if reason != :normal do
       Logger.error(
         "DbHandler: ClientHandler #{inspect(pid)} went down with reason #{inspect(reason)}"
       )
     end
 
-    if state == :busy or data.mode == :session do
-      sock_send(data.sock, Server.terminate_message())
-      :gen_tcp.close(elem(data.sock, 1))
-      {:stop, {:client_handler_down, data.mode}}
-    else
-      {:keep_state, %{data | caller: nil, buffer: []}}
-    end
+    sock_send(data.sock, Server.terminate_message())
+    :gen_tcp.close(elem(data.sock, 1))
+    {:stop, {:client_handler_down, data.mode}}
   end
 
   def handle_event({:call, from}, :get_state_and_mode, state, data) do


### PR DESCRIPTION
Among other things, this patch addresses a race condition when the socket was closed while DbHandler had `active: false`. This led to the DbHandler not receiving the TCP closed message, and the client handler crashing due to it. The DbHandler would stay on the pool with the dead socket, and and successive checkouts would get an unusable connection.

This patch ensures that the DbHandler is closed whenever the owner terminates, regardless of how it terminates or pool mode. This may cause the transaction pooler to restart connections more often, but should give us more correct behaviour.
