### PR TITLE
chore(ci): allow manual dispatch of stage deploy workflow

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -52,16 +52,25 @@ jobs:
           otp-version: "27.2.1"
           elixir-version: "1.18.2"
       - name: Set upgrade variables
+        env:
+          # Pass dispatch inputs via env (not direct ${{ }} interpolation) to
+          # avoid shell injection. See
+          # https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          INPUT_FROM: ${{ inputs.upgrade_from }}
+          INPUT_PREVIOUS: ${{ inputs.upgrade_previous }}
+          INPUT_TO: ${{ inputs.upgrade_to }}
+          INPUT_TYPE: ${{ inputs.type }}
+          INPUT_REGIONS: ${{ inputs.regions }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            FROM="${{ inputs.upgrade_from }}"
-            PREVIOUS="${{ inputs.upgrade_previous }}"
-            TO="${{ inputs.upgrade_to }}"
-            TYPE_VAL="${{ inputs.type }}"
+            FROM="$INPUT_FROM"
+            PREVIOUS="$INPUT_PREVIOUS"
+            TO="$INPUT_TO"
+            TYPE_VAL="$INPUT_TYPE"
             # Mirror handler.exs name format: supavisor_<type>_<regions joined by '&'>_<from>_<to>
-            REGIONS_SLUG="$(echo "${{ inputs.regions }}" | tr ',' '&' | tr -d ' ')"
+            REGIONS_SLUG="$(printf '%s' "$INPUT_REGIONS" | tr ',' '&' | tr -d ' ')"
             NAME_VAL="supavisor_${TYPE_VAL}_${REGIONS_SLUG}_${FROM}_${TO}"
-            echo "Dispatched: from=$FROM previous=$PREVIOUS to=$TO type=$TYPE_VAL regions=${{ inputs.regions }}"
+            echo "Dispatched: from=$FROM previous=$PREVIOUS to=$TO type=$TYPE_VAL regions=$INPUT_REGIONS"
           else
             elixir ./deploy/upgrade/handler.exs all_keys ./deploy/upgrade/staging.config
             FROM=$(elixir ./deploy/upgrade/handler.exs upgrade_from ./deploy/upgrade/staging.config)

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -64,15 +64,17 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Validate user-controlled inputs against an allowlist before they
-            # land in $GITHUB_ENV or downstream filenames.
-            VER_RE='^[0-9A-Za-z._+-]+$'
+            # Validate user-controlled inputs before they land in $GITHUB_ENV
+            # or downstream filenames. Versions must point at an existing tag;
+            # regions are checked against an allowlist.
             REG_RE='^[0-9a-z-]+$'
+            # actions/checkout is shallow by default and skips tags.
+            git fetch --tags origin --quiet
             for pair in "upgrade_from=$INPUT_FROM" "upgrade_previous=$INPUT_PREVIOUS" "upgrade_to=$INPUT_TO"; do
               name="${pair%%=*}"  # everything before the first '='
               val="${pair#*=}"    # everything after the first '='
-              if ! [[ "$val" =~ $VER_RE ]]; then
-                echo "::error::input $name='$val' fails allowlist $VER_RE"
+              if ! git rev-parse --verify --quiet "refs/tags/v$val" >/dev/null; then
+                echo "::error::input $name='$val' has no matching git tag v$val"
                 exit 1
               fi
             done

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -4,6 +4,33 @@ on:
   push:
     branches:
       - release_stage
+  workflow_dispatch:
+    inputs:
+      upgrade_from:
+        description: 'Base version on VM (last hard deploy). Must match an existing v<tag>.'
+        required: true
+        type: string
+      upgrade_previous:
+        description: 'Current version on VM (includes prior soft deploys). Usually same as upgrade_from. Must match an existing v<tag>.'
+        required: true
+        type: string
+      upgrade_to:
+        description: 'Target version. Must match an existing v<tag>. Must differ from upgrade_previous for soft deploys.'
+        required: true
+        type: string
+      regions:
+        description: 'Comma-separated region list, or "all".'
+        required: true
+        type: string
+        default: 'all'
+      type:
+        description: 'Deploy type.'
+        required: true
+        type: choice
+        default: 'soft'
+        options:
+          - soft
+          - hard
 env:
   INCLUDE_ERTS: true
   MIX_ENV: prod
@@ -26,12 +53,32 @@ jobs:
           elixir-version: "1.18.2"
       - name: Set upgrade variables
         run: |
-          elixir ./deploy/upgrade/handler.exs all_keys ./deploy/upgrade/staging.config
-          echo "RELEASE_BASE=$(elixir ./deploy/upgrade/handler.exs upgrade_from ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
-          echo "RELEASE_FROM=$(elixir ./deploy/upgrade/handler.exs upgrade_previous ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
-          echo "RELEASE_TO=$(elixir ./deploy/upgrade/handler.exs upgrade_to ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
-          echo "NAME=$(elixir ./deploy/upgrade/handler.exs name ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
-          echo "TYPE=$(elixir ./deploy/upgrade/handler.exs type ./deploy/upgrade/staging.config)" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FROM="${{ inputs.upgrade_from }}"
+            PREVIOUS="${{ inputs.upgrade_previous }}"
+            TO="${{ inputs.upgrade_to }}"
+            TYPE_VAL="${{ inputs.type }}"
+            # Mirror handler.exs name format: supavisor_<type>_<regions joined by '&'>_<from>_<to>
+            REGIONS_SLUG="$(echo "${{ inputs.regions }}" | tr ',' '&' | tr -d ' ')"
+            NAME_VAL="supavisor_${TYPE_VAL}_${REGIONS_SLUG}_${FROM}_${TO}"
+            echo "Dispatched: from=$FROM previous=$PREVIOUS to=$TO type=$TYPE_VAL regions=${{ inputs.regions }}"
+          else
+            elixir ./deploy/upgrade/handler.exs all_keys ./deploy/upgrade/staging.config
+            FROM=$(elixir ./deploy/upgrade/handler.exs upgrade_from ./deploy/upgrade/staging.config)
+            PREVIOUS=$(elixir ./deploy/upgrade/handler.exs upgrade_previous ./deploy/upgrade/staging.config)
+            TO=$(elixir ./deploy/upgrade/handler.exs upgrade_to ./deploy/upgrade/staging.config)
+            TYPE_VAL=$(elixir ./deploy/upgrade/handler.exs type ./deploy/upgrade/staging.config)
+            NAME_VAL=$(elixir ./deploy/upgrade/handler.exs name ./deploy/upgrade/staging.config)
+          fi
+          if [ "$TYPE_VAL" = "soft" ] && [ "$PREVIOUS" = "$TO" ]; then
+            echo "::error::Soft deploy requires upgrade_previous ($PREVIOUS) to differ from upgrade_to ($TO)."
+            exit 1
+          fi
+          echo "RELEASE_BASE=$FROM"     >> $GITHUB_ENV
+          echo "RELEASE_FROM=$PREVIOUS" >> $GITHUB_ENV
+          echo "RELEASE_TO=$TO"         >> $GITHUB_ENV
+          echo "TYPE=$TYPE_VAL"         >> $GITHUB_ENV
+          echo "NAME=$NAME_VAL"         >> $GITHUB_ENV
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -7,24 +7,24 @@ on:
   workflow_dispatch:
     inputs:
       upgrade_from:
-        description: 'Base version on VM (last hard deploy). Must match an existing v<tag>.'
+        description: 'Mirrors {upgrade_from, ...} in staging.config. Last hard-deployed staging version (must match an existing v<tag>). e.g. 2.9.4'
         required: true
         type: string
       upgrade_previous:
-        description: 'Current version on VM (includes prior soft deploys). Usually same as upgrade_from. Must match an existing v<tag>.'
+        description: 'Mirrors {upgrade_previous, ...} in staging.config. Version currently running on staging, including any prior soft deploys. e.g. 2.9.5'
         required: true
         type: string
       upgrade_to:
-        description: 'Target version. Must match an existing v<tag>. Must differ from upgrade_previous for soft deploys.'
+        description: 'Mirrors {upgrade_to, ...} in staging.config. Target version to deploy (must match an existing v<tag>, and differ from upgrade_previous for soft deploys). e.g. 2.9.6-rc.0'
         required: true
         type: string
       regions:
-        description: 'Comma-separated region list, or "all".'
+        description: 'Mirrors {regions, [...]} in staging.config. Comma-separated region list, or "all". e.g. all | us-east-1 | us-east-1,eu-west-2'
         required: true
         type: string
         default: 'all'
       type:
-        description: 'Deploy type.'
+        description: 'Mirrors {type, ...} in staging.config. soft = release upgrade, hard = full restart.'
         required: true
         type: choice
         default: 'soft'

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -62,32 +62,64 @@ jobs:
           INPUT_TYPE: ${{ inputs.type }}
           INPUT_REGIONS: ${{ inputs.regions }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            FROM="$INPUT_FROM"
-            PREVIOUS="$INPUT_PREVIOUS"
-            TO="$INPUT_TO"
-            TYPE_VAL="$INPUT_TYPE"
-            # Mirror handler.exs name format: supavisor_<type>_<regions joined by '&'>_<from>_<to>
-            REGIONS_SLUG="$(printf '%s' "$INPUT_REGIONS" | tr ',' '&' | tr -d ' ')"
-            NAME_VAL="supavisor_${TYPE_VAL}_${REGIONS_SLUG}_${FROM}_${TO}"
-            echo "Dispatched: from=$FROM previous=$PREVIOUS to=$TO type=$TYPE_VAL regions=$INPUT_REGIONS"
+            # Validate user-controlled inputs against an allowlist before they
+            # land in $GITHUB_ENV or downstream filenames.
+            VER_RE='^[0-9A-Za-z._+-]+$'
+            REG_RE='^[0-9a-z-]+$'
+            for pair in "upgrade_from=$INPUT_FROM" "upgrade_previous=$INPUT_PREVIOUS" "upgrade_to=$INPUT_TO"; do
+              name="${pair%%=*}"
+              val="${pair#*=}"
+              if ! [[ "$val" =~ $VER_RE ]]; then
+                echo "::error::input $name='$val' fails allowlist $VER_RE"
+                exit 1
+              fi
+            done
+            case "$INPUT_TYPE" in
+              soft|hard) ;;
+              *) echo "::error::input type='$INPUT_TYPE' must be soft|hard"; exit 1 ;;
+            esac
+            # Build the Erlang regions list for staging.config: [<<"r1">>, <<"r2">>]
+            REGIONS_ERL=""
+            IFS=',' read -ra RS <<< "$INPUT_REGIONS"
+            for r in "${RS[@]}"; do
+              r="${r// /}"
+              if ! [[ "$r" =~ $REG_RE ]]; then
+                echo "::error::input regions entry '$r' fails allowlist $REG_RE"
+                exit 1
+              fi
+              REGIONS_ERL+="<<\"$r\">>, "
+            done
+            REGIONS_ERL="${REGIONS_ERL%, }"
+            CONFIG=/tmp/dispatch.config
+            cat > "$CONFIG" <<EOF
+          [
+              {upgrade_from, "$INPUT_FROM"},
+              {upgrade_previous, "$INPUT_PREVIOUS"},
+              {upgrade_to, "$INPUT_TO"},
+              {regions, [$REGIONS_ERL]},
+              {type, $INPUT_TYPE}
+          ].
+          EOF
           else
