### PR TITLE
chore: rollback cac11 to v2.9.2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,7 +1,7 @@
 [
     {upgrade_from, "2.9.0"},
     {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.2"},
+    {upgrade_to, "2.9.2-rb"},
     % list() | [<<"all">>]
     {regions, [
 	    <<"cac11">>


### PR DESCRIPTION
Safety PR to revert #971 