### PR TITLE
chore: bump to v2.9.10 in ap-east-1-sec

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
     {upgrade_from, "2.9.0"},     % hard-deploy base of the cluster
     {upgrade_previous, "2.9.0"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.9"},       % target version
+    {upgrade_to, "2.9.10"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"use11-sec">>
+        <<"ap-east-1-sec">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
affects: https://github.com/supabase/platform/pull/34860
