### PR TITLE
fix: correct PGOPTIONS parsing and search_path handling

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -220,7 +220,7 @@ defmodule Supavisor.ClientHandler do
 
         if Helpers.validate_name(user) and Helpers.validate_name(db_name) do
           log_level = maybe_change_log(hello)
-          search_path = hello.payload["options"]["--search_path"]
+          search_path = hello.payload["options"]["search_path"]
           event = {:hello, {type, {user, tenant_or_alias, db_name, search_path}}}
           app_name = app_name(hello.payload["application_name"])
 

--- a/lib/supavisor/protocol/server.ex
+++ b/lib/supavisor/protocol/server.ex
@@ -6,7 +6,7 @@ defmodule Supavisor.Protocol.Server do
   Error codes https://www.postgresql.org/docs/current/errcodes-appendix.html
   """
   require Logger
-  alias Supavisor.Protocol.{Debug, PgType}
+  alias Supavisor.Protocol.{Debug, PgType, StartupOptions}
 
   @pkt_header_size 5
   @authentication_ok <<?R, 8::32, 0::32>>
@@ -450,7 +450,7 @@ defmodule Supavisor.Protocol.Server do
         fields
         |> Enum.chunk_every(2)
         |> Enum.map(fn
-          ["options" = k, v] -> {k, URI.decode_query(v)}
+          ["options" = k, v] -> {k, StartupOptions.parse(v)}
           [k, v] -> {k, v}
         end)
         |> Map.new()

--- a/lib/supavisor/protocol/startup_options.ex
+++ b/lib/supavisor/protocol/startup_options.ex
@@ -1,0 +1,91 @@
+defmodule Supavisor.Protocol.StartupOptions do
+  @moduledoc """
+  Parse the `options` (PGOPTIONS) field from a PostgreSQL startup packet.
+
+  Recognizes `-c key=value`, `-ckey=value`, and `--key=value` forms,
+  following PostgreSQL rules for whitespace and backslash escaping.
+
+  Returns a map of option keys to values.
+
+  ## Examples
+
+      iex> Supavisor.Protocol.StartupOptions.parse("--log_level=debug -c search_path=public")
+      %{"log_level" => "debug", "search_path" => "public"}
+  """
+
+  require Logger
+
+  def parse(options) when is_binary(options) do
+    options
+    |> String.trim()
+    |> then(fn
+      "" -> %{}
+      trimmed -> trimmed |> split_pg_opts() |> tokens_to_map()
+    end)
+  end
+
+  def parse(_), do: %{}
+
+  # Tokenizer: split PGOPTIONS into tokens while preserving escapes.
+  @spec split_pg_opts(String.t()) :: [String.t()]
+  defp split_pg_opts(str) when is_binary(str) do
+    do_split_pg_opts(String.to_charlist(str), "", [], false)
+  end
+
+  defp do_split_pg_opts([], "", acc, _escape), do: Enum.reverse(acc)
+  defp do_split_pg_opts([], current, acc, _escape), do: Enum.reverse([current | acc])
+
+  # Handle backslash escape: next char literal
+  defp do_split_pg_opts([?\\ | rest], current, acc, _escape),
+    do: do_split_pg_opts(rest, current, acc, true)
+
+  defp do_split_pg_opts([c | rest], current, acc, true),
+    do: do_split_pg_opts(rest, current <> "\\" <> <<c>>, acc, false)
+
+  # Whitespace delimiter
+  defp do_split_pg_opts([c | rest], current, acc, false) when c in [?\s, ?\t, ?\n, ?\r] do
+    if current == "" do
+      do_split_pg_opts(rest, "", acc, false)
+    else
+      do_split_pg_opts(rest, "", [current | acc], false)
+    end
+  end
+
+  # Regular character
+  defp do_split_pg_opts([c | rest], current, acc, false),
+    do: do_split_pg_opts(rest, current <> <<c>>, acc, false)
+
+  # Token reducer: handles `-c key` `-ckey` `--key` forms and builds the options map.
+  @spec tokens_to_map([String.t()]) :: map()
+  defp tokens_to_map(tokens) do
+    Enum.reduce(tokens, {nil, %{}}, fn
+      "-c", {_, acc} ->
+        {:expect_kv, acc}
+
+      <<"--", kv::binary>>, {_, acc} ->
+        {nil, maybe_put_kv(acc, kv)}
+
+      <<"-c", kv::binary>>, {_, acc} ->
+        {nil, maybe_put_kv(acc, kv)}
+
+      token, {:expect_kv, acc} ->
+        {nil, maybe_put_kv(acc, token)}
+
+      token, {_, acc} ->
+        Logger.debug("StartupOptions: ignored token #{inspect(token)}")
+        {nil, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp maybe_put_kv(acc, kv) do
+    case String.split(kv, "=", parts: 2) do
+      [key, val] when key != "" and val != "" ->
+        Map.put(acc, key, val)
+
+      _ ->
+        Logger.debug("StartupOptions: invalid argument #{inspect(kv)}")
+        acc
+    end
+  end
+end

--- a/test/supavisor/protocol/startup_options_test.exs
+++ b/test/supavisor/protocol/startup_options_test.exs
@@ -1,0 +1,102 @@
+defmodule Supavisor.Protocol.StartupOptionsTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Supavisor.Protocol.StartupOptions
+
+  doctest StartupOptions
+
+  test "parses -c and -- tokens into a map" do
+    options = StartupOptions.parse("-c search_path=schemaA,schemaB --log_level=info")
+
+    assert options == %{"search_path" => "schemaA,schemaB", "log_level" => "info"}
+  end
+
+  test "-c flag supports immediate key without separator" do
+    assert StartupOptions.parse("-csearch_path=public") == %{"search_path" => "public"}
+  end
+
+  test "does not swallow following options into search_path value" do
+    assert StartupOptions.parse(
+             "--search_path=schemaA -clog_level=info -c application_name=-test-"
+           ) ==
+             %{
+               "search_path" => "schemaA",
+               "log_level" => "info",
+               "application_name" => "-test-"
+             }
+  end
+
+  test "logs warning when -c argument lacks key/value" do
+    log =
+      capture_log(fn ->
+        assert StartupOptions.parse("-c search_path") == %{}
+      end)
+
+    assert log =~ "StartupOptions: invalid argument \"search_path\""
+  end
+
+  test "keeps only valid options" do
+    log =
+      capture_log(fn ->
+        assert StartupOptions.parse("--search_path=public -malformed") == %{
+                 "search_path" => "public"
+               }
+      end)
+
+    assert log =~ "ignored token \"-malformed\""
+  end
+
+  test "supports value with whitespaces" do
+    pgoptions = ~s(--search_path=new\\ schema)
+    expected = ~s(new\\ schema)
+
+    assert StartupOptions.parse(pgoptions) == %{"search_path" => expected}
+  end
+
+  test "supports repeated whitespace separators" do
+    options =
+      StartupOptions.parse("-c search_path=schemaA  --log_level=debug\t\t-c application_name=app")
+
+    assert options == %{
+             "search_path" => "schemaA",
+             "log_level" => "debug",
+             "application_name" => "app"
+           }
+  end
+
+  test "keeps escaped spaces inside double-quoted values" do
+    pgoptions = ~s(--search_path="schema\\ with\\ space")
+    expected = ~s("schema\\ with\\ space")
+
+    assert StartupOptions.parse(pgoptions) == %{"search_path" => expected}
+  end
+
+  test "-c flag keeps escaped spaces inside quoted values" do
+    pgoptions = ~s(-c search_path="schema\\ with\\ space")
+    expected = ~s("schema\\ with\\ space")
+
+    assert StartupOptions.parse(pgoptions) == %{"search_path" => expected}
+  end
+
+  test "skips invalid --key with empty value" do
+    assert StartupOptions.parse("--mallformed=") == %{}
+  end
+
+  test "returns empty map for blank input" do
+    assert StartupOptions.parse("   ") == %{}
+  end
+
+  test "ignores unsupported flags" do
+    assert StartupOptions.parse("-search_path=public") == %{}
+  end
+
+  test "ignores stray escape token" do
+    assert StartupOptions.parse("\\") == %{}
+  end
+
+  test "treats non-binary input as empty options" do
+    assert StartupOptions.parse(nil) == %{}
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: improves PGOPTIONS parsing to correctly handle both `--key=value` and `-c key=value` syntax, prevent malformed tokens, and avoid leaking unintended parameters to Postgres.

## What is the current behavior?

Supavisor currently parses PGOPTIONS using `URI.decode_query`, but PostgreSQL does not URI-encode connection options  they are space-separated key=value pairs.

This causes several issues:

*  Only the first parameter is parsed
```
PGOPTIONS="--log_level=debug --search_path=custom" psql 'postgresql://...' -c "show search_path"
search_path   
-----------------
 "$user", public
(1 row)
```
* Common `-c key=value` syntax is not supported
```
PGOPTIONS="-c search_path=custom" psql 'postgresql://...' -c "show search_path"
search_path   
-----------------
 "$user", public
(1 row)
```

* When `--search_path` is first, following options are passed through
```
PGOPTIONS="--search_path=custom --work_mem=1234567" psql 'postgresql://...' -c "select name, setting from pg_settings where name in ('search_path','work_mem');"
    name     | setting 
-------------+---------
 search_path | custom
 work_mem    | 1234567
(2 rows)
```
```
PGOPTIONS='--search_path=custom -malformed' psql  'postgresql://...' -c "show search_path"
server closed the connection unexpectedly
``` 
> [!NOTE]
> In this case, Supavisor repeatedly tries to reconnect and floods the logs with: `[error] DbHandler: Error auth response ["SFATAL", "VFATAL", "C42601", "Minvalid command-line argument for server process: --search_path=custom", "HTry \"postgres --help\" for more information.", "Fpostgres.c", "L3931", "Rprocess_postgres_switches"]`

###  Related issues
- https://github.com/supabase/supavisor/issues/206
- https://github.com/supabase/supavisor/issues/343

## What is the new behavior?

- Supports both --key=value and -c key=value forms.
- Ignores malformed tokens safely and logs a warning.
- Prevents unintended parameters from being forwarded to Postgres.
- Passes recognized option values as-is to Postgres, preserving quotes and escapes

## Additional context

Integration tests for this behavior are included in https://github.com/supabase/supavisor/pull/770