### PR TITLE
fix: persist DbHandler connect backoff across pool restarts

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -91,6 +91,7 @@ defmodule Supavisor.Application do
     )
 
     Supavisor.CircuitBreaker.init()
+    Supavisor.ConnectBackoff.init()
 
     topologies = Application.get_env(:libcluster, :topologies) || []
 
@@ -101,6 +102,7 @@ defmodule Supavisor.Application do
         Supavisor.Health,
         Supavisor.ClientAuthentication.RefreshLimiter,
         Supavisor.CircuitBreaker.Janitor,
+        Supavisor.ConnectBackoff.Janitor,
         {Task.Supervisor, name: Supavisor.PoolTerminator},
         {Registry, keys: :unique, name: Supavisor.Registry.Tenants},
         {Registry, keys: :unique, name: Supavisor.Registry.ManagerTables},

--- a/lib/supavisor/connect_backoff.ex
+++ b/lib/supavisor/connect_backoff.ex
@@ -1,0 +1,79 @@
+defmodule Supavisor.ConnectBackoff do
+  @moduledoc """
+  Tracks the timestamp of the most recent failed DB connect attempt per tenant
+  pool id, in a named ETS table owned by the application supervisor.
+
+  Lives at the application level (rather than under `TenantSupervisor`) so the
+  backoff survives a pool restart. If it lived inside the tenant supervision
+  tree, restarting the pool would wipe the timestamp and let new workers
+  reconnect immediately — defeating the cooldown in exactly the situation it
+  most needs to apply.
+  """
+
+  require Logger
+
+  @table __MODULE__
+
+  @stale_after_ms :timer.hours(1)
+  @cleanup_chunk_size 100
+
+  @doc """
+  Initializes the named ETS table. Called from the application supervisor.
+  """
+  @spec init() :: :ok
+  def init do
+    :ets.new(@table, [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    :ok
+  end
+
+  @spec record_failure(Supavisor.id(), integer()) :: true
+  def record_failure(id, monotonic_ms) do
+    :ets.insert(@table, {id, monotonic_ms})
+  end
+
+  @spec last_failure(Supavisor.id()) :: integer() | nil
+  def last_failure(id) do
+    :ets.lookup_element(@table, id, 2, nil)
+  end
+
+  @doc """
+  Deletes entries older than `@stale_after_ms`. Called periodically by the
+  Janitor.
+  """
+  @spec cleanup_stale_entries() :: non_neg_integer()
+  def cleanup_stale_entries do
+    now = System.monotonic_time(:millisecond)
+    cutoff = now - @stale_after_ms
+    match_spec = [{:_, [], [:"$_"]}]
+    deleted = cleanup_chunk(:ets.select(@table, match_spec, @cleanup_chunk_size), cutoff, 0)
+
+    if deleted > 0 do
+      Logger.info("ConnectBackoff cleaned up #{deleted} stale entries")
+    end
+
+    deleted
+  end
+
+  defp cleanup_chunk(:"$end_of_table", _cutoff, deleted), do: deleted
+
+  defp cleanup_chunk({entries, continuation}, cutoff, deleted) do
+    chunk_deleted =
+      Enum.reduce(entries, 0, fn {id, ts}, acc ->
+        if ts < cutoff do
+          :ets.delete_object(@table, {id, ts})
+          acc + 1
+        else
+          acc
+        end
+      end)
+
+    cleanup_chunk(:ets.select(continuation), cutoff, deleted + chunk_deleted)
+  end
+end

--- a/lib/supavisor/connect_backoff/janitor.ex
+++ b/lib/supavisor/connect_backoff/janitor.ex
@@ -1,0 +1,31 @@
+defmodule Supavisor.ConnectBackoff.Janitor do
+  @moduledoc """
+  Periodically cleans up stale entries from the ConnectBackoff ETS table.
+  """
+
+  use GenServer
+  require Logger
+
+  @cleanup_interval :timer.minutes(5)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    schedule_cleanup()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:cleanup, state) do
+    Supavisor.ConnectBackoff.cleanup_stale_entries()
+    schedule_cleanup()
+    {:noreply, state}
+  end
+
+  defp schedule_cleanup do
+    Process.send_after(self(), :cleanup, @cleanup_interval)
+  end
+end

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -1029,7 +1029,7 @@ defmodule Supavisor.DbHandler do
   defp handle_connection_failure(reason, data) do
     if not data.proxy do
       Supavisor.CircuitBreaker.record_failure(data.tenant, :db_connection)
-      Supavisor.TenantCache.put_last_connect_failure(data.id, System.monotonic_time(:millisecond))
+      Supavisor.ConnectBackoff.record_failure(data.id, System.monotonic_time(:millisecond))
     end
 
     error = %{
@@ -1061,7 +1061,7 @@ defmodule Supavisor.DbHandler do
   end
 
   defp connect_cooldown_remaining(id) do
-    case Supavisor.TenantCache.get_last_connect_failure(id) do
+    case Supavisor.ConnectBackoff.last_failure(id) do
       nil ->
         0
 

--- a/lib/supavisor/hot_upgrade.ex
+++ b/lib/supavisor/hot_upgrade.ex
@@ -2,54 +2,84 @@ defmodule Supavisor.HotUpgrade do
   @moduledoc false
   require Logger
 
-  @type app :: atom
   @type version_str :: String.t()
-  @type path_str :: String.t()
-  @type change :: :soft | {:advanced, [term]}
-  @type dep_mods :: [module]
-  @type appup_ver :: charlist | binary
-  @type instruction ::
-          {:add_module, module}
-          | {:delete_module, module}
-          | {:update, module, :supervisor | change}
-          | {:update, module, change, dep_mods}
-          | {:load_module, module}
-          | {:load_module, module, dep_mods}
-          | {:apply, {module, atom, [term]}}
-          | {:add_application, atom}
-          | {:remove_application, atom}
-          | {:restart_application, atom}
-          | :restart_new_emulator
-          | :restart_emulator
-  @type upgrade_instructions :: [{appup_ver, instruction}]
-  @type downgrade_instructions :: [{appup_ver, instruction}]
-  @type appup :: {appup_ver, upgrade_instructions, downgrade_instructions}
 
-  @spec up(app(), version_str(), version_str(), [appup()], any()) :: [appup()]
   def up(_app, _from_vsn, to_vsn, appup, _transform) do
     appup =
       Enum.reject(appup, fn
         {:load_module, __MODULE__} -> true
         {:load_module, __MODULE__, _} -> true
+        {:add_module, Supavisor.ConnectBackoff} -> true
+        {:add_module, Supavisor.ConnectBackoff, _} -> true
+        {:add_module, Supavisor.ConnectBackoff.Janitor} -> true
+        {:add_module, Supavisor.ConnectBackoff.Janitor, _} -> true
         _ -> false
       end)
 
     [
       {:load_module, __MODULE__},
       {:apply, {__MODULE__, :apply_runtime_config, [to_vsn]}},
-      {:apply, {__MODULE__, :remove_access_log_handler, []}}
+      {:apply, {__MODULE__, :remove_access_log_handler, []}},
+      {:add_module, Supavisor.ConnectBackoff},
+      {:add_module, Supavisor.ConnectBackoff.Janitor},
+      {:apply, {__MODULE__, :prepare_connect_backoff, []}}
     ] ++ appup
   end
 
-  @spec down(app(), version_str(), version_str(), [appup()], any()) :: [appup()]
   def down(_app, from_vsn, _to_vsn, appup, _transform) do
+    appup =
+      Enum.reject(appup, fn
+        {:delete_module, Supavisor.ConnectBackoff} -> true
+        {:delete_module, Supavisor.ConnectBackoff, _} -> true
+        {:delete_module, Supavisor.ConnectBackoff.Janitor} -> true
+        {:delete_module, Supavisor.ConnectBackoff.Janitor, _} -> true
+        _ -> false
+      end)
+
     [
-      {:apply, {Supavisor.HotUpgrade, :apply_runtime_config, [from_vsn]}}
+      {:apply, {Supavisor.HotUpgrade, :apply_runtime_config, [from_vsn]}},
+      {:apply, {Supavisor.HotUpgrade, :cleanup_connect_backoff, []}},
+      {:delete_module, Supavisor.ConnectBackoff.Janitor},
+      {:delete_module, Supavisor.ConnectBackoff}
     ] ++ appup
   end
 
   def remove_access_log_handler do
     :logger.remove_handler(:access_log)
+  end
+
+  @doc """
+  Creates the `Supavisor.ConnectBackoff` named ETS table and starts the
+  `Supavisor.ConnectBackoff.Janitor` child. Both are normally set up in
+  `Supavisor.Application.start/2`, which does not re-run on a hot upgrade —
+  so we wire them up explicitly here. Both steps are idempotent in case the
+  upgrade is re-applied.
+  """
+  def prepare_connect_backoff do
+    if :ets.whereis(Supavisor.ConnectBackoff) == :undefined do
+      Supavisor.ConnectBackoff.init()
+    end
+
+    case Supervisor.start_child(Supavisor.Supervisor, Supavisor.ConnectBackoff.Janitor) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, :already_present} -> :ok
+    end
+  end
+
+  @doc """
+  Reverses `prepare_connect_backoff/0` for downgrades to a version that does
+  not know about `Supavisor.ConnectBackoff`.
+  """
+  def cleanup_connect_backoff do
+    _ = Supervisor.terminate_child(Supavisor.Supervisor, Supavisor.ConnectBackoff.Janitor)
+    _ = Supervisor.delete_child(Supavisor.Supervisor, Supavisor.ConnectBackoff.Janitor)
+
+    if :ets.whereis(Supavisor.ConnectBackoff) != :undefined do
+      :ets.delete(Supavisor.ConnectBackoff)
+    end
+
+    :ok
   end
 
   @spec apply_runtime_config(version_str()) :: any()

--- a/lib/supavisor/tenant_cache.ex
+++ b/lib/supavisor/tenant_cache.ex
@@ -79,25 +79,4 @@ defmodule Supavisor.TenantCache do
     end
   end
 
-  @spec get_last_connect_failure(Supavisor.id()) :: integer() | nil
-  def get_last_connect_failure(id) do
-    case Registry.lookup(Supavisor.Registry.Tenants, {:cache, id}) do
-      [{_pid, table}] ->
-        :ets.lookup_element(table, :last_connect_failure, 2, nil)
-
-      _ ->
-        nil
-    end
-  end
-
-  @spec put_last_connect_failure(Supavisor.id(), integer()) :: true
-  def put_last_connect_failure(id, timestamp) do
-    case Registry.lookup(Supavisor.Registry.Tenants, {:cache, id}) do
-      [{_pid, table}] ->
-        :ets.insert(table, {:last_connect_failure, timestamp})
-
-      _ ->
-        true
-    end
-  end
 end

--- a/lib/supavisor/tenant_cache.ex
+++ b/lib/supavisor/tenant_cache.ex
@@ -78,5 +78,4 @@ defmodule Supavisor.TenantCache do
         true
     end
   end
-
 end

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -13,13 +13,19 @@ defmodule Supavisor.DbHandlerTest do
   require Supavisor
 
   # import Mock
-  @id Supavisor.id(
-        type: :single,
-        tenant: "tenant",
-        user: "user",
-        mode: :transaction,
-        db: "postgres"
-      )
+  setup do
+    {:ok, id: make_id()}
+  end
+
+  defp make_id do
+    Supavisor.id(
+      type: :single,
+      tenant: "tenant_#{System.unique_integer([:positive])}",
+      user: "user",
+      mode: :transaction,
+      db: "postgres"
+    )
+  end
 
   defmodule MockDbHandler do
     use GenServer
@@ -137,20 +143,19 @@ defmodule Supavisor.DbHandlerTest do
   end
 
   describe "init/1" do
-    test "starts with correct state" do
+    test "starts with correct state", %{id: id} do
       secrets = %PasswordSecrets{user: "user", password: "pass"}
       conn_params = connection_params(%{secrets: secrets})
       tenant = "test_tenant"
       user = "user"
 
-      # Set up tenant cache for the @id
       table = :ets.new(:tenant_cache, [:set, :public])
-      Registry.register(Supavisor.Registry.Tenants, {:cache, @id}, table)
+      Registry.register(Supavisor.Registry.Tenants, {:cache, id}, table)
 
-      Supavisor.UpstreamAuthentication.put_upstream_auth_secrets(@id, secrets)
+      Supavisor.UpstreamAuthentication.put_upstream_auth_secrets(id, secrets)
 
       manager_config = %{
-        id: @id,
+        id: id,
         connection_params: conn_params,
         tenant: {:single, tenant},
         user: user,
@@ -162,7 +167,7 @@ defmodule Supavisor.DbHandlerTest do
 
       {:ok, _manager} = start_supervised({FakeManager, manager_config})
 
-      args = %{id: @id}
+      args = %{id: id}
 
       {:ok, :connect, data, {:next_event, :internal, :connect}} = Db.init(args)
       assert data.sock == nil
@@ -175,17 +180,16 @@ defmodule Supavisor.DbHandlerTest do
       assert data.server_proof == nil
     end
 
-    test "enters waiting_for_secrets state when upstream secrets are missing" do
+    test "enters waiting_for_secrets state when upstream secrets are missing", %{id: id} do
       conn_params = connection_params()
       tenant = "test_tenant"
       user = "user"
 
-      # Set up tenant cache but don't put any secrets in it
       table = :ets.new(:tenant_cache, [:set, :public])
-      Registry.register(Supavisor.Registry.Tenants, {:cache, @id}, table)
+      Registry.register(Supavisor.Registry.Tenants, {:cache, id}, table)
 
       manager_config = %{
-        id: @id,
+        id: id,
         connection_params: conn_params,
         tenant: {:single, tenant},
         user: user,
@@ -197,25 +201,25 @@ defmodule Supavisor.DbHandlerTest do
 
       {:ok, _manager} = start_supervised({FakeManager, manager_config})
 
-      args = %{id: @id}
+      args = %{id: id}
 
       assert {:ok, :waiting_for_secrets, data, []} = Db.init(args)
-      assert data.id == @id
+      assert data.id == id
       assert data.manager_ref != nil
     end
 
-    test "transitions from waiting_for_secrets to connect when secrets become available" do
+    test "transitions from waiting_for_secrets to connect when secrets become available",
+         %{id: id} do
       conn_params = connection_params()
       tenant = "test_tenant"
       user = "user"
       secrets = %PasswordSecrets{user: "some user", password: "secret"}
 
-      # Set up tenant cache
       table = :ets.new(:tenant_cache, [:set, :public])
-      Registry.register(Supavisor.Registry.Tenants, {:cache, @id}, table)
+      Registry.register(Supavisor.Registry.Tenants, {:cache, id}, table)
 
       manager_config = %{
-        id: @id,
+        id: id,
         connection_params: conn_params,
         tenant: {:single, tenant},
         user: user,
@@ -227,12 +231,10 @@ defmodule Supavisor.DbHandlerTest do
 
       {:ok, _manager} = start_supervised({FakeManager, manager_config})
 
-      # Initialize in waiting_for_secrets state
-      args = %{id: @id}
+      args = %{id: id}
       assert {:ok, :waiting_for_secrets, data, []} = Db.init(args)
 
-      # Now put secrets in cache
-      Supavisor.UpstreamAuthentication.put_upstream_auth_secrets(@id, secrets)
+      Supavisor.UpstreamAuthentication.put_upstream_auth_secrets(id, secrets)
 
       # Notify that secrets are available
       assert {:next_state, :connect, updated_data, {:next_event, :internal, :connect}} =
@@ -244,7 +246,7 @@ defmodule Supavisor.DbHandlerTest do
   end
 
   describe "handle_event/4" do
-    test "db is available" do
+    test "db is available", %{id: id} do
       {:ok, sock} = :gen_tcp.listen(0, mode: :binary, active: false)
       {:ok, {host, port}} = :inet.sockname(sock)
 
@@ -263,7 +265,7 @@ defmodule Supavisor.DbHandlerTest do
         Db.handle_event(:internal, :connect, :connect, %{
           connection_params: conn_params,
           sock: {:gen_tcp, nil},
-          id: @id,
+          id: id,
           mode: :session,
           proxy: false
         })
@@ -272,12 +274,12 @@ defmodule Supavisor.DbHandlerTest do
               %{
                 connection_params: ^conn_params,
                 sock: {:gen_tcp, _},
-                id: @id,
+                id: ^id,
                 mode: :session
               }} = state
     end
 
-    test "db is not available" do
+    test "db is not available", %{id: id} do
       # We assume that there is nothing running on this port
       # credo:disable-for-next-line Credo.Check.Readability.LargeNumbers
       {host, port} = {{127, 0, 0, 1}, 12345}
@@ -298,7 +300,7 @@ defmodule Supavisor.DbHandlerTest do
                Db.handle_event(:internal, :connect, :connect, %{
                  connection_params: conn_params,
                  sock: nil,
-                 id: @id,
+                 id: id,
                  proxy: false,
                  tenant: {:single, "some tenant"}
                })
@@ -306,8 +308,8 @@ defmodule Supavisor.DbHandlerTest do
       assert error["C"] == "08006"
     end
 
-    test "checkout returns error when in waiting_for_secrets state" do
-      data = %{id: @id}
+    test "checkout returns error when in waiting_for_secrets state", %{id: id} do
+      data = %{id: id}
       from = {self(), make_ref()}
 
       expected_postgres_error = %{
@@ -328,7 +330,7 @@ defmodule Supavisor.DbHandlerTest do
                )
     end
 
-    test "rejects connection when DB responds with SSL negotiation 'N'" do
+    test "rejects connection when DB responds with SSL negotiation 'N'", %{id: id} do
       {:ok, listen} = :gen_tcp.listen(0, mode: :binary, active: false)
       {:ok, {host, port}} = :inet.sockname(listen)
 
@@ -359,7 +361,7 @@ defmodule Supavisor.DbHandlerTest do
       data = %{
         connection_params: conn_params,
         sock: {:gen_tcp, nil},
-        id: @id,
+        id: id,
         proxy: false,
         tenant: {:single, "some tenant"},
         client_sock: nil
@@ -484,7 +486,7 @@ defmodule Supavisor.DbHandlerTest do
   end
 
   describe "handle_event/4 info tcp error_response" do
-    test "handles server invalid password" do
+    test "handles server invalid password", %{id: id} do
       bin =
         Server.error_message("28P01", "password authentication failed") |> IO.iodata_to_binary()
 
@@ -492,7 +494,7 @@ defmodule Supavisor.DbHandlerTest do
       content = {:tcp, b, bin}
 
       data = %{
-        id: @id,
+        id: id,
         mode: :session,
         user: "some user",
         client_sock: nil,
@@ -530,13 +532,13 @@ defmodule Supavisor.DbHandlerTest do
                Db.handle_event(:cast, :finalize_termination, :terminating_with_error, new_data)
     end
 
-    test "encodes and forwards server error to client socket" do
+    test "encodes and forwards server error to client socket", %{id: id} do
       bin = Server.error_message("XX000", "generic error") |> IO.iodata_to_binary()
       {send, recv} = sockpair()
       content = {:tcp, recv, bin}
 
       data = %{
-        id: @id,
+        id: id,
         mode: :session,
         user: "some user",
         client_sock: {:gen_tcp, send},
@@ -652,7 +654,7 @@ defmodule Supavisor.DbHandlerTest do
   end
 
   describe "handle_event/4 info tcp notice_response during authentication" do
-    test "logs and keeps state when receiving a standalone notice" do
+    test "logs and keeps state when receiving a standalone notice", %{id: id} do
       message = ["SNOTICE", 0, "C00000", 0, "Msome notice", 0, 0]
       bin = IO.iodata_to_binary([<<?N, IO.iodata_length(message) + 4::32>>, message])
 
@@ -665,7 +667,7 @@ defmodule Supavisor.DbHandlerTest do
             secrets: %PasswordSecrets{user: "user", password: "pass"}
           }),
         sock: {:gen_tcp, nil},
-        id: @id,
+        id: id,
         mode: :session
       }
 


### PR DESCRIPTION
The cooldown timestamp lived in TenantCache, which dies with the TenantSupervisor. After a pool restart it was always nil, so new DbHandlers reconnected immediately. Move it into a new app-level named ETS table that outlives the pool.