### PR TITLE
fix(tenants): accept JSON boolean in toggle_tenant_ban to fix 500 on ban PATCH

### DIFF
--- a/lib/supavisor/tenants.ex
+++ b/lib/supavisor/tenants.ex
@@ -321,7 +321,7 @@ defmodule Supavisor.Tenants do
       nil ->
         {:error, :not_found}
 
-      tenant when banned? == "true" ->
+      tenant when banned? in [true, "true"] ->
         tenant
         |> Tenant.ban_changeset(params)
         |> Repo.update()
@@ -331,7 +331,7 @@ defmodule Supavisor.Tenants do
           terminate_error: %TenantBannedError{ban_reason: params["ban_reason"]}
         )
 
-      tenant when banned? == "false" ->
+      tenant when banned? in [false, "false"] ->
         tenant
         |> Tenant.unban_changeset(params)
         |> Repo.update()

--- a/lib/supavisor/tenants/tenant.ex
+++ b/lib/supavisor/tenants/tenant.ex
@@ -136,14 +136,14 @@ defmodule Supavisor.Tenants.Tenant do
   end
 
   @doc false
-  def ban_changeset(tenant, %{"banned" => "true"} = params) do
+  def ban_changeset(tenant, %{"banned" => banned} = params) when banned in [true, "true"] do
     tenant
     |> cast(params, [:ban_reason, :banned_until])
     |> validate_required([:ban_reason])
     |> put_change(:banned_at, DateTime.utc_now() |> DateTime.truncate(:second))
   end
 
-  def unban_changeset(tenant, %{"banned" => "false"}) do
+  def unban_changeset(tenant, %{"banned" => banned}) when banned in [false, "false"] do
     change(tenant, banned_at: nil, ban_reason: nil, banned_until: nil)
   end
 end

--- a/test/supavisor_web/controllers/tenant_controller_test.exs
+++ b/test/supavisor_web/controllers/tenant_controller_test.exs
@@ -616,6 +616,34 @@ defmodule SupavisorWeb.TenantControllerTest do
       assert diff >= 0 and diff < 5
     end
 
+    test "bans a tenant when banned is a JSON boolean true", %{
+      conn: conn,
+      tenant: %Tenant{external_id: external_id}
+    } do
+      assert %{data: %{external_id: ^external_id, banned_at: banned_at, ban_reason: "abuse"}} =
+               conn
+               |> patch(~p"/api/tenants/#{external_id}", %{banned: true, ban_reason: "abuse"})
+               |> json_response(200)
+               |> assert_schema("TenantData")
+
+      assert banned_at != nil
+    end
+
+    test "unbans a tenant when banned is a JSON boolean false", %{
+      conn: conn,
+      tenant: %Tenant{external_id: external_id}
+    } do
+      conn
+      |> patch(~p"/api/tenants/#{external_id}", %{banned: true, ban_reason: "abuse"})
+      |> json_response(200)
+
+      assert %{data: %{external_id: ^external_id, banned_at: nil, ban_reason: nil}} =
+               conn
+               |> patch(~p"/api/tenants/#{external_id}", %{banned: false})
+               |> json_response(200)
+               |> assert_schema("TenantData")
+    end
+
     test "returns 404 for non-existent tenant", %{conn: conn} do
       assert %{"error" => "not found"} =
                conn


### PR DESCRIPTION
While adding the Tenant Ban UI in Admin studio I ran into an error when adding a ban (related [issue](https://linear.app/supabase/issue/TOOLING-858/build-the-admin-studio-counterpart))

See [error log](https://logflare.app/sources/27048/event?timestamp=2026-06-25T12%3A34%3A08Z&uuid=dcbc0942-ea20-497a-9a37-4d20386e41fd&lql=ban+c%3Acount%28%2A%29+c%3Agroup_by%28t%3A%3Aminute%29)

This PR just make sure Supavisor API also allow JSON boolean (alongside string boolean)