### PR TITLE
chore: hard deploy v2.9.5 in ca-central-1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,13 +1,13 @@
 [
     {upgrade_from, "2.9.0"},
-    {upgrade_previous, "2.9.0"},
+    {upgrade_previous, "2.9.5"},
     {upgrade_to, "2.9.5"},
     % list() | [<<"all">>]
     {regions, [
 	    <<"ca-central-1">>
             ]},
     % :soft | :hard
-    {type, soft}
+    {type, hard}
 ].
 % supavisor_soft_all-1_1.1.13_1.1.39
 % vi: ft=erlang


### PR DESCRIPTION
Lock-in / fallback for #994: re-installs v2.9.5 from a fresh hard artifact. Merge only after #994 is verified, or use as fallback if the soft deploy doesn't take cleanly.