### PR TITLE
feat: handle errors on db handler

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -457,7 +457,12 @@ defmodule Supavisor.ClientHandler do
     handle_socket_close(state, data)
   end
 
-  # linked DbHandler went down
+  # If the linked DbHandler went down normally, we can trust it to have
+  # sent/logged a proper error message and just terminate
+  def handle_event(:info, {:EXIT, _db_pid, :normal}, _state, _data) do
+    {:stop, :normal}
+  end
+
   def handle_event(:info, {:EXIT, db_pid, reason}, state, data) do
     context = if state in [:idle, :busy], do: :authenticated, else: :handshake
 

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -28,6 +28,7 @@ defmodule Supavisor.DbHandler do
 
   require Logger
   require Supavisor
+  require Supavisor.Protocol.BackendMessageHandler, as: BackendMessageHandler
   require Supavisor.Protocol.Server, as: Server
   require Supavisor.Protocol.MessageStreamer, as: MessageStreamer
 
@@ -40,7 +41,6 @@ defmodule Supavisor.DbHandler do
 
   alias Supavisor.{
     ClientHandler,
-    FeatureFlag,
     HandlerHelpers,
     Helpers,
     Monitoring.Telem,
@@ -372,9 +372,12 @@ defmodule Supavisor.DbHandler do
   end
 
   # the process received message from db while idle
-  def handle_event(:info, {proto, _, bin}, :idle, _data) when proto in @proto do
-    Logger.debug("DbHandler: Got db response #{inspect(bin)} when idle")
-    :keep_state_and_data
+  def handle_event(:info, {proto, _, bin}, :idle, data) when proto in @proto do
+    Logger.debug("DbHandler: Got db response when idle")
+
+    {:ok, updated_data, _packets} = process_backend_streaming(bin, data)
+
+    {:keep_state, updated_data}
   end
 
   # forward the message to the client
@@ -433,8 +436,12 @@ defmodule Supavisor.DbHandler do
       data
       | stream_state:
           Enum.reduce(close_pkts, data.stream_state, fn _, stream_state ->
-            MessageStreamer.update_state(stream_state, fn queue ->
-              :queue.in({:intercept, :close}, queue)
+            MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                            action_queue: queue
+                                                          ) = s ->
+              BackendMessageHandler.handler_state(s,
+                action_queue: :queue.in({:intercept, :close}, queue)
+              )
             end)
           end),
         prepared_statements: prepared_statements
@@ -513,10 +520,6 @@ defmodule Supavisor.DbHandler do
     end
   end
 
-  def handle_event(_, {closed, _}, :busy, data) when closed in @sock_closed do
-    {:stop, {:shutdown, :db_termination}, data}
-  end
-
   def handle_event(_, {closed, _}, :authentication, data) when closed in @sock_closed do
     Logger.error("DbHandler: Db connection closed when state was authentication")
 
@@ -524,11 +527,18 @@ defmodule Supavisor.DbHandler do
   end
 
   def handle_event(_, {closed, _}, state, data) when closed in @sock_closed do
-    if state != :terminating_with_error do
-      Logger.error("DbHandler: Db connection closed when state was #{state}")
-    end
+    case last_fatal_error(data) do
+      %{"M" => msg, "C" => code} ->
+        Logger.error("DbHandler: Database fatal error when state was #{state}: #{msg} (#{code})")
+        {:stop, :normal, data}
 
-    {:stop, {:shutdown, :db_termination}, data}
+      _ ->
+        if state != :terminating_with_error do
+          Logger.error("DbHandler: Db connection closed when state was #{state}")
+        end
+
+        {:stop, {:shutdown, :db_termination}, data}
+    end
   end
 
   # linked client_handler went down
@@ -609,6 +619,24 @@ defmodule Supavisor.DbHandler do
           "DbHandler: Terminating with reason #{inspect(reason)} when state was #{inspect(state)}"
         )
     end
+  end
+
+  @impl true
+  def code_change(_old_vsn, state, data, _extra) do
+    stream_state = data.stream_state
+
+    new_stream_state =
+      case MessageStreamer.stream_state(stream_state, :handler_state) do
+        BackendMessageHandler.handler_state() ->
+          stream_state
+
+        old_queue ->
+          MessageStreamer.stream_state(stream_state,
+            handler_state: BackendMessageHandler.handler_state(action_queue: old_queue)
+          )
+      end
+
+    {:ok, state, %{data | stream_state: new_stream_state}}
   end
 
   @impl true
