### PR TITLE
feat: add metrics for auth_query and SecretChecker erpc calls

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -131,6 +131,7 @@ defmodule Supavisor.Application do
           child_spec: DynamicSupervisor, strategy: :one_for_one, name: Supavisor.DynamicSupervisor
         },
         Supavisor.Vault,
+        Supavisor.ConnectionListener,
 
         # Start the Endpoint (http/https)
         SupavisorWeb.Endpoint

--- a/lib/supavisor/auth_query.ex
+++ b/lib/supavisor/auth_query.ex
@@ -31,7 +31,8 @@ defmodule Supavisor.AuthQuery do
       socket_options: [ip_version],
       queue_target: 1_000,
       queue_interval: 5_000,
-      ssl_opts: ssl_opts
+      ssl_opts: ssl_opts,
+      connection_listeners: {[Supavisor.ConnectionListener], start}
     ]
     |> Postgrex.start_link()
     |> case do
@@ -39,12 +40,13 @@ defmodule Supavisor.AuthQuery do
         {:ok, pid}
 
       :ignore ->
+        telemetry_connection_stop(start, :connection_failed)
         {:error, %AuthQueryError{reason: :connection_failed, details: "connection ignored"}}
 
       {:error, reason} ->
+        telemetry_connection_stop(start, :connection_failed)
         {:error, %AuthQueryError{reason: :connection_failed, details: inspect(reason)}}
     end
-    |> tap(&telemetry_connection_stop(start, &1))
   end
 
   @doc """
@@ -181,9 +183,8 @@ defmodule Supavisor.AuthQuery do
     [verify: :verify_none]
   end
 
-  defp telemetry_connection_stop(start, result),
-    do:
-      Telem.auth_query_connection_stop(System.monotonic_time() - start, telemetry_status(result))
+  defp telemetry_connection_stop(start, error),
+    do: Telem.auth_query_connection_stop(System.monotonic_time() - start, telemetry_status(error))
 
   defp telemetry_query_stop(start, result),
     do: Telem.auth_query_query_stop(System.monotonic_time() - start, telemetry_status(result))

--- a/lib/supavisor/auth_query.ex
+++ b/lib/supavisor/auth_query.ex
@@ -20,32 +20,31 @@ defmodule Supavisor.AuthQuery do
     ip_version = Helpers.ip_version(tenant.ip_version, tenant.db_host)
     start = System.monotonic_time()
 
-    result =
-      case Postgrex.start_link(
-             hostname: tenant.db_host,
-             port: tenant.db_port,
-             database: tenant.db_database,
-             password: manager.db_password,
-             username: manager.db_user,
-             parameters: [application_name: "Supavisor (auth_query)"],
-             ssl: tenant.upstream_ssl,
-             socket_options: [ip_version],
-             queue_target: 1_000,
-             queue_interval: 5_000,
-             ssl_opts: ssl_opts
-           ) do
-        {:ok, pid} ->
-          {:ok, pid}
+    [
+      hostname: tenant.db_host,
+      port: tenant.db_port,
+      database: tenant.db_database,
+      password: manager.db_password,
+      username: manager.db_user,
+      parameters: [application_name: "Supavisor (auth_query)"],
+      ssl: tenant.upstream_ssl,
+      socket_options: [ip_version],
+      queue_target: 1_000,
+      queue_interval: 5_000,
+      ssl_opts: ssl_opts
+    ]
+    |> Postgrex.start_link()
+    |> case do
+      {:ok, pid} ->
+        {:ok, pid}
 
-        :ignore ->
-          {:error, %AuthQueryError{reason: :connection_failed, details: "connection ignored"}}
+      :ignore ->
+        {:error, %AuthQueryError{reason: :connection_failed, details: "connection ignored"}}
 
-        {:error, reason} ->
-          {:error, %AuthQueryError{reason: :connection_failed, details: inspect(reason)}}
-      end
-
-    Telem.auth_query_connection_stop(System.monotonic_time() - start, result)
-    result
+      {:error, reason} ->
+        {:error, %AuthQueryError{reason: :connection_failed, details: inspect(reason)}}
+    end
+    |> tap(&telemetry_connection_stop(start, &1))
   end
 
   @doc """
@@ -104,9 +103,10 @@ defmodule Supavisor.AuthQuery do
           {:ok, SASLSecrets.t()} | {:error, AuthQueryError.t()}
   def fetch_user_secret(conn, auth_query, user) do
     start = System.monotonic_time()
-    result = do_fetch_user_secret(conn, auth_query, user)
-    Telem.auth_query_query_stop(System.monotonic_time() - start, result)
-    result
+
+    conn
+    |> do_fetch_user_secret(auth_query, user)
+    |> tap(&telemetry_query_stop(start, &1))
   end
 
   defp do_fetch_user_secret(_conn, nil, _user) do
@@ -180,4 +180,14 @@ defmodule Supavisor.AuthQuery do
   defp build_ssl_options(_tenant) do
     [verify: :verify_none]
   end
+
+  defp telemetry_connection_stop(start, result),
+    do:
+      Telem.auth_query_connection_stop(System.monotonic_time() - start, telemetry_status(result))
+
+  defp telemetry_query_stop(start, result),
+    do: Telem.auth_query_query_stop(System.monotonic_time() - start, telemetry_status(result))
+
+  defp telemetry_status({:ok, _}), do: :ok
+  defp telemetry_status(_), do: :error
 end

--- a/lib/supavisor/auth_query.ex
+++ b/lib/supavisor/auth_query.ex
@@ -6,6 +6,7 @@ defmodule Supavisor.AuthQuery do
 
   alias Supavisor.Errors.AuthQueryError
   alias Supavisor.Helpers
+  alias Supavisor.Monitoring.Telem
   alias Supavisor.Secrets.{ManagerSecrets, SASLSecrets}
   alias Supavisor.Tenants.Tenant
 
@@ -17,29 +18,34 @@ defmodule Supavisor.AuthQuery do
   def start_link(%Tenant{} = tenant, %ManagerSecrets{} = manager) do
     ssl_opts = build_ssl_options(tenant)
     ip_version = Helpers.ip_version(tenant.ip_version, tenant.db_host)
+    start = System.monotonic_time()
 
-    case Postgrex.start_link(
-           hostname: tenant.db_host,
-           port: tenant.db_port,
-           database: tenant.db_database,
-           password: manager.db_password,
-           username: manager.db_user,
-           parameters: [application_name: "Supavisor (auth_query)"],
-           ssl: tenant.upstream_ssl,
-           socket_options: [ip_version],
-           queue_target: 1_000,
-           queue_interval: 5_000,
-           ssl_opts: ssl_opts
-         ) do
-      {:ok, pid} ->
-        {:ok, pid}
+    result =
+      case Postgrex.start_link(
+             hostname: tenant.db_host,
+             port: tenant.db_port,
+             database: tenant.db_database,
+             password: manager.db_password,
+             username: manager.db_user,
+             parameters: [application_name: "Supavisor (auth_query)"],
+             ssl: tenant.upstream_ssl,
+             socket_options: [ip_version],
+             queue_target: 1_000,
+             queue_interval: 5_000,
+             ssl_opts: ssl_opts
+           ) do
+        {:ok, pid} ->
+          {:ok, pid}
 
-      :ignore ->
-        {:error, %AuthQueryError{reason: :connection_failed, details: "connection ignored"}}
+        :ignore ->
+          {:error, %AuthQueryError{reason: :connection_failed, details: "connection ignored"}}
 
