### PR TITLE
feat: forward client application_name in session mode

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -320,7 +320,8 @@ defmodule Supavisor.ClientHandler do
          {:ok, opts} <- Supavisor.subscribe(data.id),
          manager_ref = Process.monitor(opts.workers.manager),
          data = Map.merge(data, opts.workers),
-         {:ok, db_connection} <- maybe_checkout(:on_connect, data) do
+         {:ok, db_connection} <- maybe_checkout(:on_connect, data),
+         :ok <- maybe_set_application_name(data, db_connection) do
       data = %{
         data
         | manager: manager_ref,
@@ -716,6 +717,20 @@ defmodule Supavisor.ClientHandler do
 
     Logger.log(level, "ClientHandler: terminating with reason #{inspect(reason)}")
   end
+
+  defp maybe_set_application_name(%{mode: :session, app_name: app_name}, {_pool, db_pid, _sock})
+       when is_binary(app_name) and app_name != "" and app_name != "Supavisor" do
+    case DbHandler.set_application_name(db_pid, app_name) do
+      :ok ->
+        :ok
+
+      error ->
+        Logger.warning("ClientHandler: failed to set application_name: #{inspect(error)}")
+        :ok
+    end
+  end
+
+  defp maybe_set_application_name(_data, _db_connection), do: :ok
 
   defp maybe_cleanup_db_handler(state, data) do
     if state == :idle and data.mode == :session and data.db_connection != nil and

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -452,8 +452,11 @@ defmodule Supavisor.DbHandler do
       # Only when checked out to this client (:busy).
       state == :busy ->
         Logger.debug("DbHandler: Setting application_name to #{inspect(name)}")
-        query = "SET application_name = #{quote_literal(name)}"
-        :ok = HandlerHelpers.sock_send(data.sock, :pgo_protocol.encode_query_message(query))
+
+        query =
+          Server.extended_query("SELECT set_config('application_name', $1, false)", [name])
+
+        :ok = HandlerHelpers.sock_send(data.sock, query)
 
         {:next_state, :setting_application_name,
          Map.merge(data, %{set_app_name_from: from, pending_bin: <<>>}),
@@ -930,9 +933,6 @@ defmodule Supavisor.DbHandler do
       data
     end
   end
-
-  # Quote a value as a SQL string literal.
-  defp quote_literal(value), do: "'" <> String.replace(value, "'", "''") <> "'"
 
   # If the prepared statement exists for us, it exists for the server, so we just send the
   # bind to the socket. If it doesn't, we must send the parse pkt first.

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -58,6 +58,7 @@ defmodule Supavisor.DbHandler do
           | :busy
           | :terminating_with_error
           | :waiting_for_secrets
+          | :setting_application_name
 
   @sock_closed [:tcp_closed, :ssl_closed]
   @proto [:tcp, :ssl]
@@ -122,6 +123,17 @@ defmodule Supavisor.DbHandler do
   @spec attempt_cleanup(pid()) :: :ok | {:error, term()}
   def attempt_cleanup(db_handler_pid) do
     :gen_statem.call(db_handler_pid, :cleanup, 5_000)
+  catch
+    :exit, reason ->
+      {:error, {:exit, reason}}
+  end
+
+  @doc """
+  Sets `application_name` on the backend connection.
+  """
+  @spec set_application_name(pid(), String.t()) :: :ok | {:error, term()}
+  def set_application_name(db_handler_pid, name) do
+    :gen_statem.call(db_handler_pid, {:set_application_name, name}, 5_000)
   catch
     :exit, reason ->
       {:error, {:exit, reason}}
@@ -425,6 +437,61 @@ defmodule Supavisor.DbHandler do
       true ->
         {:keep_state, %{data | pending_bin: buffered_bin}}
     end
+  end
+
+  def handle_event({:call, from}, {:set_application_name, name}, state, data) do
+    cond do
+      data.mode == :transaction ->
+        Logger.error(
+          "DbHandler: set_application_name called on transaction mode - only supported in session mode"
+        )
+
+        {:keep_state_and_data,
+         {:reply, from, {:error, :set_application_name_not_supported_in_transaction_mode}}}
+
+      # Only when checked out to this client (:busy).
+      state == :busy ->
+        Logger.debug("DbHandler: Setting application_name to #{inspect(name)}")
+        query = "SET application_name = #{quote_literal(name)}"
+        :ok = HandlerHelpers.sock_send(data.sock, :pgo_protocol.encode_query_message(query))
+
+        {:next_state, :setting_application_name,
+         Map.merge(data, %{set_app_name_from: from, pending_bin: <<>>}),
+         {:state_timeout, 5_000, :set_application_name_timeout}}
+
+      true ->
+        {:keep_state_and_data, {:reply, from, :ok}}
+    end
+  end
+
+  # Swallow the SET application_name response so it never reaches the client.
+  # Setting application name should feel like an implicit feature.
+  def handle_event(:info, {proto, _, bin}, :setting_application_name, data)
+      when proto in @proto do
+    buffered_bin = data.pending_bin <> bin
+
+    cond do
+      String.ends_with?(buffered_bin, Server.ready_for_query()) ->
+        {:next_state, :busy, %{data | pending_bin: nil, set_app_name_from: nil},
+         {:reply, data.set_app_name_from, :ok}}
+
+      byte_size(buffered_bin) > @cleanup_buffer_limit ->
+        Logger.error("DbHandler: application_name buffer limit exceeded, shutting down")
+        {:stop, :normal}
+
+      true ->
+        {:keep_state, %{data | pending_bin: buffered_bin}}
+    end
+  end
+
+  def handle_event(
+        :state_timeout,
+        :set_application_name_timeout,
+        :setting_application_name,
+        _data
+      ) do
+    Logger.error("DbHandler: set application_name timeout, shutting down")
+    {:stop, :normal}
   end
 
   def handle_event({:call, from}, {:handle_ps_pkts, pkts}, :busy, data) do
@@ -864,6 +931,9 @@ defmodule Supavisor.DbHandler do
       data
     end
   end
+
+  # Quote a value as a SQL string literal.
+  defp quote_literal(value), do: "'" <> String.replace(value, "'", "''") <> "'"
 
   # If the prepared statement exists for us, it exists for the server, so we just send the
   # bind to the socket. If it doesn't, we must send the parse pkt first.

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -465,7 +465,6 @@ defmodule Supavisor.DbHandler do
   end
 
   # Swallow the SET application_name response so it never reaches the client.
-  # Setting application name should feel like an implicit feature.
   def handle_event(:info, {proto, _, bin}, :setting_application_name, data)
       when proto in @proto do
     buffered_bin = data.pending_bin <> bin

--- a/lib/supavisor/protocol/server.ex
+++ b/lib/supavisor/protocol/server.ex
@@ -207,7 +207,39 @@ defmodule Supavisor.Protocol.Server do
   @spec ssl_request :: binary()
   def ssl_request, do: @ssl_request
 
+  @spec extended_query(iodata(), [binary()]) :: binary()
+  def extended_query(statement, params \\ []) do
+    IO.iodata_to_binary([
+      :pgo_protocol.encode_parse_message("", statement, []),
+      encode_bind(params),
+      :pgo_protocol.encode_execute_message("", 0),
+      :pgo_protocol.encode_sync_message()
+    ])
+  end
+
   # Internal functions
+
+  defp encode_bind(params) do
+    encoded_params =
+      Enum.map(params, fn value ->
+        value = IO.iodata_to_binary(value)
+        [<<byte_size(value)::32>>, value]
+      end)
+
+    body = [
+      # unnamed portal and prepared statement
+      <<0>>,
+      <<0>>,
+      # text params only
+      <<0::16>>,
+      <<length(params)::16>>,
+      encoded_params,
+      # results are text too
+      <<0::16>>
+    ]
+
+    [<<?B, IO.iodata_length(body) + 4::32>>, body]
+  end
 
   @spec decode(binary(), list()) :: {:ok, [Pkt.t()], rest :: binary()}
   defp decode(data, acc) when byte_size(data) >= @pkt_header_size do

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -871,7 +871,7 @@ defmodule Supavisor.Integration.ProxyTest do
   end
 
   test "cleanup resets session state in session mode" do
-    %{db_conf: db_conf} = setup_tenant_connections(List.first(@tenants))
+    %{db_conf: db_conf, origin: origin} = setup_tenant_connections(List.first(@tenants))
 
     connection_opts = [
       hostname: db_conf[:hostname],
@@ -883,10 +883,21 @@ defmodule Supavisor.Integration.ProxyTest do
 
     test_timeout = "12345ms"
 
-    assert {:ok, conn1} = start_supervised({SingleConnection, connection_opts}, id: :conn1)
+    conn1_opts = Keyword.put(connection_opts, :parameters, application_name: "app_one")
+    conn2_opts = Keyword.put(connection_opts, :parameters, application_name: "app_two")
+
+    assert {:ok, conn1} = start_supervised({SingleConnection, conn1_opts}, id: :conn1)
 
     assert [%P.Result{rows: [[backend_pid_1]]}] =
              P.SimpleConnection.call(conn1, {:query, "SELECT pg_backend_pid();"})
+
+    # conn1's application_name reached the backend
+    assert [%P.Result{rows: [["app_one"]]}] =
+             P.SimpleConnection.call(
+               conn1,
+               {:query,
+                "SELECT application_name FROM pg_stat_activity WHERE pid = pg_backend_pid();"}
+             )
 
     assert [%P.Result{}] =
              P.SimpleConnection.call(
@@ -900,12 +911,28 @@ defmodule Supavisor.Integration.ProxyTest do
     stop_supervised(:conn1)
     Process.sleep(100)
 
-    assert {:ok, conn2} = start_supervised({SingleConnection, connection_opts}, id: :conn2)
+    # Check if application_name was reset
+    assert %P.Result{rows: [["Supavisor"]]} =
+             P.query!(
+               origin,
+               "SELECT application_name FROM pg_stat_activity WHERE pid = $1",
+               [String.to_integer(backend_pid_1)]
+             )
+
+    assert {:ok, conn2} = start_supervised({SingleConnection, conn2_opts}, id: :conn2)
 
     assert [%P.Result{rows: [[backend_pid_2]]}] =
              P.SimpleConnection.call(conn2, {:query, "SELECT pg_backend_pid();"})
 
     assert backend_pid_1 == backend_pid_2
+
+    # conn2's application_name reached the backend
+    assert [%P.Result{rows: [["app_two"]]}] =
+             P.SimpleConnection.call(
+               conn2,
+               {:query,
+                "SELECT application_name FROM pg_stat_activity WHERE pid = pg_backend_pid();"}
+             )
 
     assert [%P.Result{rows: [[timeout]]}] =
              P.SimpleConnection.call(conn2, {:query, "SHOW statement_timeout;"})

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -905,7 +905,7 @@ defmodule Supavisor.DbHandlerTest do
                )
     end
 
-    test "sends a SET application_name query" do
+    test "sends a parameterized set_config query" do
       {send, recv} = sockpair()
       from = {self(), make_ref()}
 
@@ -924,7 +924,8 @@ defmodule Supavisor.DbHandlerTest do
       assert new_data.pending_bin == <<>>
 
       assert {:ok, message} = :gen_tcp.recv(recv, 0, 1000)
-      assert message =~ "SET application_name = 'my app''s name'"
+      assert message =~ "SELECT set_config('application_name', $1, false)"
+      assert message =~ "my app's name"
 
       :gen_tcp.close(send)
       :gen_tcp.close(recv)

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -868,4 +868,145 @@ defmodule Supavisor.DbHandlerTest do
                Db.handle_event(:state_timeout, :cleanup_timeout, :waiting_cleanup, data)
     end
   end
+
+  describe "set_application_name/2" do
+    test "returns error when called on transaction mode" do
+      {send, recv} = sockpair()
+
+      data = %{sock: {:gen_tcp, send}, mode: :transaction}
+
+      assert {:keep_state_and_data,
+              {:reply, _from, {:error, :set_application_name_not_supported_in_transaction_mode}}} =
+               Db.handle_event(
+                 {:call, {self(), make_ref()}},
+                 {:set_application_name, "app"},
+                 :idle,
+                 data
+               )
+
+      :gen_tcp.close(send)
+      :gen_tcp.close(recv)
+    end
+
+    test "skips when called in invalid state" do
+      from = {self(), make_ref()}
+
+      data = %{mode: :session}
+
+      assert {:keep_state_and_data, {:reply, ^from, :ok}} =
+               Db.handle_event({:call, from}, {:set_application_name, "app"}, :idle, data)
+
+      assert {:keep_state_and_data, {:reply, ^from, :ok}} =
+               Db.handle_event(
+                 {:call, from},
+                 {:set_application_name, "app"},
+                 :authentication,
+                 data
+               )
+    end
+
+    test "sends a SET application_name query" do
+      {send, recv} = sockpair()
+      from = {self(), make_ref()}
+
+      data = %{sock: {:gen_tcp, send}, mode: :session}
+
+      assert {:next_state, :setting_application_name, new_data,
+              {:state_timeout, 5_000, :set_application_name_timeout}} =
+               Db.handle_event(
+                 {:call, from},
+                 {:set_application_name, "my app's name"},
+                 :busy,
+                 data
+               )
+
+      assert new_data.set_app_name_from == from
+      assert new_data.pending_bin == <<>>
+
+      assert {:ok, message} = :gen_tcp.recv(recv, 0, 1000)
+      assert message =~ "SET application_name = 'my app''s name'"
+
+      :gen_tcp.close(send)
+      :gen_tcp.close(recv)
+    end
+
+    test "swallows the response and replies :ok, returning to :busy" do
+      {send, recv} = sockpair()
+      from = {self(), make_ref()}
+
+      data = %{
+        sock: {:gen_tcp, send},
+        mode: :session,
+        set_app_name_from: from,
+        pending_bin: <<>>
+      }
+
+      content = {:tcp, recv, Server.ready_for_query()}
+
+      assert {:next_state, :busy, new_data, {:reply, ^from, :ok}} =
+               Db.handle_event(:info, content, :setting_application_name, data)
+
+      assert new_data.pending_bin == nil
+      assert new_data.set_app_name_from == nil
+
+      :gen_tcp.close(send)
+      :gen_tcp.close(recv)
+    end
+
+    test "buffers incomplete messages while waiting for ReadyForQuery" do
+      {send, recv} = sockpair()
+      from = {self(), make_ref()}
+
+      data = %{
+        sock: {:gen_tcp, send},
+        mode: :session,
+        set_app_name_from: from,
+        pending_bin: <<>>
+      }
+
+      partial_message = <<"partial">>
+      content = {:tcp, recv, partial_message}
+
+      assert {:keep_state, new_data} =
+               Db.handle_event(:info, content, :setting_application_name, data)
+
+      assert new_data.pending_bin == partial_message
+
+      :gen_tcp.close(send)
+      :gen_tcp.close(recv)
+    end
+
+    test "stops when buffer limit exceeded" do
+      {send, recv} = sockpair()
+      from = {self(), make_ref()}
+
+      data = %{
+        sock: {:gen_tcp, send},
+        mode: :session,
+        set_app_name_from: from,
+        pending_bin: <<>>
+      }
+
+      large_message = :binary.copy(<<1>>, 70_000)
+      content = {:tcp, recv, large_message}
+
+      assert {:stop, :normal} =
+               Db.handle_event(:info, content, :setting_application_name, data)
+
+      :gen_tcp.close(send)
+      :gen_tcp.close(recv)
+    end
+
+    test "stops on set application_name timeout" do
+      data = %{mode: :session}
+
+      assert {:stop, :normal} =
+               Db.handle_event(
+                 :state_timeout,
+                 :set_application_name_timeout,
+                 :setting_application_name,
+                 data
+               )
+    end
+  end
 end

--- a/test/supavisor/protocol/server_test.exs
+++ b/test/supavisor/protocol/server_test.exs
@@ -216,6 +216,18 @@ defmodule Supavisor.Protocol.ServerTest do
     assert Server.ready_for_query() == <<90, 0, 0, 0, 5, 73>>
   end
 
+  test "extended_query/2" do
+    statement = "SELECT set_config('application_name', $1, false)"
+    bin = Server.extended_query(statement, ["my app's name"])
+
+    assert <<?P, _::binary>> = bin
+
+    assert bin =~ statement
+    assert bin =~ "my app's name"
+
+    assert String.ends_with?(bin, Server.sync())
+  end
+
   test "decode_pkt/1 correctly maps all message tags" do
     tag_tests = [
       {82, :authentication, <<0, 0, 0, 0>>},


### PR DESCRIPTION
## What kind of change does this PR introduce?

A simple cosmetic, quality-of-life, better debuggability change. Names the specific backend connection to the client's application name.

## What is the current behavior?

Name is always "Supavisor". Makes sense in transaction mode.

## What is the new behavior?

Name is now what the client provides (in session mode). Makes sense in session-modes where we want to give them the feeling that they own the backend connection.

## Additional context

Closes #343 