@@ -853,19 +881,13 @@ defmodule Supavisor.DbHandler do
 
   @spec handle_server_messages(binary(), map()) :: map()
   defp handle_server_messages(bin, data) do
-    if FeatureFlag.enabled?(data.tenant_feature_flags, "named_prepared_statements") do
-      {:ok, updated_data, packets_to_send} = process_backend_streaming(bin, data)
+    {:ok, updated_data, to_send} = process_backend_streaming(bin, data)
 
-      if packets_to_send != [] do
-        HandlerHelpers.sock_send(data.client_sock, packets_to_send)
-      end
-
-      updated_data
-    else
-      HandlerHelpers.sock_send(data.client_sock, bin)
-
-      data
+    if to_send != [] do
+      HandlerHelpers.sock_send(data.client_sock, to_send)
     end
+
+    updated_data
   end
 
   # If the prepared statement exists for us, it exists for the server, so we just send the
@@ -880,9 +902,14 @@ defmodule Supavisor.DbHandler do
       new_data = %{
         data
         | stream_state:
-            MessageStreamer.update_state(data.stream_state, fn queue ->
-              :queue.in({:intercept, :parse}, queue)
-            end),
+            MessageStreamer.update_state(
+              data.stream_state,
+              fn BackendMessageHandler.handler_state(action_queue: queue) = s ->
+                BackendMessageHandler.handler_state(s,
+                  action_queue: :queue.in({:intercept, :parse}, queue)
+                )
+              end
+            ),
           prepared_statements: MapSet.put(data.prepared_statements, stmt_name)
       }
 
@@ -896,8 +923,12 @@ defmodule Supavisor.DbHandler do
        data
        | prepared_statements: MapSet.delete(data.prepared_statements, stmt_name),
          stream_state:
-           MessageStreamer.update_state(data.stream_state, fn queue ->
-             :queue.in({:forward, :close}, queue)
+           MessageStreamer.update_state(data.stream_state, fn BackendMessageHandler.handler_state(
+                                                                action_queue: queue
+                                                              ) = s ->
+             BackendMessageHandler.handler_state(s,
+               action_queue: :queue.in({:forward, :close}, queue)
+             )
            end)
      }}
   end
@@ -914,9 +945,14 @@ defmodule Supavisor.DbHandler do
        %{
          data
          | stream_state:
-             MessageStreamer.update_state(data.stream_state, fn queue ->
-               :queue.in({:inject, :parse}, queue)
-             end)
+             MessageStreamer.update_state(
+               data.stream_state,
+               fn BackendMessageHandler.handler_state(action_queue: queue) = s ->
+                 BackendMessageHandler.handler_state(s,
+                   action_queue: :queue.in({:inject, :parse}, queue)
+                 )
+               end
+             )
        }}
     else
       prepared_statements = MapSet.put(data.prepared_statements, stmt_name)
@@ -926,9 +962,14 @@ defmodule Supavisor.DbHandler do
          data
          | prepared_statements: prepared_statements,
            stream_state:
-             MessageStreamer.update_state(data.stream_state, fn queue ->
-               :queue.in({:forward, :parse}, queue)
-             end)
+             MessageStreamer.update_state(
+               data.stream_state,
+               fn BackendMessageHandler.handler_state(action_queue: queue) = s ->
+                 BackendMessageHandler.handler_state(s,
+                   action_queue: :queue.in({:forward, :parse}, queue)
+                 )
+               end
+             )
        }}
     end
   end
@@ -952,12 +993,18 @@ defmodule Supavisor.DbHandler do
   defp process_backend_streaming(bin, data) do
     case MessageStreamer.handle_packets(data.stream_state, bin) do
       {:ok, new_stream_state, packets} ->
-        updated_data = %{data | stream_state: new_stream_state}
-        {:ok, updated_data, packets}
+        {:ok, %{data | stream_state: new_stream_state}, packets}
 
       err ->
         err
     end
+  end
+
+  defp last_fatal_error(data) do
+    BackendMessageHandler.handler_state(
+      MessageStreamer.stream_state(data.stream_state, :handler_state),
+      :fatal_error
+    )
   end
 
   defp get_connection_params_with_secrets(conn_params, id) do

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -529,7 +529,7 @@ defmodule Supavisor.DbHandler do
   end
 
   def handle_event(_, {closed, _}, :authentication, data) when closed in @sock_closed do
