### PR TITLE
chore: upgrade euc21 to v2.9

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -4,7 +4,7 @@
     {upgrade_to, "2.9.0"},
     % list() | [<<"all">>]
     {regions, [
-	<<"use12">>
+	<<"euc21">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
upgrade euc21 to v2.9

platform: https://github.com/supabase/platform/pull/31535