### PR TITLE
fix(errors): improve checkout timeout error with actionable guidance

### DIFF
--- a/lib/supavisor/errors/checkout_timeout_error.ex
+++ b/lib/supavisor/errors/checkout_timeout_error.ex
@@ -1,8 +1,12 @@
 defmodule Supavisor.Errors.CheckoutTimeoutError do
   @moduledoc """
   This error is returned when unable to check out a connection from the pool due to timeout.
-  This happens when all connections in the pool are busy and none become available within the checkout timeout period.
-  Applies to both session and transaction modes.
+
+  This happens when all connections in the pool are busy and none become available within
+  the checkout timeout period. The error provides actionable guidance to help users
+  diagnose and resolve connection pool exhaustion issues.
+
+  Applies to both session and transaction modes, with mode-specific remediation hints.
   """
 
   use Supavisor.Error, [:mode, :timeout_ms, code: "ECHECKOUTTIMEOUT"]
@@ -13,9 +17,57 @@ defmodule Supavisor.Errors.CheckoutTimeoutError do
           code: binary()
         }
 
+  @docs_url "https://supabase.com/docs/guides/database/connecting-to-postgres"
+
   @impl Supavisor.Error
   def error_message(%{mode: mode, timeout_ms: timeout_ms}) do
-    mode_str = mode |> to_string() |> String.capitalize()
-    "unable to check out connection from the pool after #{timeout_ms}ms in #{mode_str} mode"
+    mode_str = format_mode(mode)
+
+    """
+    connection not available and checkout timed out after #{timeout_ms}ms in #{mode_str} mode. \
+    This means requests are coming in and your connection pool cannot serve them fast enough.
+
+    You can address this by:
+
+      1. Ensuring your database is available and that you can connect to it
+      2. Tracking down slow queries and making sure they are running fast enough
+      3. #{pool_size_hint(mode)}
+      4. Increasing the checkout timeout (note: this increases latency under load)
+
+    See #{@docs_url} for more information on connection pooling.\
+    """
+  end
+
+  @impl Supavisor.Error
+  def log_message(%{mode: mode, timeout_ms: timeout_ms} = error) do
+    mode_str = format_mode(mode)
+
+    IO.iodata_to_binary([
+      ?(,
+      error.code,
+      ?),
+      " checkout timeout after #{timeout_ms}ms in #{mode_str} mode"
+    ])
+  end
+
+  @impl Supavisor.Error
+  def log_level(_), do: :warning
+
+  # Private helpers
+
+  defp format_mode(:session), do: "Session"
+  defp format_mode(:transaction), do: "Transaction"
+  defp format_mode(mode), do: mode |> to_string() |> String.capitalize()
+
+  defp pool_size_hint(:session) do
+    "Increasing the pool_size (note: in Session mode each client holds a dedicated connection, so pool_size directly limits concurrent clients)"
+  end
+
+  defp pool_size_hint(:transaction) do
+    "Increasing the pool_size (note: this increases database resource consumption, but Transaction mode allows connection reuse between queries)"
+  end
+
+  defp pool_size_hint(_mode) do
+    "Increasing the pool_size (note: this increases database resource consumption)"
   end
 end