-      {:error, reason} ->
-        {:error, %AuthQueryError{reason: :connection_failed, details: inspect(reason)}}
-    end
+        {:error, reason} ->
+          {:error, %AuthQueryError{reason: :connection_failed, details: inspect(reason)}}
+      end
+
+    Telem.auth_query_connection_stop(System.monotonic_time() - start, result)
+    result
   end
 
   @doc """
@@ -96,11 +102,18 @@ defmodule Supavisor.AuthQuery do
   """
   @spec fetch_user_secret(pid(), String.t() | nil, String.t()) ::
           {:ok, SASLSecrets.t()} | {:error, AuthQueryError.t()}
-  def fetch_user_secret(_conn, nil, _user) do
+  def fetch_user_secret(conn, auth_query, user) do
+    start = System.monotonic_time()
+    result = do_fetch_user_secret(conn, auth_query, user)
+    Telem.auth_query_query_stop(System.monotonic_time() - start, result)
+    result
+  end
+
+  defp do_fetch_user_secret(_conn, nil, _user) do
     {:error, %AuthQueryError{reason: :no_auth_query}}
   end
 
-  def fetch_user_secret(conn, auth_query, user) when is_binary(auth_query) do
+  defp do_fetch_user_secret(conn, auth_query, user) when is_binary(auth_query) do
     Postgrex.query!(conn, auth_query, [user])
   catch
     _error, reason ->

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -1009,6 +1009,7 @@ defmodule Supavisor.ClientHandler do
 
     error = %ClientSocketClosedError{mode: data.mode, client_state: state}
     context = if state in [:idle, :busy], do: :authenticated, else: :handshake
+
     Error.terminate_with_error(data, error, context)
   end
 end

--- a/lib/supavisor/connection_listener.ex
+++ b/lib/supavisor/connection_listener.ex
@@ -1,0 +1,88 @@
+defmodule Supavisor.ConnectionListener do
+  use GenServer
+
+  require Logger
+
+  @name __MODULE__
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, nil, Keyword.put_new(opts, :name, @name))
+  end
+
+  @impl true
+  def init(nil) do
+    Process.flag(:trap_exit, true)
+    {:ok, %{monitoring: %{}}}
+  end
+
+  @impl true
+  def handle_info({:connected, pid, connect_start_time}, state) do
+    {start_time, state} =
+      case Map.get(state.monitoring, pid) do
+        nil ->
+          ref = Process.monitor(pid)
+          {connect_start_time, put_in(state, [:monitoring, pid], {ref, nil})}
+
+        {ref, disconnect_time} ->
+          {disconnect_time || connect_start_time, put_in(state, [:monitoring, pid], {ref, nil})}
+      end
+
+    connect_duration = System.monotonic_time() - start_time
+
+    :telemetry.execute(
+      [:supavisor, :auth_query, :connection, :stop],
+      %{duration: connect_duration}
+    )
+
+    {:noreply, state}
+  end
+
+  def handle_info({:disconnected, pid, _}, state) do
+    case Map.get(state.monitoring, pid) do
+      nil ->
+        {:noreply, state}
+
+      {_ref, prev_disconnect_ts} when not is_nil(prev_disconnect_ts) ->
+        Logger.warning("Duplicate disconnected event for pid #{inspect(pid)})")
+        {:noreply, state}
+
+      {ref, nil} ->
+        :telemetry.execute(
+          [:supavisor, :auth_query, :disconnection],
+          %{count: 1}
+        )
+
+        {:noreply, put_in(state, [:monitoring, pid], {ref, System.monotonic_time()})}
+    end
+  end
+
+  def handle_info({:disconnected, pid}, state) do
+    handle_info({:disconnected, pid, nil}, state)
+  end
+
+  # we only get monitor message if we have seen the connected event first
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    case Map.pop(state.monitoring, pid) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {{_ref, prev_disconnect_ts}, monitoring} when not is_nil(prev_disconnect_ts) ->
+        Logger.warning(
+          "Duplicate disconnected event for pid #{inspect(pid)} (#{inspect(reason)})"
+        )
+
+        {:noreply, %{state | monitoring: monitoring}}
+
+      {{ref, nil}, monitoring} ->
+        Process.demonitor(ref, [:flush])
+
+        :telemetry.execute(
+          [:supavisor, :auth_query, :disconnection],
+          %{count: 1},
+          (reason == :normal && %{}) || %{kind: :exit, reason: reason}
+        )
+
+        {:noreply, %{state | monitoring: monitoring}}
+    end
+  end
+end

--- a/lib/supavisor/monitoring/telem.ex
+++ b/lib/supavisor/monitoring/telem.ex
@@ -118,12 +118,12 @@ defmodule Supavisor.Monitoring.Telem do
     )
   end
 
-  @spec auth_query_connection_stop(integer(), :ok | :error) :: :ok
-  def auth_query_connection_stop(duration, status) do
+  @spec auth_query_connection_stop(integer(), term()) :: :ok
+  def auth_query_connection_stop(duration, error_or_nil) do
     telemetry_execute(
       [:supavisor, :auth_query, :connection, :stop],
       %{duration: duration},
-      %{status: status}
+      %{error: error_or_nil}
     )
   end
 

--- a/lib/supavisor/monitoring/telem.ex
+++ b/lib/supavisor/monitoring/telem.ex
@@ -4,7 +4,10 @@ defmodule Supavisor.Monitoring.Telem do
   require Logger
   require Supavisor
 
+  alias Supavisor.Errors.AuthQueryError
+
   @disabled Application.compile_env(:supavisor, :metrics_disabled, false)
+  @slow_auth_query_ms 1_000
 
   if @disabled do
     defp telemetry_execute(_name, _measurements, _meta), do: :ok
@@ -117,6 +120,67 @@ defmodule Supavisor.Monitoring.Telem do
     )
   end
 
+  @spec auth_query_connection_stop(integer(), {:ok, any()} | {:error, AuthQueryError.t()}) ::
+          :ok | nil
+  def auth_query_connection_stop(duration, result) do
+    {result_tag, reason_tag} = classify_auth_query_result(result)
+
+    telemetry_execute(
+      [:supavisor, :auth_query, :connection, :stop],
+      %{duration: duration},
+      %{result: result_tag, reason: reason_tag}
+    )
+  end
+
+  @spec auth_query_query_stop(integer(), {:ok, any()} | {:error, AuthQueryError.t()}) :: :ok | nil
+  def auth_query_query_stop(duration, result) do
+    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+
+    if duration_ms > @slow_auth_query_ms do
+      Logger.warning("auth_query took over #{@slow_auth_query_ms}ms (#{duration_ms}ms)")
+    end
+
+    {result_tag, reason_tag} = classify_auth_query_result(result)
+
+    telemetry_execute(
+      [:supavisor, :auth_query, :query, :stop],
+      %{duration: duration},
+      %{result: result_tag, reason: reason_tag}
+    )
+  end
+
+  @spec get_secrets_stop(integer(), {:ok, any()} | {:error, any()}, :local | :remote) :: :ok | nil
+  def get_secrets_stop(duration, result, locality) when locality in [:local, :remote] do
+    {result_tag, reason_tag} =
+      case result do
+        {:error, :not_started} -> {:error, :not_started}
+        {:error, :no_auth_config} -> {:error, :no_auth_config}
+        other -> classify_auth_query_result(other)
+      end
+
+    telemetry_execute(
+      [:supavisor, :secret_checker, :get_secrets, :stop, locality],
+      %{duration: duration},
+      %{result: result_tag, reason: reason_tag}
+    )
+  end
+
+  @spec update_credentials_stop(integer(), :ok | {:error, any()}, :local | :remote) :: :ok | nil
+  def update_credentials_stop(duration, result, locality) when locality in [:local, :remote] do
+    {result_tag, reason_tag} =
+      case result do
+        :ok -> {:ok, :ok}
+        {:error, :not_started} -> {:error, :not_started}
+        {:error, _} -> {:error, :unknown}
+      end
+
+    telemetry_execute(
+      [:supavisor, :secret_checker, :update_credentials, :stop, locality],
+      %{duration: duration},
+      %{result: result_tag, reason: reason_tag}
+    )
+  end
+
   @spec id_to_tags(Supavisor.id()) :: map()
   defp id_to_tags(
          Supavisor.id(
@@ -137,4 +201,9 @@ defmodule Supavisor.Monitoring.Telem do
       search_path: search_path
     }
   end
+
+  defp classify_auth_query_result(:ok), do: {:ok, :ok}
+  defp classify_auth_query_result({:ok, _}), do: {:ok, :ok}
+  defp classify_auth_query_result({:error, %AuthQueryError{reason: r}}), do: {:error, r}
+  defp classify_auth_query_result({:error, _}), do: {:error, :unknown}
 end

--- a/lib/supavisor/monitoring/telem.ex
+++ b/lib/supavisor/monitoring/telem.ex
@@ -4,8 +4,6 @@ defmodule Supavisor.Monitoring.Telem do
   require Logger
   require Supavisor
 
-  alias Supavisor.Errors.AuthQueryError
-
   @disabled Application.compile_env(:supavisor, :metrics_disabled, false)
   @slow_auth_query_ms 1_000
 
@@ -120,64 +118,47 @@ defmodule Supavisor.Monitoring.Telem do
     )
   end
 
