### PR TITLE
chore: upgrade to v2.9.1 in eu-north-1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,7 +1,7 @@
 [
-    {upgrade_from, "2.9.1"},     % hard-deploy base of the cluster
+    {upgrade_from, "2.9.10"},     % hard-deploy base of the cluster
     {upgrade_previous, "2.9.8"}, % version currently running after the forward deploy
-    {upgrade_to, "2.9.1-rb"},    % -rb suffix bypasses elx_updater guards (/current == to_vsn and {service_dir}/{to_vsn} exists)
+    {upgrade_to, "2.9.1"},    % -rb suffix bypasses elx_updater guards (/current == to_vsn and {service_dir}/{to_vsn} exists)
     % list() | [<<"all">>]
     {regions, [
         <<"eu-north-1">>

--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.0"},     % hard-deploy base of the cluster
-    {upgrade_previous, "2.9.0"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.7"},       % target version
+    {upgrade_from, "2.9.1"},     % hard-deploy base of the cluster
+    {upgrade_previous, "2.9.8"}, % version currently running after the forward deploy
+    {upgrade_to, "2.9.1-rb"},    % -rb suffix bypasses elx_updater guards (/current == to_vsn and {service_dir}/{to_vsn} exists)
     % list() | [<<"all">>]
     {regions, [
-        <<"apne21">>
+        <<"eu-north-1">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for  #1042

The `-rb` tag suffix is not required as we rollout out a new AMI in this region.

The `v2.9.1` hard artifact built [here](https://github.com/supabase/supavisor/actions/runs/28779737915/job/85332206672).