-    Logger.error("DbHandler: Db connection closed when state was authentication")
+    Logger.error("DbHandler: Connection closed unexpectedly during authentication")
 
     handle_connection_failure({:error, :db_connection_closed_in_auth}, data)
   end
@@ -537,12 +537,14 @@ defmodule Supavisor.DbHandler do
   def handle_event(_, {closed, _}, state, data) when closed in @sock_closed do
     case last_fatal_error(data) do
       %{"M" => msg, "C" => code} ->
-        Logger.error("DbHandler: Database fatal error when state was #{state}: #{msg} (#{code})")
+        status = if state == :busy, do: "checked out by a client", else: "idle in the pool"
+        Logger.error("DbHandler: Session terminated by server while #{status}: #{msg} (#{code})")
         {:stop, :normal, data}
 
       _ ->
         if state != :terminating_with_error do
-          Logger.error("DbHandler: Db connection closed when state was #{state}")
+          status = if state == :busy, do: "checked out by a client", else: "idle in the pool"
+          Logger.error("DbHandler: Connection closed unexpectedly while #{status}")
         end
 
         {:stop, {:shutdown, :db_termination}, data}

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -188,6 +188,7 @@ defmodule Supavisor.DbHandler do
       client_tls: Map.get(config, :client_tls),
       client_jit: Map.get(config, :client_jit),
       stream_state: MessageStreamer.new_stream_state(BackendMessageHandler),
+      backend_message_streaming: true,
       mode: config.mode,
       replica_type: config.replica_type,
       caller: nil,
@@ -372,12 +373,19 @@ defmodule Supavisor.DbHandler do
   end
 
   # the process received message from db while idle
-  def handle_event(:info, {proto, _, bin}, :idle, data) when proto in @proto do
+  def handle_event(:info, {proto, _, bin}, :idle, %{backend_message_streaming: true} = data)
+      when proto in @proto do
     Logger.debug("DbHandler: Got db response when idle")
 
     {:ok, updated_data, _packets} = process_backend_streaming(bin, data)
 
     {:keep_state, updated_data}
+  end
+
+  # hot code reload compat: remove after full rollout
+  def handle_event(:info, {proto, _, _bin}, :idle, _data) when proto in @proto do
+    Logger.debug("DbHandler: Got db response when idle")
+    :keep_state_and_data
   end
 
   # forward the message to the client
@@ -622,24 +630,6 @@ defmodule Supavisor.DbHandler do
   end
 
   @impl true
-  def code_change(_old_vsn, state, data, _extra) do
-    stream_state = data.stream_state
-
-    new_stream_state =
-      case MessageStreamer.stream_state(stream_state, :handler_state) do
-        BackendMessageHandler.handler_state() ->
-          stream_state
-
-        old_queue ->
-          MessageStreamer.stream_state(stream_state,
-            handler_state: BackendMessageHandler.handler_state(action_queue: old_queue)
-          )
-      end
-
-    {:ok, state, %{data | stream_state: new_stream_state}}
-  end
-
-  @impl true
   def format_status(status) do
     Map.put(status, :queue, [])
   end
@@ -880,7 +870,7 @@ defmodule Supavisor.DbHandler do
   end
 
   @spec handle_server_messages(binary(), map()) :: map()
-  defp handle_server_messages(bin, data) do
+  defp handle_server_messages(bin, %{backend_message_streaming: true} = data) do
     {:ok, updated_data, to_send} = process_backend_streaming(bin, data)
 
     if to_send != [] do
@@ -888,6 +878,12 @@ defmodule Supavisor.DbHandler do
     end
 
     updated_data
+  end
+
+  # hot code reload compat: remove after full rollout
+  defp handle_server_messages(bin, data) do
+    HandlerHelpers.sock_send(data.client_sock, bin)
+    data
   end
 
   # If the prepared statement exists for us, it exists for the server, so we just send the
@@ -1000,12 +996,15 @@ defmodule Supavisor.DbHandler do
     end
   end
 
-  defp last_fatal_error(data) do
+  defp last_fatal_error(%{backend_message_streaming: true} = data) do
     BackendMessageHandler.handler_state(
       MessageStreamer.stream_state(data.stream_state, :handler_state),
       :fatal_error
     )
   end