-  @spec auth_query_connection_stop(integer(), {:ok, any()} | {:error, AuthQueryError.t()}) ::
-          :ok | nil
-  def auth_query_connection_stop(duration, result) do
-    {result_tag, reason_tag} = classify_auth_query_result(result)
-
+  @spec auth_query_connection_stop(integer(), :ok | :error) :: :ok
+  def auth_query_connection_stop(duration, status) do
     telemetry_execute(
       [:supavisor, :auth_query, :connection, :stop],
       %{duration: duration},
-      %{result: result_tag, reason: reason_tag}
+      %{status: status}
     )
   end
 
-  @spec auth_query_query_stop(integer(), {:ok, any()} | {:error, AuthQueryError.t()}) :: :ok | nil
-  def auth_query_query_stop(duration, result) do
+  @spec auth_query_query_stop(integer(), :ok | :error) :: :ok
+  def auth_query_query_stop(duration, status) do
     duration_ms = System.convert_time_unit(duration, :native, :millisecond)
 
     if duration_ms > @slow_auth_query_ms do
       Logger.warning("auth_query took over #{@slow_auth_query_ms}ms (#{duration_ms}ms)")
     end
 
-    {result_tag, reason_tag} = classify_auth_query_result(result)
-
     telemetry_execute(
       [:supavisor, :auth_query, :query, :stop],
       %{duration: duration},
-      %{result: result_tag, reason: reason_tag}
+      %{status: status}
     )
   end
 
-  @spec get_secrets_stop(integer(), {:ok, any()} | {:error, any()}, :local | :remote) :: :ok | nil
-  def get_secrets_stop(duration, result, locality) when locality in [:local, :remote] do
-    {result_tag, reason_tag} =
-      case result do
-        {:error, :not_started} -> {:error, :not_started}
-        {:error, :no_auth_config} -> {:error, :no_auth_config}
-        other -> classify_auth_query_result(other)
-      end
-
+  @spec secret_checker_get_secrets_stop(integer(), :ok | :error, :local | :remote) :: :ok
+  def secret_checker_get_secrets_stop(duration, status, locality)
+      when locality in [:local, :remote] do
     telemetry_execute(
       [:supavisor, :secret_checker, :get_secrets, :stop, locality],
       %{duration: duration},
-      %{result: result_tag, reason: reason_tag}
+      %{status: status}
     )
   end
 
-  @spec update_credentials_stop(integer(), :ok | {:error, any()}, :local | :remote) :: :ok | nil
-  def update_credentials_stop(duration, result, locality) when locality in [:local, :remote] do
-    {result_tag, reason_tag} =
-      case result do
-        :ok -> {:ok, :ok}
-        {:error, :not_started} -> {:error, :not_started}
-        {:error, _} -> {:error, :unknown}
-      end
-
+  @spec secret_checker_update_credentials_stop(integer(), :ok | :error, :local | :remote) :: :ok
+  def secret_checker_update_credentials_stop(duration, status, locality)
+      when locality in [:local, :remote] do
     telemetry_execute(
       [:supavisor, :secret_checker, :update_credentials, :stop, locality],
       %{duration: duration},
-      %{result: result_tag, reason: reason_tag}
+      %{status: status}
     )
   end
 
@@ -201,9 +182,4 @@ defmodule Supavisor.Monitoring.Telem do
       search_path: search_path
     }
   end
-
-  defp classify_auth_query_result(:ok), do: {:ok, :ok}
-  defp classify_auth_query_result({:ok, _}), do: {:ok, :ok}
-  defp classify_auth_query_result({:error, %AuthQueryError{reason: r}}), do: {:error, r}
-  defp classify_auth_query_result({:error, _}), do: {:error, :unknown}
 end

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -28,7 +28,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
       system_metrics(),
       client_metrics(),
       db_metrics(),
-      auth_query_metrics()
+      client_auth_metrics()
     ]
   end
 
@@ -192,9 +192,9 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
     )
   end
 
-  defp auth_query_metrics do
+  defp client_auth_metrics do
     Event.build(
-      :supavisor_auth_query_event_metrics,
+      :supavisor_client_auth_event_metrics,
       [
         distribution(
           [:supavisor, :auth_query, :connection, :duration],

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -27,7 +27,8 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
     [
       system_metrics(),
       client_metrics(),
-      db_metrics()
+      db_metrics(),
+      auth_query_metrics()
     ]
   end
 
@@ -186,6 +187,68 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           reporter_options: [
             peep_bucket_calculator: Buckets
           ]
+        )
+      ]
+    )
+  end
+
+  defp auth_query_metrics do
+    Event.build(
+      :supavisor_auth_query_event_metrics,
+      [
+        distribution(
+          [:supavisor, :auth_query, :connection, :duration],
+          event_name: [:supavisor, :auth_query, :connection, :stop],
+          measurement: :duration,
+          description: "Duration of auth_query Postgrex connection setup.",
+          tags: [:result, :reason],
+          unit: {:native, :millisecond},
+          reporter_options: [peep_bucket_calculator: Buckets]
+        ),
+        distribution(
+          [:supavisor, :auth_query, :query, :duration],
+          event_name: [:supavisor, :auth_query, :query, :stop],
+          measurement: :duration,
+          description: "Duration of auth_query execution including Postgrex queue wait.",
+          tags: [:result, :reason],
+          unit: {:native, :millisecond},
+          reporter_options: [peep_bucket_calculator: Buckets]
+        ),
+        distribution(
+          [:supavisor, :secret_checker, :get_secrets, :duration, :local],
+          event_name: [:supavisor, :secret_checker, :get_secrets, :stop, :local],
+          measurement: :duration,
+          description: "Duration of get_secrets erpc call (same-node).",
+          tags: [:result, :reason],
+          unit: {:native, :millisecond},
+          reporter_options: [peep_bucket_calculator: Buckets]
+        ),
+        distribution(
+          [:supavisor, :secret_checker, :get_secrets, :duration, :remote],
+          event_name: [:supavisor, :secret_checker, :get_secrets, :stop, :remote],
+          measurement: :duration,
+          description: "Duration of get_secrets erpc call (cross-node).",
+          tags: [:result, :reason],
+          unit: {:native, :millisecond},
+          reporter_options: [peep_bucket_calculator: Buckets]
+        ),
+        distribution(
+          [:supavisor, :secret_checker, :update_credentials, :duration, :local],
+          event_name: [:supavisor, :secret_checker, :update_credentials, :stop, :local],
+          measurement: :duration,
+          description: "Duration of update_credentials erpc call (same-node).",
+          tags: [:result, :reason],
+          unit: {:native, :millisecond},
+          reporter_options: [peep_bucket_calculator: Buckets]
+        ),
+        distribution(
+          [:supavisor, :secret_checker, :update_credentials, :duration, :remote],
+          event_name: [:supavisor, :secret_checker, :update_credentials, :stop, :remote],
+          measurement: :duration,
+          description: "Duration of update_credentials erpc call (cross-node).",
+          tags: [:result, :reason],
+          unit: {:native, :millisecond},
+          reporter_options: [peep_bucket_calculator: Buckets]
         )
       ]
     )

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -219,7 +219,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :secret_checker, :get_secrets, :stop, :local],
           measurement: :duration,
           description: "Duration of get_secrets erpc call (same-node).",