-            elixir ./deploy/upgrade/handler.exs all_keys ./deploy/upgrade/staging.config
-            FROM=$(elixir ./deploy/upgrade/handler.exs upgrade_from ./deploy/upgrade/staging.config)
-            PREVIOUS=$(elixir ./deploy/upgrade/handler.exs upgrade_previous ./deploy/upgrade/staging.config)
-            TO=$(elixir ./deploy/upgrade/handler.exs upgrade_to ./deploy/upgrade/staging.config)
-            TYPE_VAL=$(elixir ./deploy/upgrade/handler.exs type ./deploy/upgrade/staging.config)
-            NAME_VAL=$(elixir ./deploy/upgrade/handler.exs name ./deploy/upgrade/staging.config)
+            CONFIG=./deploy/upgrade/staging.config
           fi
+          elixir ./deploy/upgrade/handler.exs all_keys "$CONFIG"
+          FROM=$(elixir ./deploy/upgrade/handler.exs upgrade_from "$CONFIG")
+          PREVIOUS=$(elixir ./deploy/upgrade/handler.exs upgrade_previous "$CONFIG")
+          TO=$(elixir ./deploy/upgrade/handler.exs upgrade_to "$CONFIG")
+          TYPE_VAL=$(elixir ./deploy/upgrade/handler.exs type "$CONFIG")
+          NAME_VAL=$(elixir ./deploy/upgrade/handler.exs name "$CONFIG")
           if [ "$TYPE_VAL" = "soft" ] && [ "$PREVIOUS" = "$TO" ]; then
             echo "::error::Soft deploy requires upgrade_previous ($PREVIOUS) to differ from upgrade_to ($TO)."
             exit 1
           fi
