### PR TITLE
perf: micro optimizations in the tls handshake

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -159,7 +159,8 @@ defmodule Supavisor.ClientHandler do
       opts = [
         verify: :verify_none,
         certs_keys: certs_keys,
-        sni_fun: fn _hostname -> [certs_keys: certs_keys] end
+        sni_fun: fn _hostname -> :undefined end,
+        receiver_spawn_opts: [min_heap_size: 2048]
       ]
 
       case :ssl.handshake(elem(sock, 1), opts) do

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -659,11 +659,12 @@ defmodule Supavisor.DbHandler do
             cacerts: [conn_params.upstream_tls_ca],
             # unclear behavior on pg14
             server_name_indication: conn_params.sni_hostname || conn_params.host,
-            customize_hostname_check: [{:match_fun, fn _, _ -> true end}]
+            customize_hostname_check: [{:match_fun, fn _, _ -> true end}],
+            receiver_spawn_opts: [min_heap_size: 2048]
           ]
 
         :none ->
-          [verify: :verify_none]
+          [verify: :verify_none, receiver_spawn_opts: [min_heap_size: 2048]]
       end
 
     case :ssl.connect(sock, opts, timeout) do


### PR DESCRIPTION
using :undefined instead of the list avoids recomputation. using a min heap size reduces the number of GCs during hte handshake