-          tags: [:result, :reason],
+          tags: [:status],
           unit: {:native, :millisecond},
           reporter_options: [peep_bucket_calculator: Buckets]
         ),
@@ -228,7 +228,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :secret_checker, :get_secrets, :stop, :remote],
           measurement: :duration,
           description: "Duration of get_secrets erpc call (cross-node).",
-          tags: [:result, :reason],
+          tags: [:status],
           unit: {:native, :millisecond},
           reporter_options: [peep_bucket_calculator: Buckets]
         ),
@@ -237,7 +237,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :secret_checker, :update_credentials, :stop, :local],
           measurement: :duration,
           description: "Duration of update_credentials erpc call (same-node).",
-          tags: [:result, :reason],
+          tags: [:status],
           unit: {:native, :millisecond},
           reporter_options: [peep_bucket_calculator: Buckets]
         ),
@@ -246,7 +246,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :secret_checker, :update_credentials, :stop, :remote],
           measurement: :duration,
           description: "Duration of update_credentials erpc call (cross-node).",
-          tags: [:result, :reason],
+          tags: [:status],
           unit: {:native, :millisecond},
           reporter_options: [peep_bucket_calculator: Buckets]
         )

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -201,7 +201,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :auth_query, :connection, :stop],
           measurement: :duration,
           description: "Duration of auth_query Postgrex connection setup.",
-          tags: [:result, :reason],
+          tags: [:status],
           unit: {:native, :millisecond},
           reporter_options: [peep_bucket_calculator: Buckets]
         ),
@@ -210,7 +210,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :auth_query, :query, :stop],
           measurement: :duration,
           description: "Duration of auth_query execution including Postgrex queue wait.",
-          tags: [:result, :reason],
+          tags: [:status],
           unit: {:native, :millisecond},
           reporter_options: [peep_bucket_calculator: Buckets]
         ),

--- a/lib/supavisor/secret_checker.ex
+++ b/lib/supavisor/secret_checker.ex
@@ -9,6 +9,7 @@ defmodule Supavisor.SecretChecker do
   alias Supavisor.ClientAuthentication
   alias Supavisor.ClientAuthentication.ValidationSecrets
   alias Supavisor.Errors.AuthQueryError
+  alias Supavisor.Monitoring.Telem
 
   @interval :timer.seconds(15)
 
@@ -40,7 +41,12 @@ defmodule Supavisor.SecretChecker do
             {:error, %AuthQueryError{reason: :timeout}}
 
           :exit, reason ->
-            Logger.error("SecretChecker: get_secrets call exited: #{inspect(reason)}")
+            Supavisor.id(tenant: tenant) = id
+
+            Logger.error("SecretChecker: get_secrets call exited: #{inspect(reason)}",
+              project: tenant
+            )
+
             {:error, :not_started}
         end
     end
@@ -163,16 +169,31 @@ defmodule Supavisor.SecretChecker do
   defp erpc_call_node(id, mod, fun, args) do
     case Supavisor.get_global_sup(id) do
       nil ->
-        {:error, :not_started}
+        result = {:error, :not_started}
+        emit_erpc_metric(fun, 0, result, :local)
+        result
 
       pid ->
-        try do
-          :erpc.call(node(pid), mod, fun, args)
-        catch
-          :exit, reason ->
-            Logger.error("SecretChecker: erpc call exited: #{inspect(reason)}")
-            {:error, :not_started}
-        end
+        locality = if node(pid) == node(), do: :local, else: :remote
+        start = System.monotonic_time()
+
+        result =
+          try do
+            :erpc.call(node(pid), mod, fun, args)
+          catch
+            :exit, reason ->
+              Logger.error("SecretChecker: erpc call exited: #{inspect(reason)}")
+              {:error, :not_started}
+          end
+
+        emit_erpc_metric(fun, System.monotonic_time() - start, result, locality)
+        result
     end
   end
+
+  defp emit_erpc_metric(:do_get_secrets, duration, result, local),
+    do: Telem.get_secrets_stop(duration, result, local)
+
+  defp emit_erpc_metric(:do_update_credentials, duration, result, local),
+    do: Telem.update_credentials_stop(duration, result, local)
 end

--- a/lib/supavisor/secret_checker.ex
+++ b/lib/supavisor/secret_checker.ex
@@ -41,10 +41,8 @@ defmodule Supavisor.SecretChecker do
             {:error, %AuthQueryError{reason: :timeout}}
 
           :exit, reason ->
-            Supavisor.id(tenant: tenant) = id
-
             Logger.error("SecretChecker: get_secrets call exited: #{inspect(reason)}",
-              project: tenant
+              project: Supavisor.id(id, :tenant)
             )
 
             {:error, :not_started}

--- a/lib/supavisor/secret_checker.ex
+++ b/lib/supavisor/secret_checker.ex
@@ -167,33 +167,42 @@ defmodule Supavisor.SecretChecker do
   defp jitter, do: :rand.uniform(div(@interval, 10))
 
   defp erpc_call_node(id, mod, fun, args) do
+    start = System.monotonic_time()
+
     case Supavisor.get_global_sup(id) do
       nil ->
-        result = {:error, :not_started}
-        emit_erpc_metric(fun, 0, result, :local)
-        result
+        {:error, :not_started}
+        |> tap(&telemetry_stop(fun, start, &1, :local))
 
       pid ->
-        locality = if node(pid) == node(), do: :local, else: :remote
-        start = System.monotonic_time()
-
-        result =
-          try do
-            :erpc.call(node(pid), mod, fun, args)
-          catch
-            :exit, reason ->
-              Logger.error("SecretChecker: erpc call exited: #{inspect(reason)}")
-              {:error, :not_started}
-          end
-
-        emit_erpc_metric(fun, System.monotonic_time() - start, result, locality)
-        result
+        try do
+          :erpc.call(node(pid), mod, fun, args)
+        catch
+          :exit, reason ->
+            Logger.error("SecretChecker: erpc call exited: #{inspect(reason)}")
+            {:error, :not_started}
+        end
+        |> tap(&telemetry_stop(fun, start, &1, (node(pid) == node() && :local) || :remote))
     end
   end
 
