### PR TITLE
fix: add backend_pid to logger metadata allow-list

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -36,7 +36,8 @@ metadata = [
   :app_name,
   :peer_ip,
   :local,
-  :proxy
+  :proxy,
+  :backend_pid
 ]
 
 # Configures Elixir's Logger

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -75,7 +75,8 @@ config :logger, :console,
     :app_name,
     :peer_ip,
     :local,
-    :proxy
+    :proxy,
+    :backend_pid
   ]
 
 # Set a higher stacktrace during development. Avoid configuring such


### PR DESCRIPTION
The DbHandler process added the postgres backend PID to metadata, but this wasn't available in the logs due to lacking configuration.

POOLER-180
