### PR TITLE
fix: apply log_level from options payload during startup

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -1308,7 +1308,7 @@ defmodule Supavisor.ClientHandler do
   end
 
   @spec maybe_change_log(map()) :: atom() | nil
-  def maybe_change_log(%{"payload" => %{"options" => options}}) do
+  def maybe_change_log(%{payload: %{"options" => options}}) do
     level = options["log_level"] && String.to_existing_atom(options["log_level"])
 
     if level in [:debug, :info, :notice, :warning, :error] do


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: ensures the log_level option from the client startup payload is correctly applied during connection initialization.

## What is the current behavior?

The log_level value from client connection options is currently ignored.
The `maybe_change_log` function expected the incoming payload to use string keys, but the payload from `Server.decode_startup_packet` uses an atom-keyed map.

Related (closed) issue: https://github.com/supabase/supavisor/issues/209

## What is the new behavior?

When connecting with:
```
PGOPTIONS='--log_level=debug' psql  'postgresql://...' -c ''
```

Supavisor now set the requested level, and the following appears in logs:
`[notice] Setting log level to :debug`  appears in the Supavisor logs.

## Additional context

Integration tests for this behavior are included in https://github.com/supabase/supavisor/pull/770