-  defp emit_erpc_metric(:do_get_secrets, duration, result, local),
-    do: Telem.get_secrets_stop(duration, result, local)
+  defp telemetry_stop(:do_get_secrets, start, result, locality) do
+    Telem.secret_checker_get_secrets_stop(
+      System.monotonic_time() - start,
+      telemetry_status(result),
+      locality
+    )
+  end
 
-  defp emit_erpc_metric(:do_update_credentials, duration, result, local),
-    do: Telem.update_credentials_stop(duration, result, local)
+  defp telemetry_stop(:do_update_credentials, start, result, locality) do
+    Telem.secret_checker_update_credentials_stop(
+      System.monotonic_time() - start,
+      telemetry_status(result),
+      locality
+    )
+  end
+
+  defp telemetry_status({:error, _}), do: :error
+  defp telemetry_status({:ok, _}), do: :ok
+  defp telemetry_status(:ok), do: :ok
 end

--- a/test/integration/secret_checker_test.exs
+++ b/test/integration/secret_checker_test.exs
@@ -135,4 +135,136 @@ defmodule Supavisor.Integration.SecretCheckerTest do
     assert {:ok, %Supavisor.ClientAuthentication.ValidationSecrets{}} =
              Task.await(task, 5_000)
   end
+
+  describe "telemetry:" do
+    setup ctx do
+      ref = make_ref()
+
+      :telemetry.attach(
+        {__MODULE__, ctx.test},
+        ctx.event,
+        fn _event, measurements, metadata, {pid, r} -> send(pid, {r, measurements, metadata}) end,
+        {self(), ref}
+      )
+
+      on_exit(fn -> :telemetry.detach({__MODULE__, ctx.test}) end)
+      {:ok, ref: ref}
+    end
+
+    @tag event: [:supavisor, :secret_checker, :get_secrets, :stop, :local]
+    test "get_secrets/1 emits :local event when pool is not started", %{
+      tenant_id: tenant_id,
+      db_conf: db_conf,
+      ref: ref
+    } do
+      id =
+        Supavisor.id(
+          type: :single,
+          tenant: tenant_id,
+          user: to_string(db_conf[:username]),
+          mode: :transaction,
+          db: db_conf[:database]
+        )
+
+      assert {:error, :not_started} = Supavisor.SecretChecker.get_secrets(id)
+      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :not_started}}
+    end
+
+    @tag event: [:supavisor, :secret_checker, :get_secrets, :stop, :local]
+    test "get_secrets/1 emits :local event on successful fetch", %{
+      tenant_id: tenant_id,
+      db_conf: db_conf,
+      ref: ref
+    } do
+      proxy =
+        start_supervised!(
+          {Postgrex,
+           hostname: db_conf[:hostname],
+           port: Application.get_env(:supavisor, :proxy_port_transaction),
+           database: db_conf[:database],
+           password: db_conf[:password],
+           username: "#{db_conf[:username]}.#{tenant_id}"},
+          id: :telemetry_proxy_conn
+        )
+
+      assert %P.Result{rows: [[1]]} = P.query!(proxy, "SELECT 1", [])
+      Process.sleep(100)
+
+      pool_id =
+        Supavisor.id(
+          type: :single,
+          tenant: tenant_id,
+          user: to_string(db_conf[:username]),
+          mode: :transaction,
+          db: db_conf[:database]
+        )
+
+      assert {:ok, %Supavisor.ClientAuthentication.ValidationSecrets{}} =
+               Supavisor.SecretChecker.get_secrets(pool_id)
+
+      assert_receive {^ref, %{duration: d}, %{result: :ok, reason: :ok}}
+      assert d > 0
+    end
+
+    @tag event: [:supavisor, :secret_checker, :update_credentials, :stop, :local]
+    test "update_credentials/3 emits :local event on successful update", %{
+      tenant_id: tenant_id,
+      db_conf: db_conf,
+      ref: ref
+    } do
+      proxy =
+        start_supervised!(
+          {Postgrex,
+           hostname: db_conf[:hostname],
+           port: Application.get_env(:supavisor, :proxy_port_transaction),
+           database: db_conf[:database],
+           password: db_conf[:password],
+           username: "#{db_conf[:username]}.#{tenant_id}"},
+          id: :telemetry_proxy_conn
+        )
+
+      assert %P.Result{rows: [[1]]} = P.query!(proxy, "SELECT 1", [])
+      Process.sleep(100)
+
+      pool_id =
+        Supavisor.id(
+          type: :single,
+          tenant: tenant_id,
+          user: to_string(db_conf[:username]),
+          mode: :transaction,
+          db: db_conf[:database]
+        )
+
+      assert :ok =
+               Supavisor.SecretChecker.update_credentials(
+                 pool_id,
+                 to_string(db_conf[:username]),
+                 to_string(db_conf[:password])
+               )
+
+      assert_receive {^ref, %{duration: d}, %{result: :ok, reason: :ok}}
+      assert d > 0
+    end
+
+    @tag event: [:supavisor, :secret_checker, :update_credentials, :stop, :local]
+    test "update_credentials/3 emits :local event when pool is not started", %{
+      tenant_id: tenant_id,
+      db_conf: db_conf,
+      ref: ref
+    } do
+      id =
+        Supavisor.id(
+          type: :single,
+          tenant: tenant_id,
+          user: to_string(db_conf[:username]),
+          mode: :transaction,
+          db: db_conf[:database]
+        )
+
+      assert {:error, :not_started} =
+               Supavisor.SecretChecker.update_credentials(id, "new_user", "new_password")
+
+      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :not_started}}
+    end
+  end
 end

--- a/test/integration/secret_checker_test.exs
+++ b/test/integration/secret_checker_test.exs
@@ -143,7 +143,9 @@ defmodule Supavisor.Integration.SecretCheckerTest do
       :telemetry.attach(
         {__MODULE__, ctx.test},
         ctx.event,
-        fn _event, measurements, metadata, {pid, r} -> send(pid, {r, measurements, metadata}) end,
+        fn _event, measurements, metadata, {pid, ref} ->
+          send(pid, {ref, measurements, metadata})
+        end,
         {self(), ref}
       )
 
@@ -167,7 +169,7 @@ defmodule Supavisor.Integration.SecretCheckerTest do
         )
 
       assert {:error, :not_started} = Supavisor.SecretChecker.get_secrets(id)
-      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :not_started}}
+      assert_receive {^ref, %{duration: _}, %{status: :error}}
     end
 
     @tag event: [:supavisor, :secret_checker, :get_secrets, :stop, :local]
@@ -202,8 +204,8 @@ defmodule Supavisor.Integration.SecretCheckerTest do
       assert {:ok, %Supavisor.ClientAuthentication.ValidationSecrets{}} =
                Supavisor.SecretChecker.get_secrets(pool_id)
 
-      assert_receive {^ref, %{duration: d}, %{result: :ok, reason: :ok}}
-      assert d > 0
+      assert_receive {^ref, %{duration: duration}, %{status: :ok}}
+      assert duration > 0
     end
 
     @tag event: [:supavisor, :secret_checker, :update_credentials, :stop, :local]
@@ -242,8 +244,8 @@ defmodule Supavisor.Integration.SecretCheckerTest do
                  to_string(db_conf[:password])
                )
 
-      assert_receive {^ref, %{duration: d}, %{result: :ok, reason: :ok}}
-      assert d > 0
+      assert_receive {^ref, %{duration: duration}, %{status: :ok}}
+      assert is_integer(duration) and duration > 0
     end
 
     @tag event: [:supavisor, :secret_checker, :update_credentials, :stop, :local]
@@ -264,7 +266,8 @@ defmodule Supavisor.Integration.SecretCheckerTest do
       assert {:error, :not_started} =
                Supavisor.SecretChecker.update_credentials(id, "new_user", "new_password")
 