--- a/test/supavisor/errors/checkout_timeout_error_test.exs
+++ b/test/supavisor/errors/checkout_timeout_error_test.exs
@@ -1,0 +1,133 @@
+defmodule Supavisor.Errors.CheckoutTimeoutErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Supavisor.Errors.CheckoutTimeoutError
+
+  describe "error_message/1" do
+    test "includes timeout duration and mode for transaction mode" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 5000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "checkout timed out after 5000ms"
+      assert message =~ "Transaction mode"
+      assert message =~ "connection pool cannot serve them fast enough"
+    end
+
+    test "includes timeout duration and mode for session mode" do
+      error = %CheckoutTimeoutError{mode: :session, timeout_ms: 3000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "checkout timed out after 3000ms"
+      assert message =~ "Session mode"
+    end
+
+    test "provides actionable guidance about database availability" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "Ensuring your database is available"
+    end
+
+    test "provides actionable guidance about slow queries" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "Tracking down slow queries"
+    end
+
+    test "includes mode-specific pool_size hint for transaction mode" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "pool_size"
+      assert message =~ "Transaction mode allows connection reuse"
+    end
+
+    test "includes mode-specific pool_size hint for session mode" do
+      error = %CheckoutTimeoutError{mode: :session, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "pool_size"
+      assert message =~ "Session mode each client holds a dedicated connection"
+    end
+
+    test "provides actionable guidance about checkout timeout" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "Increasing the checkout timeout"
+      assert message =~ "increases latency"
+    end
+
+    test "includes documentation URL" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      message = CheckoutTimeoutError.error_message(error)
+
+      assert message =~ "https://supabase.com/docs/guides/database/connecting-to-postgres"
+    end
+  end
+
+  describe "log_message/1" do
+    test "returns concise message for logging" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 5000, code: "ECHECKOUTTIMEOUT"}
+      log_msg = CheckoutTimeoutError.log_message(error)
+
+      assert log_msg == "(ECHECKOUTTIMEOUT) checkout timeout after 5000ms in Transaction mode"
+    end
+
+    test "formats session mode correctly" do
+      error = %CheckoutTimeoutError{mode: :session, timeout_ms: 2500, code: "ECHECKOUTTIMEOUT"}
+      log_msg = CheckoutTimeoutError.log_message(error)
+
+      assert log_msg == "(ECHECKOUTTIMEOUT) checkout timeout after 2500ms in Session mode"
+    end
+
+    test "is shorter than error_message for reduced log verbosity" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 5000, code: "ECHECKOUTTIMEOUT"}
+
+      log_msg = CheckoutTimeoutError.log_message(error)
+      error_msg = CheckoutTimeoutError.error_message(error)
+
+      assert String.length(log_msg) < String.length(error_msg)
+    end
+  end
+
+  describe "log_level/1" do
+    test "returns warning level since timeouts are often transient" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      assert CheckoutTimeoutError.log_level(error) == :warning
+    end
+  end
+
+  describe "message/1" do
+    test "prefixes error_message with error code in parentheses" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      full_message = CheckoutTimeoutError.message(error)
+
+      assert full_message =~ "(ECHECKOUTTIMEOUT)"
+      assert full_message =~ "checkout timed out after 1000ms"
+    end
+  end
+
+  describe "postgres_error/1" do
+    test "returns fatal postgres error map with correct structure" do
+      error = %CheckoutTimeoutError{mode: :transaction, timeout_ms: 1000, code: "ECHECKOUTTIMEOUT"}
+      pg_error = CheckoutTimeoutError.postgres_error(error)
+
+      assert pg_error["S"] == "FATAL"
+      assert pg_error["C"] == "XX000"
+      assert pg_error["M"] =~ "ECHECKOUTTIMEOUT"
+      assert pg_error["M"] =~ "checkout timed out"
+    end
+  end
+
+  describe "exception/1" do
+    test "creates struct with provided fields and default code" do
+      error = CheckoutTimeoutError.exception(mode: :session, timeout_ms: 2500)
+
+      assert error.mode == :session
+      assert error.timeout_ms == 2500
+      assert error.code == "ECHECKOUTTIMEOUT"
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

This addresses #172 by making the checkout timeout error message actually helpful. Right now when users hit a pool timeout, they just get a terse message that doesn't tell them what to do about it. I've updated it to follow the same pattern that DBConnection uses - explaining what's happening and giving concrete steps to fix it.

## The problem

Current error message:
```
(ECHECKOUTTIMEOUT) unable to check out connection from the pool after 5000ms in Transaction mode
```

Users see this and have no idea what to do next. They end up searching forums, reading docs, or just increasing timeouts randomly hoping it helps.

## The solution

New error message:
```
(ECHECKOUTTIMEOUT) connection not available and checkout timed out after 5000ms in Transaction mode. This means requests are coming in and your connection pool cannot serve them fast enough.

You can address this by:

  1. Ensuring your database is available and that you can connect to it
  2. Tracking down slow queries and making sure they are running fast enough
  3. Increasing the pool_size (note: this increases database resource consumption, but Transaction mode allows connection reuse between queries)
  4. Increasing the checkout timeout (note: this increases latency under load)

See https://supabase.com/docs/guides/database/connecting-to-postgres for more information on connection pooling.
```

The hints are also mode-specific - Session mode users get reminded that each client holds a dedicated connection, so they understand why pool_size matters differently for them.

## Other changes

- Added a separate `log_message/1` that keeps logs concise (nobody wants multi-line error messages in their log aggregator)
- Changed log level to `:warning` instead of `:error` since timeouts are usually transient and self-resolving
- Added tests covering all the new functionality

## Testing

Added a new test file at `test/supavisor/errors/checkout_timeout_error_test.exs` that covers:
- Error message content for both modes
- All 4 remediation steps being present
- Mode-specific pool_size hints
- Log message format
- Log level
- Postgres error structure

## Notes

I noticed PR #896 attempted something similar but was closed. I took a slightly different approach here - keeping the log messages short while making the client-facing error detailed. Happy to adjust based on feedback.