### PR TITLE
fix: SNI-based tenant routing 

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -158,7 +158,8 @@ defmodule Supavisor.ClientHandler do
 
       opts = [
         verify: :verify_none,
-        certs_keys: certs_keys
+        certs_keys: certs_keys,
+        sni_fun: fn _hostname -> [certs_keys: certs_keys] end
       ]
 
       case :ssl.handshake(elem(sock, 1), opts) do
@@ -228,10 +229,12 @@ defmodule Supavisor.ClientHandler do
       {:ok, info} ->
         upstream_tls = upstream_tls(info.tenant, effective_ssl)
 
+        resolved_tenant = tenant_or_alias || info.tenant.external_id
+
         id =
           Supavisor.id(
             type: type,
-            tenant: tenant_or_alias,
+            tenant: resolved_tenant,
             user: user,
             mode: data.mode,
             db: db_name,

--- a/test/supavisor/tenants_test.exs
+++ b/test/supavisor/tenants_test.exs
@@ -235,6 +235,39 @@ defmodule Supavisor.TenantsTest do
                Tenants.get_user_cache(:single, "postgres", "dev_tenant", nil)
     end
 
+    test "get_user_cache/4 resolves tenant via sni_hostname when external_id is nil" do
+      external_id = "sni_routing_tenant_#{System.unique_integer([:positive])}"
+      sni_hostname = "sni-routing-#{System.unique_integer([:positive])}.example.com"
+
+      tenant_fixture(%{
+        external_id: external_id,
+        sni_hostname: sni_hostname,
+        users: [
+          %{
+            "db_user" => "sni_user",
+            "db_password" => "sni_pass",
+            "pool_size" => 3,
+            "mode_type" => "transaction"
+          }
+        ]
+      })
+
+      assert {:ok, %{tenant: tenant, user: user}} =
+               Tenants.get_user_cache(:single, "sni_user", nil, sni_hostname)
+
+      assert tenant.external_id == external_id
+      assert tenant.sni_hostname == sni_hostname
+      assert user.db_user == "sni_user"
+
+      assert [%Tenant{}] = Tenants.get_pool_config(tenant.external_id, "sni_user")
+    end
+
+    test "get_pool_config/2 raises when called with nil external_id" do
+      assert_raise ArgumentError, ~r/comparison with nil is forbidden/, fn ->
+        Tenants.get_pool_config(nil, "some_user")
+      end
+    end
+
     test "get_user_cache/4 returns error when tenant doesn't exist, then returns tenant after creation" do
       external_id = "cache_test_tenant_#{System.unique_integer([:positive])}"
       user = "cache_test_user"


### PR DESCRIPTION
## What is the current behavior?
SNI-based tenant routing silently fails across all tested versions (2.7.4, 2.8.8, 2.9.0-rc). When a client connects with a plain username (e.g. user=appuser) and relies on the TLS SNI hostname (e.g. demo-db.local.arc.cloud) for tenant resolution, try_get_sni() returns nil and the connection either falls back to dot-delimited username routing or crashes with "comparison with nil is forbidden" in Ecto.Query.Builder.


## What is the new behavior?
SNI-based tenant routing works end-to-end. Clients can connect with a plain username and the tenant is correctly resolved from the TLS SNI hostname. Pool identity and config lookups use the resolved tenant's external_id.
## Additional context
Two separate bugs in lib/supavisor/client_handler.ex:

The :ssl.handshake call doesn't include an sni_fun callback. Erlang OTP's :ssl module requires sni_fun to be registered during the handshake for the SNI hostname to be captured and returned by :ssl.connection_information/2. Without it, the handshake succeeds but sni_hostname is never stored. Fixed by adding sni_fun: fn _hostname -> [certs_keys: certs_keys] end to the handshake opts.


After SNI extraction works, the pool identity struct is still built with tenant: tenant_or_alias, where tenant_or_alias is parsed from the username and is nil for SNI-only connections. This nil propagates through start_local_pool → get_pool_config_cache → get_pool_config, where Ecto rejects the nil comparison. Fixed by falling back to info.tenant.external_id when tenant_or_alias is nil.

## Personal Context
I was trying to run Supavisor with sni routing on K8s but it kept failing for all tested versions (2.7.4, 2.8.8, 2.9.0-rc-3). Tried looking into the code & fixing this, this change did fix the error 

[logfile.txt](https://github.com/user-attachments/files/26358228/logfile.txt)
adding the error log i recieved when trying to connect using SNI routing - it would fail just after the correct password was accepted and just before the handshake

Hoping this helps!