### PR TITLE
chore: upgrade to v2.9.2 in eu-central-2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -4,7 +4,7 @@
     {upgrade_to, "2.9.2"},
     % list() | [<<"all">>]
     {regions, [
-	    <<"euw11">>
+	    <<"eu-central-2">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Upgrade to v2.9.2 in eu-central-2

This region has been recently bumped to v2.9.0 but we want to test a new [AMI](https://github.com/supabase/elx_updater/pull/48) in prod, an this region is a good candidate b/c of the way smaller blast radius.

[Tests in staging we successful.](https://linear.app/supabase/issue/POOLER-383/disable-needrestart#comment-fa875135)