-          echo "RELEASE_BASE=$FROM"     >> $GITHUB_ENV
-          echo "RELEASE_FROM=$PREVIOUS" >> $GITHUB_ENV
-          echo "RELEASE_TO=$TO"         >> $GITHUB_ENV
-          echo "TYPE=$TYPE_VAL"         >> $GITHUB_ENV
-          echo "NAME=$NAME_VAL"         >> $GITHUB_ENV
+          printf 'RELEASE_BASE=%s\n' "$FROM"     >> "$GITHUB_ENV"
+          printf 'RELEASE_FROM=%s\n' "$PREVIOUS" >> "$GITHUB_ENV"
+          printf 'RELEASE_TO=%s\n'   "$TO"       >> "$GITHUB_ENV"
+          printf 'TYPE=%s\n'         "$TYPE_VAL" >> "$GITHUB_ENV"
+          printf 'NAME=%s\n'         "$NAME_VAL" >> "$GITHUB_ENV"
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -69,8 +69,8 @@ jobs:
             VER_RE='^[0-9A-Za-z._+-]+$'
             REG_RE='^[0-9a-z-]+$'
             for pair in "upgrade_from=$INPUT_FROM" "upgrade_previous=$INPUT_PREVIOUS" "upgrade_to=$INPUT_TO"; do
