### PR TITLE
test: add upstream TLS validation and schema assertions

### DIFF
--- a/lib/supavisor_web/open_api_schemas.ex
+++ b/lib/supavisor_web/open_api_schemas.ex
@@ -18,7 +18,7 @@ defmodule SupavisorWeb.OpenApiSchemas do
         db_password: %Schema{type: :string, description: "Database password"},
         pool_size: %Schema{type: :integer, description: "Pool size"},
         mode_type: %Schema{type: :string, description: "Pooling mode type"},
-        max_clients: %Schema{type: :integer, description: "Max clients count"},
+        max_clients: %Schema{type: :integer, description: "Max clients count", nullable: true},
         pool_checkout_timeout: %Schema{type: :integer, description: "Pool checkout timeout"},
         is_manager: %Schema{
           type: :boolean,
@@ -43,8 +43,7 @@ defmodule SupavisorWeb.OpenApiSchemas do
         max_clients: 25_000,
         mode_type: "transaction",
         inserted_at: "2023-03-27T12:00:00Z",
-        updated_at: "2023-03-27T12:00:00Z",
-        allow_list: ["0.0.0.0/0", "::/0"]
+        updated_at: "2023-03-27T12:00:00Z"
       }
     })
 
@@ -65,13 +64,19 @@ defmodule SupavisorWeb.OpenApiSchemas do
         db_database: %Schema{type: :string, description: "Database name"},
         ip_version: %Schema{type: :string, description: "auto"},
         require_user: %Schema{type: :boolean, description: false},
-        sni_hostname: %Schema{type: :string, description: "your.domain.com"},
+        sni_hostname: %Schema{type: :string, description: "your.domain.com", nullable: true},
         upstream_ssl: %Schema{type: :boolean, description: true},
-        upstream_verify: %Schema{type: :string, description: "none"},
+        upstream_verify: %Schema{type: :string, description: "none", nullable: true},
         enforce_ssl: %Schema{type: :boolean, description: false},
+        allow_list: %Schema{
+          type: :array,
+          description: "List of CIDR addresses",
+          items: %Schema{type: :string}
+        },
         auth_query: %Schema{
           type: :string,
-          description: "SELECT rolname, rolpassword FROM pg_authid WHERE rolname=$1"
+          description: "SELECT rolname, rolpassword FROM pg_authid WHERE rolname=$1",
+          nullable: true
         },
         users: %Schema{type: :array, items: User},
         inserted_at: %Schema{type: :string, format: :date_time, readOnly: true},
@@ -112,6 +117,15 @@ defmodule SupavisorWeb.OpenApiSchemas do
     })
 
     def response, do: {"Tenant Response", "application/json", __MODULE__}
+  end
+
+  defmodule TenantData do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{type: :object, properties: %{data: Tenant}, required: [:data]})
+
+    def response, do: {"Tenant Show Response", "application/json", __MODULE__}
   end
 
   defmodule TenantList do
@@ -211,6 +225,14 @@ defmodule SupavisorWeb.OpenApiSchemas do
     def response, do: {"Not found", "application/json", __MODULE__}
   end
 
+  defmodule BadRequest do
+    @moduledoc false
+    require OpenApiSpex
+    OpenApiSpex.schema(%{})
+
+    def response, do: {"Bad request", "application/json", __MODULE__}
+  end
+
   defmodule ServiceUnavailable do
     @moduledoc false
     require OpenApiSpex
@@ -237,5 +259,13 @@ defmodule SupavisorWeb.OpenApiSchemas do
     })
 
     def response, do: {"Service Unavailable", "application/json", __MODULE__}
+  end
+
+  defmodule UnprocessablyEntity do
+    @moduledoc false
+    require OpenApiSpex
+    OpenApiSpex.schema(%{})
+
+    def response, do: {"Unprocessable Entity", "application/json", __MODULE__}
   end
 end

--- a/lib/supavisor_web/views/user_view.ex
+++ b/lib/supavisor_web/views/user_view.ex
@@ -5,6 +5,7 @@ defmodule SupavisorWeb.UserView do
     %{
       db_user_alias: user.db_user_alias,
       db_user: user.db_user,
+      db_password: user.db_password,
       pool_size: user.pool_size,
       is_manager: user.is_manager,
       mode_type: user.mode_type,

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -22,17 +22,23 @@ defmodule SupavisorWeb.ConnCase do
       # Import conveniences for testing with connections
       import Plug.Conn
       import Phoenix.ConnTest
+      import Phoenix.VerifiedRoutes
       import SupavisorWeb.ConnCase
 
       alias SupavisorWeb.Router.Helpers, as: Routes
 
       # The default endpoint for testing
       @endpoint SupavisorWeb.Endpoint
+      @router SupavisorWeb.Router
     end
   end
 
   setup tags do
     Supavisor.DataCase.setup_sandbox(tags)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+
+  def assert_schema(data, schema_name) do
+    OpenApiSpex.TestAssertions.assert_schema(data, schema_name, SupavisorWeb.ApiSpec.spec())
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test improvements

## What is the current behavior?

- `TenantControllerTest` did not cover upstream TLS certificate validation (`upstream_tls_ca`, `upstream_verify`).
- Tests used `Routes.tenant_path/3` instead of `~p` verified routes.
- JSON responses were not validated against OpenAPI schemas.

## What is the new behavior?

- Added tests for upstream TLS CA handling (valid, invalid, and verify cases).
- Migrated tests to use `~p` verified routes.
- Added `assert_schema/2` checks for JSON responses.