-      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :not_started}}
+      assert_receive {^ref, %{duration: duration}, %{status: :error}}
+      assert is_integer(duration) and duration >= 0
     end
   end
 end

--- a/test/integration/secret_checker_test.exs
+++ b/test/integration/secret_checker_test.exs
@@ -169,7 +169,8 @@ defmodule Supavisor.Integration.SecretCheckerTest do
         )
 
       assert {:error, :not_started} = Supavisor.SecretChecker.get_secrets(id)
-      assert_receive {^ref, %{duration: _}, %{status: :error}}
+      assert_receive {^ref, %{duration: duration}, %{status: :error}}
+      assert is_integer(duration) and duration >= 0
     end
 
     @tag event: [:supavisor, :secret_checker, :get_secrets, :stop, :local]
@@ -205,7 +206,7 @@ defmodule Supavisor.Integration.SecretCheckerTest do
                Supavisor.SecretChecker.get_secrets(pool_id)
 
       assert_receive {^ref, %{duration: duration}, %{status: :ok}}
-      assert duration > 0
+      assert is_integer(duration) and duration > 0
     end
 
     @tag event: [:supavisor, :secret_checker, :update_credentials, :stop, :local]

--- a/test/supavisor/auth_query_test.exs
+++ b/test/supavisor/auth_query_test.exs
@@ -3,7 +3,6 @@ defmodule Supavisor.AuthQueryTest do
 
   import Supavisor.Asserts
   import ExUnit.CaptureLog
-  alias Supavisor.Monitoring.Telem
 
   alias Supavisor.AuthQuery
   alias Supavisor.Errors.AuthQueryError
@@ -45,7 +44,7 @@ defmodule Supavisor.AuthQueryTest do
 
     test "rejects md5 secrets" do
       assert {:error,
-              %Supavisor.Errors.AuthQueryError{
+              %AuthQueryError{
                 reason: :md5_not_supported,
                 details: nil,
                 code: "EAUTHQUERY"
@@ -148,6 +147,58 @@ defmodule Supavisor.AuthQueryTest do
     end
   end
 
+  describe "start_link/2 telemetry:" do
+    setup ctx do
+      ref = make_ref()
+
+      :telemetry.attach(
+        {ctx.test, :auth_query_connection_stop},
+        [:supavisor, :auth_query, :connection, :stop],
+        fn _event, measurements, metadata, {pid, ref} ->
+          send(pid, {ref, measurements, metadata})
+        end,
+        {self(), ref}
+      )
+
+      on_exit(fn -> :telemetry.detach({ctx.test, :auth_query_connection_stop}) end)
+
+      db_conf = Application.get_env(:supavisor, Supavisor.Repo)
+
+      tenant = %Supavisor.Tenants.Tenant{
+        db_host: to_string(db_conf[:hostname]),
+        db_port: db_conf[:port],
+        db_database: db_conf[:database]
+      }
+
+      {:ok, ref: ref, db_conf: db_conf, tenant: tenant}
+    end
+
+    test "emits :ok on successful connection", %{ref: ref, db_conf: db_conf, tenant: tenant} do
+      manager = %Supavisor.Secrets.ManagerSecrets{
+        db_user: to_string(db_conf[:username]),
+        db_password: to_string(db_conf[:password])
+      }
+
+      {:ok, _conn} = AuthQuery.start_link(tenant, manager)
+
+      assert_receive {^ref, %{duration: duration}, %{status: :ok}}
+      assert is_integer(duration) && duration > 0
+    end
+
+    test "emits :error on failed connection", %{ref: ref, tenant: tenant} do
+      :meck.new(Postgrex, [:passthrough])
+      :meck.expect(Postgrex, :start_link, fn _opts -> {:error, :reason} end)
+
+      manager = %Supavisor.Secrets.ManagerSecrets{db_user: "user", db_password: nil}
+
+      assert {:error, _} = AuthQuery.start_link(tenant, manager)
+      assert_receive {^ref, %{duration: duration}, %{status: :error}}
+      assert is_integer(duration) && duration >= 0
+
+      :meck.unload(Postgrex)
+    end
+  end
+
   describe "fetch_user_secret/3 telemetry" do
     setup ctx do
       ref = make_ref()
@@ -155,7 +206,9 @@ defmodule Supavisor.AuthQueryTest do
       :telemetry.attach(
         {ctx.test, :auth_query_query_stop},
         [:supavisor, :auth_query, :query, :stop],
-        fn _event, measurements, metadata, {pid, r} -> send(pid, {r, measurements, metadata}) end,
+        fn _event, measurements, metadata, {pid, ref} ->
+          send(pid, {ref, measurements, metadata})
+        end,
         {self(), ref}
       )
 
@@ -172,17 +225,16 @@ defmodule Supavisor.AuthQueryTest do
         "postgres"
       )
 
-      assert_receive {^ref, %{duration: d}, %{result: :ok, reason: :ok}}
-      assert d > 0
-      GenServer.stop(conn)
+      assert_receive {^ref, %{duration: duration}, %{status: :ok}}
+      assert is_integer(duration) && duration > 0
     end
 
-    test "emits :no_auth_query when nil", %{ref: ref} do
+    test "emits :error when query is nil", %{ref: ref} do
       AuthQuery.fetch_user_secret(self(), nil, "user")
-      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :no_auth_query}}
+      assert_receive {^ref, %{duration: _}, %{status: :error}}
     end
 
-    test "emits :user_not_found", %{ref: ref} do
+    test "emits :error when user doesn't exist", %{ref: ref} do
       conn = start_conn()
 
       AuthQuery.fetch_user_secret(
@@ -191,32 +243,41 @@ defmodule Supavisor.AuthQueryTest do
         "nonexistent_user_xyz"
       )
 
-      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :user_not_found}}
-      GenServer.stop(conn)
+      assert_receive {^ref, %{duration: duration}, %{status: :error}}
+      assert is_integer(duration) && duration > 0
     end
 
-    test "emits :query_failed for invalid query", %{ref: ref} do
+    test "emits :error for invalid query", %{ref: ref} do
       conn = start_conn()
+
       AuthQuery.fetch_user_secret(conn, "SELECT * FROM nonexistent_table WHERE u=$1", "user")
-      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :query_failed}}
-      GenServer.stop(conn)
+
+      assert_receive {^ref, %{duration: duration}, %{status: :error}}
+      assert is_integer(duration) && duration > 0
     end
 
     test "auth_query_query_stop logs warning when duration exceeds 1s" do
-      slow = System.convert_time_unit(1_001, :millisecond, :native)
+      conn = start_conn()
 
-      log =
-        capture_log(fn ->
-          Telem.auth_query_query_stop(slow, {:error, %AuthQueryError{reason: :query_failed}})
-        end)
-
-      assert log =~ "auth_query took over"
+      assert capture_log(fn ->
+               AuthQuery.fetch_user_secret(
+                 conn,
+                 "SELECT $1::text, 'dummy'::text FROM pg_sleep(1)",
+                 "postgres"
+               )
+             end) =~ "auth_query took over"
     end
 
     test "auth_query_query_stop does not log warning for fast queries" do
-      fast = System.convert_time_unit(100, :millisecond, :native)
-      log = capture_log(fn -> Telem.auth_query_query_stop(fast, {:ok, %{}}) end)
-      refute log =~ "auth_query took over"
+      conn = start_conn()
+
+      refute capture_log(fn ->
+               AuthQuery.fetch_user_secret(
+                 conn,
+                 "SELECT rolname, rolpassword FROM pg_authid WHERE rolname=$1",
+                 "postgres"
+               )
+             end) =~ "auth_query took over"
     end
   end
 end

