### PR TITLE
chore: hard deploy v2.9.5 in staging

### DIFF
--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,11 +1,11 @@
 [
     {upgrade_from, "2.9.0"}, %% base on VM, last hard
-    {upgrade_previous, "2.9.0"}, %% current version on VM, includes soft deploys
+    {upgrade_previous, "2.9.5"}, %% current version on VM, includes soft deploys
     {upgrade_to, "2.9.5"},
     % list() | [<<"all">>]
     {regions, [<<"all">>]},
     % :soft | :hard
-    {type, soft}
+    {type, hard}
 ].
 % supavisor_soft_all-1_1.1.13_1.1.39
 % vi: ft=erlang

--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,11 +1,11 @@
 [
-    {upgrade_from, "2.9.2"}, %% base on VM, last hard
-    {upgrade_previous, "2.9.2"}, %% current version on VM, includes soft deploys
-    {upgrade_to, "2.9.0"},
+    {upgrade_from, "2.9.0"}, %% base on VM, last hard
+    {upgrade_previous, "2.9.0"}, %% current version on VM, includes soft deploys
+    {upgrade_to, "2.9.5"},
     % list() | [<<"all">>]
     {regions, [<<"all">>]},
     % :soft | :hard
-    {type, hard}
+    {type, soft}
 ].
 % supavisor_soft_all-1_1.1.13_1.1.39
 % vi: ft=erlang

--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,11 +1,11 @@
 [
     {upgrade_from, "2.9.2"}, %% base on VM, last hard
     {upgrade_previous, "2.9.2"}, %% current version on VM, includes soft deploys
-    {upgrade_to, "2.9.4"}, 
+    {upgrade_to, "2.9.0"},
     % list() | [<<"all">>]
     {regions, [<<"all">>]},
     % :soft | :hard
-    {type, soft}
+    {type, hard}
 ].
 % supavisor_soft_all-1_1.1.13_1.1.39
 % vi: ft=erlang


### PR DESCRIPTION
Lock-in / fallback for #997: re-installs v2.9.5 from a fresh hard artifact.