### PR TITLE
Revert "Upgrade GitHub Actions to latest versions (#840)"

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -22,19 +22,19 @@ jobs:
       id-token: write
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v5.1.1
+        uses: aws-actions/configure-aws-credentials@v2.2.0
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: us-east-1
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v2
         with:
           registry: public.ecr.aws
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: akhilerm/tag-push-action@v2.2.0
+      - uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: docker.io/supabase/supavisor:${{ inputs.version }}
           dst: |

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Create tarball
         run: cd _build/${{ env.MIX_ENV }} && mv supavisor-${{ env.RELEASE_TO }}.tar.gz "${{ env.NAME }}_$(date "+%s").tar.gz"
       - name: configure aws credentials - production
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: "us-east-1"

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -38,12 +38,12 @@ jobs:
       - uses: docker/setup-buildx-action@v3
         with:
           endpoint: builders
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ needs.settings.outputs.image_tag }}_${{ matrix.arch }}
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Create tarball
         run: cd _build/${{ env.MIX_ENV }} && mv supavisor-${{ env.RELEASE_TO }}.tar.gz "${{ env.NAME }}_$(date "+%s").tar.gz"
       - name: configure aws credentials - staging
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.DEV_AWS_ROLE }}
           aws-region: "us-east-1"


### PR DESCRIPTION
This reverts commit 6a5215c1543b4c611ca281ae698796a74547d38c.

Prisma tests started failing, reverting to unblock main. Once fixed we can merge again.