--- a/test/supavisor/auth_query_test.exs
+++ b/test/supavisor/auth_query_test.exs
@@ -130,8 +130,10 @@ defmodule Supavisor.AuthQueryTest do
       {:ok, conn} =
         Postgrex.start_link(
           hostname: "invalid.nonexistent.host",
-          port: 5432,
-          database: "test"
+          port: 5433,
+          database: "test",
+          queue_target: 1,
+          queue_interval: 4
         )
 
       assert {:error, %AuthQueryError{reason: :query_failed}} =

--- a/test/supavisor/auth_query_test.exs
+++ b/test/supavisor/auth_query_test.exs
@@ -175,7 +175,11 @@ defmodule Supavisor.AuthQueryTest do
       {:ok, ref: ref, db_conf: db_conf, tenant: tenant}
     end
 
-    test "emits :ok on successful connection", %{ref: ref, db_conf: db_conf, tenant: tenant} do
+    test "emits connection:stop on successful connection", %{
+      ref: ref,
+      db_conf: db_conf,
+      tenant: tenant
+    } do
       manager = %Supavisor.Secrets.ManagerSecrets{
         db_user: to_string(db_conf[:username]),
         db_password: to_string(db_conf[:password])
@@ -183,21 +187,8 @@ defmodule Supavisor.AuthQueryTest do
 
       {:ok, _conn} = AuthQuery.start_link(tenant, manager)
 
-      assert_receive {^ref, %{duration: duration}, %{status: :ok}}
+      assert_receive {^ref, %{duration: duration}, _}
       assert is_integer(duration) && duration > 0
-    end
-
-    test "emits :error on failed connection", %{ref: ref, tenant: tenant} do
-      :meck.new(Postgrex, [:passthrough])
-      :meck.expect(Postgrex, :start_link, fn _opts -> {:error, :reason} end)
-
-      manager = %Supavisor.Secrets.ManagerSecrets{db_user: "user", db_password: nil}
-
-      assert {:error, _} = AuthQuery.start_link(tenant, manager)
-      assert_receive {^ref, %{duration: duration}, %{status: :error}}
-      assert is_integer(duration) && duration >= 0
-
-      :meck.unload(Postgrex)
     end
   end
 
@@ -227,7 +218,7 @@ defmodule Supavisor.AuthQueryTest do
         "postgres"
       )
 
-      assert_receive {^ref, %{duration: duration}, %{status: :ok}}
+      assert_receive {^ref, %{duration: duration}, _}
       assert is_integer(duration) && duration > 0
     end
 
@@ -280,6 +271,77 @@ defmodule Supavisor.AuthQueryTest do
                  "postgres"
                )
              end) =~ "auth_query took over"
+    end
+  end
+
+  describe "connect_and_fetch_user_secret/4 telemetry" do
+    setup ctx do
+      ref = make_ref()
+
+      :telemetry.attach(
+        {ctx.test, :auth_query_connection_stop},
+        [:supavisor, :auth_query, :connection, :stop],
+        fn _event, measurements, metadata, {pid, ref} ->
+          send(pid, {:connection_stop, ref, measurements, metadata})
+        end,
+        {self(), ref}
+      )
+
+      :telemetry.attach(
+        {ctx.test, :auth_query_query_stop},
+        [:supavisor, :auth_query, :query, :stop],
+        fn _event, measurements, metadata, {pid, ref} ->
+          send(pid, {:query_stop, ref, measurements, metadata})
+        end,
+        {self(), ref}
+      )
+
+      :telemetry.attach(
+        {ctx.test, :auth_query_disconnection},
+        [:supavisor, :auth_query, :disconnection],
+        fn _event, measurements, metadata, {pid, ref} ->
+        send(pid, {:disconnection, ref, measurements, metadata})
+        end,
+        {self(), ref}
+      )
+
+      on_exit(fn ->
+        :telemetry.detach({ctx.test, :auth_query_connection_stop})
+        :telemetry.detach({ctx.test, :auth_query_query_stop})
+      end)
+
+      db_conf = Application.get_env(:supavisor, Supavisor.Repo)
+
+      tenant = %Supavisor.Tenants.Tenant{
+        db_host: to_string(db_conf[:hostname]),
+        db_port: db_conf[:port],
+        db_database: db_conf[:database]
+      }
+
+      {:ok, ref: ref, db_conf: db_conf, tenant: tenant}
+    end
+
+    test "emits connection:stop and query:stop and :disconnection on successful fetch", %{
+      ref: ref,
+      tenant: tenant,
+      db_conf: db_conf
+    } do
+      manager = %Supavisor.Secrets.ManagerSecrets{
+        db_user: to_string(db_conf[:username]),
+        db_password: to_string(db_conf[:password])
+      }
+
+      {:ok, _result} =
+        AuthQuery.connect_and_fetch_user_secret(
+          tenant,
+          manager,
+          "SELECT rolname, rolpassword FROM pg_authid WHERE rolname=$1",
+          "postgres"
+        )
+
+        assert_receive {:connection_stop, ^ref, %{duration: _connection_duration}, _}
+        assert_receive {:query_stop, ^ref, %{duration: _query_duration}, _}
+        assert_receive {:disconnection, ^ref, %{count: 1}, _}
     end
   end
 end

--- a/test/supavisor/auth_query_test.exs
+++ b/test/supavisor/auth_query_test.exs
@@ -2,6 +2,8 @@ defmodule Supavisor.AuthQueryTest do
   use ExUnit.Case, async: true
 
   import Supavisor.Asserts
+  import ExUnit.CaptureLog
+  alias Supavisor.Monitoring.Telem
 
   alias Supavisor.AuthQuery
   alias Supavisor.Errors.AuthQueryError
@@ -143,6 +145,78 @@ defmodule Supavisor.AuthQueryTest do
 
       assert_valid_error(result)
       GenServer.stop(conn)
+    end
+  end
+
+  describe "fetch_user_secret/3 telemetry" do
+    setup ctx do
+      ref = make_ref()
+
+      :telemetry.attach(
+        {ctx.test, :auth_query_query_stop},
+        [:supavisor, :auth_query, :query, :stop],
+        fn _event, measurements, metadata, {pid, r} -> send(pid, {r, measurements, metadata}) end,
+        {self(), ref}
+      )
+
+      on_exit(fn -> :telemetry.detach({ctx.test, :auth_query_query_stop}) end)
+      {:ok, ref: ref}
+    end
+
+    test "emits :ok on successful fetch", %{ref: ref} do
+      conn = start_conn()
+
+      AuthQuery.fetch_user_secret(
+        conn,
+        "SELECT rolname, rolpassword FROM pg_authid WHERE rolname=$1",
+        "postgres"
+      )
+
+      assert_receive {^ref, %{duration: d}, %{result: :ok, reason: :ok}}
+      assert d > 0
+      GenServer.stop(conn)
+    end
+
+    test "emits :no_auth_query when nil", %{ref: ref} do
+      AuthQuery.fetch_user_secret(self(), nil, "user")
+      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :no_auth_query}}
+    end
+
+    test "emits :user_not_found", %{ref: ref} do
+      conn = start_conn()
+
+      AuthQuery.fetch_user_secret(
+        conn,
+        "SELECT rolname, rolpassword FROM pg_authid WHERE rolname=$1",
+        "nonexistent_user_xyz"
+      )
+
+      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :user_not_found}}
+      GenServer.stop(conn)
+    end
+
+    test "emits :query_failed for invalid query", %{ref: ref} do
+      conn = start_conn()
+      AuthQuery.fetch_user_secret(conn, "SELECT * FROM nonexistent_table WHERE u=$1", "user")
+      assert_receive {^ref, %{duration: _}, %{result: :error, reason: :query_failed}}
+      GenServer.stop(conn)
+    end
+
+    test "auth_query_query_stop logs warning when duration exceeds 1s" do
+      slow = System.convert_time_unit(1_001, :millisecond, :native)
+
+      log =
+        capture_log(fn ->
+          Telem.auth_query_query_stop(slow, {:error, %AuthQueryError{reason: :query_failed}})
+        end)
+
+      assert log =~ "auth_query took over"
+    end
+
+    test "auth_query_query_stop does not log warning for fast queries" do
+      fast = System.convert_time_unit(100, :millisecond, :native)
+      log = capture_log(fn -> Telem.auth_query_query_stop(fast, {:ok, %{}}) end)
+      refute log =~ "auth_query took over"
     end
   end
 end