-              name="${pair%%=*}"
-              val="${pair#*=}"
+              name="${pair%%=*}"  # everything before the first '='
+              val="${pair#*=}"    # everything after the first '='
               if ! [[ "$val" =~ $VER_RE ]]; then
                 echo "::error::input $name='$val' fails allowlist $VER_RE"
                 exit 1


### PR DESCRIPTION
Adds `workflow_dispatch` with inputs (`upgrade_from`, `upgrade_previous`, `upgrade_to`, `regions`, `type`) so a stage deploy can be triggered from the Actions UI without editing `staging.config` and pushing.

The `Set upgrade variables` step now branches on `github.event_name`: inputs when dispatched manually, `staging.config` on push (existing behaviour preserved). Also aborts up-front when `type=soft` and `upgrade_previous == upgrade_to`, which otherwise silently hangs the second `mix release` on \`Release already exists. Overwrite? [Yn]\` and surfaces only as a confusing \`mv: cannot stat ...tar.gz\` later (see failed run [#26285657935](https://github.com/supabase/supavisor/actions/runs/26285657935)).

No change to soft/hard branching, action versions, or any other step.

## Test plan
- [ ] Merge, then trigger from Actions UI ("Run workflow") with `upgrade_from=2.9.4`, `upgrade_previous=…`, `upgrade_to=2.9.6-rc.0`, `regions=all`, `type=soft`.
- [ ] Confirm next push to `release_stage` (existing flow) still reads `staging.config` and works as before.