### PR TITLE
fix(db_handler): handle ReadyForQuery split across TCP reads

### DIFF
--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -407,6 +407,41 @@ defmodule Supavisor.DbHandler do
   end
 
   # forward the message to the client
+  def handle_event(
+        :info,
+        {proto, _, bin},
+        :busy,
+        %{backend_message_streaming: true, caller: caller} = data
+      )
+      when is_pid(caller) and proto in @proto do
+    Logger.debug("DbHandler: Got messages: #{Debug.packet_to_string(bin, :backend)}")
+
+    data = reset_ready_for_query(data)
+    {:ok, data, to_send} = process_backend_streaming(bin, data)
+
+    if ready_for_query_idle?(data) do
+      ClientHandler.db_status(data.caller, :ready_for_query)
+      if to_send != [], do: client_send(data, to_send)
+
+      case data.mode do
+        :transaction ->
+          {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
+          {:next_state, :idle, %{data | stats: stats, caller: nil, client_sock: nil}}
+
+        :proxy ->
+          {:keep_state, data}
+
+        :session ->
+          {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
+          {:keep_state, %{data | stats: stats}}
+      end
+    else
+      if to_send != [], do: client_send(data, to_send)
+      {:keep_state, data}
+    end
+  end
+
+  # hot code reload compat: remove after full rollout
   def handle_event(:info, {proto, _, bin}, :busy, %{caller: caller} = data)
       when is_pid(caller) and proto in @proto do
     Logger.debug("DbHandler: Got messages: #{Debug.packet_to_string(bin, :backend)}")
@@ -892,18 +927,9 @@ defmodule Supavisor.DbHandler do
     Supavisor.UpstreamAuthentication.delete_upstream_auth_secrets(data.id)
   end
 
+  # hot code reload compat: remove after full rollout. The streaming path now
+  # inlines process_backend_streaming + client_send in the :busy handler.
   @spec handle_server_messages(binary(), map()) :: map()
-  defp handle_server_messages(bin, %{backend_message_streaming: true} = data) do
-    {:ok, updated_data, to_send} = process_backend_streaming(bin, data)
-
-    if to_send != [] do
-      client_send(data, to_send)
-    end
-
-    updated_data
-  end
-
-  # hot code reload compat: remove after full rollout
   defp handle_server_messages(bin, data) do
     client_send(data, bin)
     data
@@ -1063,6 +1089,24 @@ defmodule Supavisor.DbHandler do
       err ->
         err
     end
+  end
+
+  # Clears previously recorded ReadyForQuery status before processing a bin.
+  defp reset_ready_for_query(data) do
+    %{
+      data
+      | stream_state:
+          MessageStreamer.update_state(data.stream_state, fn state ->
+            BackendMessageHandler.handler_state(state, ready_for_query: nil)
+          end)
+    }
+  end
+
+  defp ready_for_query_idle?(data) do
+    BackendMessageHandler.handler_state(
+      MessageStreamer.stream_state(data.stream_state, :handler_state),
+      :ready_for_query
+    ) == ?I
   end
 
   defp last_fatal_error(%{backend_message_streaming: true} = data) do

--- a/lib/supavisor/protocol/backend_message_handler.ex
+++ b/lib/supavisor/protocol/backend_message_handler.ex
@@ -16,7 +16,11 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
   require Record
   require Supavisor.Protocol.Server, as: Server
 
-  Record.defrecord(:handler_state, action_queue: :queue.new(), fatal_error: nil)
+  Record.defrecord(:handler_state,
+    action_queue: :queue.new(),
+    fatal_error: nil,
+    ready_for_query: nil
+  )
 
   @impl true
   def handled_message_types do
@@ -38,6 +42,7 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
   end
 
   def handle_message(state, tag, len, payload) do
+    state = maybe_record_ready_for_query(state, tag, payload)
     action_queue = handler_state(state, :action_queue)
     message_type = message_type(tag)
     {injected_pkts, action_queue} = maybe_inject(action_queue)
@@ -55,6 +60,12 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
          [injected_pkts, <<tag, len::32, payload::binary>>]}
     end
   end
+
+  # ReadyForQuery's payload is the 1-byte transaction status (I/T/E).
+  defp maybe_record_ready_for_query(state, ?Z, <<status::8>>),
+    do: handler_state(state, ready_for_query: status)
+
+  defp maybe_record_ready_for_query(state, _tag, _payload), do: state
 
   defp maybe_inject(action_queue) do
     case :queue.out(action_queue) do

--- a/test/supavisor/protocol/backend_message_handler_test.exs
+++ b/test/supavisor/protocol/backend_message_handler_test.exs
@@ -55,7 +55,7 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       assert IO.iodata_to_binary(result) == original_bin
     end
 
-    test "ready for query message with no actions passes through unchanged", %{
+    test "ready for query message is forwarded and its status is observed", %{
       stream_state: stream_state
     } do
       original_bin = <<?Z, 5::32, ?I>>
@@ -63,8 +63,15 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
-               MessageStreamer.stream_state(stream_state, :handler_state)
+      new_state = MessageStreamer.stream_state(new_stream_state, :handler_state)
+
+      assert BackendMessageHandler.handler_state(new_state, :ready_for_query) == ?I
+
+      assert BackendMessageHandler.handler_state(new_state, :action_queue) ==
+               BackendMessageHandler.handler_state(
+                 MessageStreamer.stream_state(stream_state, :handler_state),
+                 :action_queue
+               )
 
       assert IO.iodata_to_binary(result) == original_bin
     end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Uses the `MessageStreamer` via the backend message handler to detect ReadyForQuery, so it's always detecting from a framed TCP stream, and not a single packet in which the message is prone to be split.

## What is the current behavior?

ReadyForQuery appears at the end of a variable-sized result message in the hot path. So there is a risk of the ReadyForQuery message splitting across two socket reads due to a network hiccup, or just because the OS decided to. This wouldn't clean up the DB handler even if it's done with use.

## What is the new behavior?

Uses the existing Backend Message handler to use the stream state and detect ReadyForQuery even across TCP packets.