+
+  # hot code reload compat: remove after full rollout
+  defp last_fatal_error(_data), do: nil
 
   defp get_connection_params_with_secrets(conn_params, id) do
     case Supavisor.UpstreamAuthentication.get_upstream_auth_secrets(id) do

--- a/lib/supavisor/protocol/backend_message_handler.ex
+++ b/lib/supavisor/protocol/backend_message_handler.ex
@@ -2,47 +2,57 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
   @moduledoc """
   Message handler for PostgreSQL backend messages.
 
-  This handler processes only the messages that need special handling for prepared
-  statements, namely `ParseComplete`, `CloseComplete`, and `ParameterDescription`.
+  Handles messages that need special processing:
 
-  `ParseComplete` sometimes need to be intercepted (when the prepared statement was prepared
-  from client's perspective, but not from ours). The same goes for `CloseComplete`. Additionally,
-  `ParameterDescription` is handled because we need to inject a `ParseComplete` response
-  before it when the prepared statement wasn't prepared from the client's perspective, but
-  was from the server's.
-
-  We use a queue to manage the actions that need to be performed on the messages, and actions
-  may be inserted through `Supavisor.Protocol.MessageHandler.update_state/2`.
+  - `ParseComplete`, `CloseComplete`, `ParameterDescription`: prepared statement management.
+    We use a queue to manage the actions that need to be performed on these messages, and
+    actions may be inserted through `Supavisor.Protocol.MessageHandler.update_state/2`.
+  - `ErrorResponse`: FATAL/PANIC errors are detected and stored in the handler state so the
+    DbHandler can read the error reason before the connection closes.
   """
 
   @behaviour Supavisor.Protocol.MessageHandler
 
+  require Record
   require Supavisor.Protocol.Server, as: Server
+
+  Record.defrecord(:handler_state, action_queue: :queue.new(), fatal_error: nil)
 
   @impl true
   def handled_message_types do
-    [?1, ?3, ?t, ?Z]
+    [?1, ?3, ?t, ?Z, ?E]
   end
 
   @impl true
   def init_state do
-    :queue.new()
+    handler_state()
   end
 
   @impl true
-  def handle_message(action_queue, tag, len, payload) do
+  def handle_message(state, ?E, len, payload) do
+    pkt = <<?E, len::32, payload::binary>>
+    error = Server.decode_error_response(payload)
+
+    fatal = if error["S"] in ["FATAL", "PANIC"], do: error
+    {:ok, handler_state(state, fatal_error: fatal), pkt}
+  end
+
+  def handle_message(state, tag, len, payload) do
+    action_queue = handler_state(state, :action_queue)
     message_type = message_type(tag)
     {injected_pkts, action_queue} = maybe_inject(action_queue)
 
     case :queue.out(action_queue) do
       {{:value, {:intercept, ^message_type}}, updated_queue} ->
-        {:ok, updated_queue, injected_pkts}
+        {:ok, handler_state(state, action_queue: updated_queue), injected_pkts}
 
       {{:value, {:forward, ^message_type}}, updated_queue} ->
-        {:ok, updated_queue, [injected_pkts, <<tag, len::32, payload::binary>>]}
+        {:ok, handler_state(state, action_queue: updated_queue),
+         [injected_pkts, <<tag, len::32, payload::binary>>]}
 
       _other ->
-        {:ok, action_queue, [injected_pkts, <<tag, len::32, payload::binary>>]}
+        {:ok, handler_state(state, action_queue: action_queue),
+         [injected_pkts, <<tag, len::32, payload::binary>>]}
     end
   end
 

--- a/lib/supavisor/protocol/server.ex
+++ b/lib/supavisor/protocol/server.ex
@@ -256,6 +256,18 @@ defmodule Supavisor.Protocol.Server do
     end
   end
 
+  @spec decode_error_response(binary()) :: %{String.t() => String.t()}
+  def decode_error_response(payload) do
+    fields = String.split(payload, <<0>>, trim: true)
+
+    Enum.reduce(fields, %{}, fn field, acc ->
+      case field do
+        <<char::binary-1, content::binary>> -> Map.put(acc, char, content)
+        _ -> acc
+      end
+    end)
+  end
+
   @spec decode_payload(:authentication, binary()) ::
           atom() | {atom(), binary()} | {:undefined, any()}
   defp decode_payload(:authentication, payload) do
