### PR TITLE
chore(ci): expose stage deploy workflow on the Actions UI

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -43,6 +43,12 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Guard - dispatch must target release_stage
+        if: github.event_name == 'workflow_dispatch' && github.ref_name != 'release_stage'
+        run: |
+          echo "::error::This workflow must be dispatched against the 'release_stage' branch."
+          echo "::error::On the Actions page, open 'Run workflow' and pick 'release_stage' in the 'Use workflow from' dropdown."
+          exit 1
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set upgrade variables

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -4,6 +4,33 @@ on:
   push:
     branches:
       - release_stage
+  workflow_dispatch:
+    inputs:
+      upgrade_from:
+        description: 'Base version on VM (last hard deploy). Must match an existing v<tag>.'
+        required: true
+        type: string
+      upgrade_previous:
+        description: 'Current version on VM (includes prior soft deploys). Usually same as upgrade_from. Must match an existing v<tag>.'
+        required: true
+        type: string
+      upgrade_to:
+        description: 'Target version. Must match an existing v<tag>. Must differ from upgrade_previous for soft deploys.'
+        required: true
+        type: string
+      regions:
+        description: 'Comma-separated region list, or "all".'
+        required: true
+        type: string
+        default: 'all'
+      type:
+        description: 'Deploy type.'
+        required: true
+        type: choice
+        default: 'soft'
+        options:
+          - soft
+          - hard
 env:
   INCLUDE_ERTS: true
   MIX_ENV: prod


### PR DESCRIPTION
GitHub only renders the **Run workflow** button when the workflow file *on the default branch* declares a \`workflow_dispatch\` trigger ([docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)). The actual deploy logic lives on \`release_stage\` (see PR #1007), so this PR adds only the trigger and its input schema to main — the existing \`push: branches: [release_stage]\` flow is unchanged.

After this lands, the button appears on the Actions tab. Picking \`release_stage\` from the **Use workflow from** dropdown executes that branch's workflow file (per [this writeup](https://www.joshmcarthur.com/til/2025/09/29/How-to-test-new-Github-Actions-workflows.html)) — which is where the soft/hard branching, the same-version guard, and the input-handling \`Set upgrade variables\` step live (PR #1007).

## Test plan
- [ ] Merge.
- [ ] Open Actions → "Publish upgrade artifacts to staging" — the "Run workflow" button is now present.
- [ ] Confirm a push to \`release_stage\` still triggers the old flow (it does — the \`on: push\` trigger is untouched).