### PR TITLE
chore: rollback to v2.9.0 at ca-central-1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
-    {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.5"},
+    {upgrade_from, "2.9.0"},
+    {upgrade_previous, "2.9.0"},
+    {upgrade_to, "2.9.0-rb"},
     % list() | [<<"all">>]
     {regions, [
-	    <<"eu-central-1-ter">>
+	    <<"ca-central-1">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Based on the https://github.com/supabase/supavisor/releases/tag/v2.9.0-rb

To be merged if #994 must be rolled back.