--- a/test/supavisor/connection_listener_test.exs
+++ b/test/supavisor/connection_listener_test.exs
@@ -1,0 +1,158 @@
+defmodule Supavisor.ConnectionListenerTest do
+  use ExUnit.Case, async: true
+
+  alias Supavisor.ConnectionListener
+
+  setup ctx do
+    listener = start_supervised!({ConnectionListener, [name: ctx.test]})
+    ref = make_ref()
+
+    :telemetry.attach(
+      {ctx.test, :stop},
+      [:supavisor, :auth_query, :connection, :stop],
+      fn _, meas, meta, {pid, r} -> send(pid, {r, :stop, meas, meta}) end,
+      {self(), ref}
+    )
+
+    :telemetry.attach(
+      {ctx.test, :exception},
+      [:supavisor, :auth_query, :connection, :exception],
+      fn _, meas, meta, {pid, r} -> send(pid, {r, :exception, meas, meta}) end,
+      {self(), ref}
+    )
+
+    :telemetry.attach(
+      {ctx.test, :disconnection},
+      [:supavisor, :auth_query, :disconnection],
+      fn _, meas, meta, {pid, r} -> send(pid, {r, :disconnection, meas, meta}) end,
+      {self(), ref}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach({ctx.test, :stop})
+      :telemetry.detach({ctx.test, :exception})
+    end)
+
+    {:ok, listener: listener, ref: ref}
+  end
+
+  defp fake_conn,
+    do:
+      spawn(fn ->
+        receive do
+          :stop_normal -> exit(:normal)
+        end
+      end)
+
+  defp sync(listener), do: :sys.get_state(listener)
+
+  describe ":connected" do
+    test "emits connection:stop with non-negative duration", %{listener: l, ref: ref} do
+      pid = fake_conn()
+      send(l, {:connected, pid, System.monotonic_time()})
+      assert_receive {^ref, :stop, %{duration: d}, _}
+      assert is_integer(d) and d >= 0
+    end
+
+    test "uses stored disconnect_time as start for reconnection", %{listener: l, ref: ref} do
+      pid = fake_conn()
+      tag = System.monotonic_time()
+
+      Process.sleep(100)
+      send(l, {:connected, pid, tag})
+      assert_receive {^ref, :stop, %{duration: _duration1}, _}
+
+      send(l, {:disconnected, pid, nil})
+      # Pass the original tag as the actual Postgrex would
+      # — the listener should use disconnect_time instead
+      send(l, {:connected, pid, tag})
+      assert_receive {^ref, :stop, %{duration: duration2}, _}
+      # if the original start_time was used, duration2 would be at least 100ms
+      assert is_integer(duration2) and
+               duration2 < System.convert_time_unit(100, :millisecond, :native)
+    end
+  end
+
+  describe ":disconnection" do
+    test "emitted on normal disconnect", %{listener: l, ref: ref} do
+      pid = fake_conn()
+      send(l, {:connected, pid, System.monotonic_time()})
+      assert_receive {^ref, :stop, _, _}
+
+      send(l, {:disconnected, pid, nil})
+      assert_receive {^ref, :disconnection, %{count: 1}, _}
+    end
+
+    test "handles duplicate :disconnected gracefully", %{listener: l, ref: ref} do
+      pid = fake_conn()
+      send(l, {:connected, pid, System.monotonic_time()})
+
+      send(l, {:disconnected, pid, nil})
+      send(l, {:disconnected, pid, nil})
+      assert_receive {^ref, :disconnection, _, _}
+      refute_receive {^ref, :disconnection, _, _}
+      assert Process.alive?(l)
+    end
+  end
+
+  describe ":DOWN" do
+    test "normal exit — emitted if has previously connected", %{listener: l, ref: ref} do
+      pid = fake_conn()
+      send(l, {:connected, pid, System.monotonic_time()})
+      assert_receive {^ref, :stop, _, _}
+
+      send(pid, :stop_normal)
+      assert_receive {^ref, :disconnection, _, _}
+    end
+
+    test "normal exit — no event emitted if has previously disconnected", %{
+      listener: l,
+      ref: ref
+    } do
+      pid = fake_conn()
+      send(l, {:connected, pid, System.monotonic_time()})
+      assert_receive {^ref, :stop, _, _}
+
+      send(l, {:disconnected, pid, nil})
+      assert_receive {^ref, :disconnection, _, _}
+
+      send(pid, :stop_normal)
+      refute_receive {^ref, :disconnection, _, _}
+    end
+
+    test "non-normal exit — emits disconnection if if has previously connected", %{
+      listener: l,
+      ref: ref
+    } do
+      pid = fake_conn()
+      send(l, {:connected, pid, System.monotonic_time()})
+      assert_receive {^ref, :stop, _, _}
+
+      Process.exit(pid, :some_error)
+      assert_receive {^ref, :disconnection, _, %{kind: :exit, reason: :some_error}}
+    end
+
+    test "non-normal exit — do not emits disocnnection if if has previously disconnected", %{
+      listener: l,
+      ref: ref
+    } do
+      pid = fake_conn()
+      send(l, {:connected, pid, System.monotonic_time()})
+      assert_receive {^ref, :stop, _, _}
+
+      send(l, {:disconnected, pid, nil})
+      assert_receive {^ref, :disconnection, _, _}
+
+      Process.exit(pid, :some_error)
+      refute_receive {^ref, :disconnection, _, _}
+    end
+
+    test "no crash when :DOWN arrives for unknown pid", %{listener: l} do
+      unknown = spawn(fn -> :ok end)
+      Process.sleep(10)
+      send(l, {:DOWN, make_ref(), :process, unknown, :reason})
+      sync(l)
+      assert Process.alive?(l)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes POOLER-392.

Adds four distribution metrics to improve observability of `auth_query` and `SecretChecker` operations:

- **`supavisor_auth_query_connection_duration`** — Postgrex connection setup time, emitted from `AuthQuery.start_link/2`
- **`supavisor_auth_query_query_duration`** — queue wait + query RTT, emitted from `AuthQuery.fetch_user_secret/3`; logs a warning when execution exceeds 1s
- **`supavisor_secret_checker_get_secrets_duration_{local,remote}`** — full erpc round-trip for `get_secrets`, split by locality (same pattern as `pool_checkout`)
- **`supavisor_secret_checker_update_credentials_duration_{local,remote}`** — same for `update_credentials`

All metrics tagged with `status` only — no per-tenant tags to avoid cardinality explosion.

Also fixes `Logger.error` in `do_get_secrets/1` to include `project: tenant` structured metadata (the function runs in the erpc caller process, not the SecretChecker GenServer, so the metadata was previously missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)