@@ -335,16 +347,7 @@ defmodule Supavisor.Protocol.Server do
 
   # https://www.postgresql.org/docs/current/protocol-error-fields.html
   @spec decode_payload(:error_response, binary()) :: %{String.t() => String.t()}
-  defp decode_payload(:error_response, payload) do
-    fields = String.split(payload, <<0>>, trim: true)
-
-    Enum.reduce(fields, %{}, fn field, acc ->
-      case field do
-        <<char::binary-1, content::binary>> -> Map.put(acc, char, content)
-        _ -> acc
-      end
-    end)
-  end
+  defp decode_payload(:error_response, payload), do: decode_error_response(payload)
 
   @spec decode_payload(:password_message, binary()) ::
           {:scram_sha_256, map()} | {:md5, binary()} | :undefined

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -1060,6 +1060,22 @@ defmodule Supavisor.Integration.ProxyTest do
     assert %Postgrex.Result{rows: [[1]]} = Postgrex.query!(proxy3, "SELECT 1", [])
   end
 
+  test "logs database fatal error reason on admin_shutdown" do
+    %{proxy: proxy, origin: origin} = setup_tenant_connections(List.first(@tenants))
+
+    assert %P.Result{rows: [[backend_pid]]} =
+             P.query!(proxy, "SELECT pg_backend_pid()", [])
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        P.query!(origin, "SELECT pg_terminate_backend($1)", [backend_pid])
+        Process.sleep(500)
+      end)
+
+    assert log =~
+             "DbHandler: Database fatal error when state was idle: terminating connection due to administrator command (57P01)"
+  end
+
   defp parse_uri(uri) do
     %URI{
       userinfo: userinfo,

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -1073,7 +1073,7 @@ defmodule Supavisor.Integration.ProxyTest do
       end)
 
     assert log =~
-             "DbHandler: Database fatal error when state was idle: terminating connection due to administrator command (57P01)"
+             "DbHandler: Session terminated by server while idle in the pool: terminating connection due to administrator command (57P01)"
   end
 
   defp parse_uri(uri) do

--- a/test/supavisor/protocol/backend_message_handler_test.exs
+++ b/test/supavisor/protocol/backend_message_handler_test.exs
@@ -4,6 +4,7 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
   alias Supavisor.Protocol.BackendMessageHandler
   alias Supavisor.Protocol.MessageStreamer
 
+  require BackendMessageHandler
   require MessageStreamer
 
   setup do
@@ -72,8 +73,12 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       stream_state: stream_state
     } do
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:intercept, :parse}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:intercept, :parse}, queue)
+          )
         end)
 
       original_bin = <<?1, 4::32>>
@@ -81,7 +86,9 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) == :queue.new()
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
+               BackendMessageHandler.init_state()
+
       assert IO.iodata_to_binary(result) == <<>>
     end
 
@@ -89,8 +96,12 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       stream_state: stream_state
     } do
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:intercept, :close}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:intercept, :close}, queue)
+          )
         end)
 
       original_bin = <<?3, 4::32>>
@@ -98,7 +109,9 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) == :queue.new()
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
+               BackendMessageHandler.init_state()
+
       assert IO.iodata_to_binary(result) == <<>>
     end
 
@@ -106,8 +119,12 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       stream_state: stream_state
     } do
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:intercept, :parameter_description}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:intercept, :parameter_description}, queue)
+          )
         end)
 
       original_bin = <<?t, 10::32, 1::16, 23::32>>
@@ -115,14 +132,20 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) == :queue.new()
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
+               BackendMessageHandler.init_state()
+
       assert IO.iodata_to_binary(result) == <<>>
     end
 
     test "parse complete message with forward action is forwarded", %{stream_state: stream_state} do
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:forward, :parse}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:forward, :parse}, queue)
+          )
         end)
 
       original_bin = <<?1, 4::32>>
@@ -130,14 +153,20 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) == :queue.new()
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
+               BackendMessageHandler.init_state()
+
       assert IO.iodata_to_binary(result) == original_bin
     end
 
     test "close complete message with forward action is forwarded", %{stream_state: stream_state} do
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:forward, :close}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:forward, :close}, queue)
+          )
         end)
 
       original_bin = <<?3, 4::32>>
