### PR TITLE
chore: bump the max no pools per tenant to 50

### DIFF
--- a/lib/supavisor.ex
+++ b/lib/supavisor.ex
@@ -42,7 +42,7 @@ defmodule Supavisor do
           )
 
   @registry Supavisor.Registry.Tenants
-  @max_pools Application.compile_env(:supavisor, :max_pools, 20)
+  @max_pools Application.compile_env(:supavisor, :max_pools, 50)
 
   @spec start_dist(id, secrets, keyword()) :: {:ok, pid()} | {:error, any()}
   def start_dist(id, secrets, options \\ []) do


### PR DESCRIPTION
During the v1->v2 upgrade we run into an issue with a tenant hitting the previous limit