### PR TITLE
chore(supavisor): soft upgrade to v2.9.6 in eu-west-1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.0"},
-    {upgrade_previous, "2.9.0"},
+    {upgrade_from, "2.9.1"},
+    {upgrade_previous, "2.9.1"},
     {upgrade_to, "2.9.6"},
     % list() | [<<"all">>]
     {regions, [
-	    <<"ca-central-1">>
+	    <<"eu-west-1">>
             ]},
     % :soft | :hard
     {type, soft}


### PR DESCRIPTION
soft upgrade to v2.9.6 in eu-west-1

https://linear.app/supabase/issue/POOLER-415/roll-out-v294-to-eu-west-1-from-v291