@@ -145,7 +174,9 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) == :queue.new()
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
+               BackendMessageHandler.init_state()
+
       assert IO.iodata_to_binary(result) == original_bin
     end
 
@@ -153,8 +184,12 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       stream_state: stream_state
     } do
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:forward, :parameter_description}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:forward, :parameter_description}, queue)
+          )
         end)
 
       original_bin = <<?t, 10::32, 1::16, 23::32>>
@@ -162,7 +197,9 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) == :queue.new()
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
+               BackendMessageHandler.init_state()
+
       assert IO.iodata_to_binary(result) == original_bin
     end
 
@@ -170,8 +207,12 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       stream_state: stream_state
     } do
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:inject, :parse}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:inject, :parse}, queue)
+          )
         end)
 
       original_bin = <<?t, 10::32, 1::16, 23::32>>
@@ -179,7 +220,9 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) == :queue.new()
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
+               BackendMessageHandler.init_state()
+
       assert IO.iodata_to_binary(result) == <<?1, 4::32, original_bin::binary>>
     end
 
@@ -187,10 +230,12 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       stream_state = MessageStreamer.new_stream_state(BackendMessageHandler)
 
       stream_state_with_actions =
-        MessageStreamer.update_state(stream_state, fn queue ->
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
           queue = :queue.in({:inject, :parse}, queue)
-
-          :queue.in({:forward, :close}, queue)
+          queue = :queue.in({:forward, :close}, queue)
+          BackendMessageHandler.handler_state(s, action_queue: queue)
         end)
 
       parameter_desc_bin = <<?t, 10::32, 1::16, 23::32>>
@@ -199,21 +244,20 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, stream_state_after_param, param_result} =
         MessageStreamer.handle_packets(stream_state_with_actions, parameter_desc_bin)
 
-      remaining_queue_after_param =
+      remaining_state =
         MessageStreamer.stream_state(stream_state_after_param, :handler_state)
 
-      assert :queue.len(remaining_queue_after_param) == 1
-      assert {:value, {:forward, :close}} = :queue.peek(remaining_queue_after_param)
+      remaining_queue = BackendMessageHandler.handler_state(remaining_state, :action_queue)
+      assert :queue.len(remaining_queue) == 1
+      assert {:value, {:forward, :close}} = :queue.peek(remaining_queue)
 
       assert IO.iodata_to_binary(param_result) == <<?1, 4::32, parameter_desc_bin::binary>>
 
       {:ok, stream_state_after_close, close_result} =
         MessageStreamer.handle_packets(stream_state_after_param, close_bin)
 
-      remaining_queue_after_close =
-        MessageStreamer.stream_state(stream_state_after_close, :handler_state)
-
-      assert remaining_queue_after_close == :queue.new()
+      assert MessageStreamer.stream_state(stream_state_after_close, :handler_state) ==
+               BackendMessageHandler.init_state()
 
       assert IO.iodata_to_binary(close_result) == close_bin
     end
@@ -222,8 +266,12 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       stream_state = MessageStreamer.new_stream_state(BackendMessageHandler)
 
       stream_state_with_action =
-        MessageStreamer.update_state(stream_state, fn queue ->
-          :queue.in({:intercept, :close}, queue)
+        MessageStreamer.update_state(stream_state, fn BackendMessageHandler.handler_state(
+                                                        action_queue: queue
+                                                      ) = s ->
+          BackendMessageHandler.handler_state(s,
+            action_queue: :queue.in({:intercept, :close}, queue)
+          )
         end)
 
       original_bin = <<?1, 4::32>>
@@ -231,7 +279,8 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state_with_action, original_bin)
 
-      remaining_queue = MessageStreamer.stream_state(new_stream_state, :handler_state)
+      remaining_state = MessageStreamer.stream_state(new_stream_state, :handler_state)
+      remaining_queue = BackendMessageHandler.handler_state(remaining_state, :action_queue)
       assert :queue.len(remaining_queue) == 1
       assert {:value, {:intercept, :close}} = :queue.peek(remaining_queue)
 


### PR DESCRIPTION
This PR is stacked on top of #941.

Uses the message streamer to read errors sent from the database. Store these errors in the DbHandler state. When the socket is closed, log the error returned by the database and terminate gracefully.