### PR TITLE
feat: compress metrics when sending them between nodes

### DIFF
--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -119,11 +119,21 @@ defmodule Supavisor.Monitoring.PromEx do
     Peep.get_all_metrics(__metrics_collector_name__())
   end
 
+  def fetch_metrics_compressed do
+    fetch_metrics()
+    |> :erlang.term_to_binary(compressed: 6)
+  end
+
   def fetch_tenant_metrics(tenant) do
     case Cachex.get(Supavisor.Cache, {:metrics, tenant}) do
       {_, metrics} when is_map(metrics) -> metrics
       _ -> %{}
     end
+  end
+
+  def fetch_tenant_metrics_compressed(tenant) do
+    fetch_tenant_metrics(tenant)
+    |> :erlang.term_to_binary(compressed: 6)
   end
 
   def fetch_cluster_metrics do
@@ -141,17 +151,17 @@ defmodule Supavisor.Monitoring.PromEx do
   end
 
   @spec fetch_node_metrics(atom()) :: map()
-  defp fetch_node_metrics(node), do: do_fetch(node, :fetch_metrics, [])
+  defp fetch_node_metrics(node), do: do_fetch(node, :fetch_metrics_compressed, [])
 
   @spec fetch_node_tenant_metrics(atom(), String.t()) :: map()
   defp fetch_node_tenant_metrics(node, tenant),
-    do: do_fetch(node, :fetch_tenant_metrics, [tenant])
+    do: do_fetch(node, :fetch_tenant_metrics_compressed, [tenant])
 
   @spec do_fetch(node(), atom(), list()) :: map()
   defp do_fetch(node, f, a) do
     case :rpc.call(node, __MODULE__, f, a, 25_000) do
-      map when is_map(map) ->
-        map
+      binary when is_binary(binary) ->
+        :erlang.binary_to_term(binary)
 
       {:badrpc, reason} ->
         Logger.error(


### PR DESCRIPTION
Should help to reduce erlang distribution traffic, at the price of some extra CPU.