### PR TITLE
Update local dev postgres setup

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   db:
-    image: supabase/postgres:14.1.0.106
+    image: supabase/postgres:15.14.1.072
     container_name: supavisor-db
     ports:
       - "6432:5432"
@@ -16,6 +16,7 @@ services:
     environment:
       POSTGRES_HOST: /var/run/postgresql
       POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
       # Uncomment to set MD5 authentication method on uninitialized databases
       # POSTGRES_INITDB_ARGS: --auth-host=md5
       # Uncomment to set password authentication method on uninitialized databases


### PR DESCRIPTION
Bumps the `supabase/postgres` Docker image version and sets the `POSTGRES_USER`

Without the `POSTGRES_USER` the setup doesn't work.
