### PR TITLE
chore: deploy supavisor v2.9.9 to ap-east-1-sec

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -4,7 +4,7 @@
     {upgrade_to, "2.9.7"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"apne21">>
+        <<"eun11-tst">>
             ]},
     % :soft | :hard
     {type, hard}

--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
     {upgrade_from, "2.9.0"},     % hard-deploy base of the cluster
     {upgrade_previous, "2.9.0"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.8"},       % target version
+    {upgrade_to, "2.9.9"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"eun11-tst">>
+        <<"ap-east-1-sec">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
deploy v2.9.9 to ap-east-1


Affects: https://github.com/supabase/platform/pull/34860