### PR TITLE
Handle client socket errors on DbHandler, sweep zombie ports, hold check-in till flush complete

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -107,6 +107,7 @@ defmodule Supavisor.Application do
         Supavisor.ClientAuthentication.RefreshLimiter,
         Supavisor.CircuitBreaker.Janitor,
         Supavisor.ConnectBackoff.Janitor,
+        Supavisor.DeadPortSweeper,
         {Task.Supervisor, name: Supavisor.PoolTerminator},
         {Registry, keys: :unique, name: Supavisor.Registry.Tenants},
         {Registry, keys: :unique, name: Supavisor.Registry.ManagerTables},

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -515,7 +515,9 @@ defmodule Supavisor.ClientHandler do
   def handle_event(:cast, {:db_status, :ready_for_query}, :busy, data) do
     Logger.debug("ClientHandler: Client is ready")
 
-    db_connection = maybe_checkin(data.mode, data.pool, data.db_connection)
+    # In transaction mode the DbHandler checks itself back into the pool once
+    # it finishes forwarding the response; we only drop our reference to it.
+    db_connection = if data.mode == :transaction, do: nil, else: data.db_connection
 
     {_, stats} =
       if data.local,
@@ -860,18 +862,6 @@ defmodule Supavisor.ClientHandler do
         other
     end
   end
-
-  @spec maybe_checkin(:proxy, pool_pid :: pid(), Data.db_connection()) :: Data.db_connection()
-  defp maybe_checkin(:transaction, _pool, nil), do: nil
-
-  defp maybe_checkin(:transaction, pool, {_, db_pid, _}) do
-    Process.unlink(db_pid)
-    :poolboy.checkin(pool, db_pid)
-    nil
-  end
-
-  defp maybe_checkin(:session, _, db_connection), do: db_connection
-  defp maybe_checkin(:proxy, _, db_connection), do: db_connection
 
   @spec handle_data(binary(), map()) :: {:ok, map()} | {:error, Exception.t()}
   defp handle_data(data_to_send, data) do

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -832,14 +832,7 @@ defmodule Supavisor.DbHandler do
     secrets = data.connection_params.secrets
 
     {client_final_message, server_proof, derived_secrets} =
-      case Helpers.get_client_final(secrets, server_first_parts, nonce, secrets.user, "biws") do
-        {client_final_message, server_proof, derived_secrets} ->
-          {client_final_message, server_proof, derived_secrets}
-
-        # TODO: drop once v2.9.7 is everywhere
-        {client_final_message, server_proof} ->
-          {client_final_message, server_proof, nil}
-      end
+      Helpers.get_client_final(secrets, server_first_parts, nonce, secrets.user, "biws")
 
     bin = :pgo_protocol.encode_scram_response_message(client_final_message)
     :ok = HandlerHelpers.sock_send(data.sock, bin)

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -411,25 +411,30 @@ defmodule Supavisor.DbHandler do
       when is_pid(caller) and proto in @proto do
     Logger.debug("DbHandler: Got messages: #{Debug.packet_to_string(bin, :backend)}")
 
-    if String.ends_with?(bin, Server.ready_for_query()) do
-      ClientHandler.db_status(data.caller, :ready_for_query)
-      data = handle_server_messages(bin, data)
+    case handle_server_messages(bin, data) do
+      {:error, reason} ->
+        Logger.error("DbHandler: Failed to forward message to client: #{inspect(reason)}")
+        {:stop, :normal}
 
-      case data.mode do
-        :transaction ->
-          {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
-          {:next_state, :idle, %{data | stats: stats, caller: nil, client_sock: nil}}
+      {:ok, data} ->
+        if String.ends_with?(bin, Server.ready_for_query()) do
+          ClientHandler.db_status(data.caller, :ready_for_query)
 
-        :proxy ->
+          case data.mode do
+            :transaction ->
+              {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
+              {:next_state, :idle, %{data | stats: stats, caller: nil, client_sock: nil}}
+
+            :proxy ->
+              {:keep_state, data}
+
+            :session ->
+              {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
+              {:keep_state, %{data | stats: stats}}
+          end
+        else
           {:keep_state, data}
-
-        :session ->
-          {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
-          {:keep_state, %{data | stats: stats}}
-      end
-    else
-      data = handle_server_messages(bin, data)
-      {:keep_state, data}
+        end
     end
   end
 
@@ -892,21 +897,26 @@ defmodule Supavisor.DbHandler do
     Supavisor.UpstreamAuthentication.delete_upstream_auth_secrets(data.id)
   end
 
-  @spec handle_server_messages(binary(), map()) :: map()
+  @spec handle_server_messages(binary(), map()) :: {:ok, map()} | {:error, term()}
   defp handle_server_messages(bin, %{backend_message_streaming: true} = data) do
     {:ok, updated_data, to_send} = process_backend_streaming(bin, data)
 
     if to_send != [] do
-      client_send(data, to_send)
+      case client_send(data, to_send) do
+        :ok -> {:ok, updated_data}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      {:ok, updated_data}
     end
-
-    updated_data
   end
 
   # hot code reload compat: remove after full rollout
   defp handle_server_messages(bin, data) do
-    client_send(data, bin)
-    data
+    case client_send(data, bin) do
+      :ok -> {:ok, data}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   # libpq's async API hangs when a TLS record leaves bytes in OpenSSL's

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -176,6 +176,8 @@ defmodule Supavisor.DbHandler do
 
     storage_mod = BackendStorage.select(config.tenant_feature_flags)
 
+    pool = if pool_name = Map.get(args, :pool), do: GenServer.whereis(pool_name)
+
     data = %{
       id: id,
       sock: nil,
@@ -199,6 +201,7 @@ defmodule Supavisor.DbHandler do
       replica_type: config.replica_type,
       caller: nil,
       client_sock: nil,
+      pool: pool,
       terminating_error: nil,
       manager_ref: nil,
       derived_secrets: nil
@@ -411,18 +414,28 @@ defmodule Supavisor.DbHandler do
       when is_pid(caller) and proto in @proto do
     Logger.debug("DbHandler: Got messages: #{Debug.packet_to_string(bin, :backend)}")
 
+    ready_for_query? = String.ends_with?(bin, Server.ready_for_query())
+
+    # db_status must be enqueued in the ClientHandler's mailbox before
+    # ReadyForQuery reaches the client socket: the client sends its next query
+    # as soon as it reads ReadyForQuery, and if that query arrives while the
+    # ClientHandler is still :busy it gets forwarded to a connection the client
+    # no longer owns.
+    if ready_for_query?, do: ClientHandler.db_status(data.caller, :ready_for_query)
+
     case handle_server_messages(bin, data) do
       {:error, reason} ->
+        # Still linked to the ClientHandler (checkin is what unlinks), so
+        # stopping tears the client connection down with us.
         Logger.error("DbHandler: Failed to forward message to client: #{inspect(reason)}")
         {:stop, :normal}
 
       {:ok, data} ->
-        if String.ends_with?(bin, Server.ready_for_query()) do
-          ClientHandler.db_status(data.caller, :ready_for_query)
-
+        if ready_for_query? do
           case data.mode do
             :transaction ->
               {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
+              checkin(data)
               {:next_state, :idle, %{data | stats: stats, caller: nil, client_sock: nil}}
 
             :proxy ->
@@ -895,6 +908,22 @@ defmodule Supavisor.DbHandler do
     tenant = Supavisor.id(data.id, :tenant)
     Supavisor.ClientAuthentication.invalidate_global(tenant, data.user)
     Supavisor.UpstreamAuthentication.delete_upstream_auth_secrets(data.id)
+  end
+
+  # Returning to the pool only after the response is fully forwarded keeps
+  # workers flushing to slow clients out of circulation. If the caller died
+  # mid-send (link gone), poolboy's owner monitor already reclaimed the worker
+  # and may have handed it out, so checking in again would corrupt the pool.
+  @spec checkin(map()) :: :ok
+  defp checkin(%{caller: caller, pool: pool}) do
+    {:links, links} = Process.info(self(), :links)
+
+    if caller in links do
+      Process.unlink(caller)
+      :poolboy.checkin(pool, self())
+    end
+
+    :ok
   end
 
   @spec handle_server_messages(binary(), map()) :: {:ok, map()} | {:error, term()}

--- a/lib/supavisor/dead_port_sweeper.ex
+++ b/lib/supavisor/dead_port_sweeper.ex
@@ -1,7 +1,6 @@
 defmodule Supavisor.DeadPortSweeper do
   @moduledoc """
-  Periodically closes zombie TCP ports: connected sockets whose peer already
-  disconnected but whose port was never closed.
+  Periodically closes zombie TCP ports: ports for which the socket is closed
   """
 
   use GenServer

--- a/lib/supavisor/dead_port_sweeper.ex
+++ b/lib/supavisor/dead_port_sweeper.ex
@@ -1,0 +1,65 @@
+defmodule Supavisor.DeadPortSweeper do
+  @moduledoc """
+  Periodically closes zombie TCP ports: connected sockets whose peer already
+  disconnected but whose port was never closed.
+  """
+
+  use GenServer
+  require Logger
+
+  @interval :timer.hours(1)
+  @name __MODULE__
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: @name)
+  end
+
+  def sweep do
+    GenServer.cast(@name, :sweep)
+  end
+
+  @impl true
+  def init(_args) do
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_cast(:sweep, state) do
+    do_sweep()
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:sweep, state) do
+    do_sweep()
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  @doc false
+  def dead_port?(port) do
+    with {:name, ~c"tcp_inet"} <- :erlang.port_info(port, :name),
+         {:ok, flags} <- :prim_inet.getstatus(port) do
+      :inet.peername(port) == {:error, :enotconn} and :listen not in flags
+    else
+      _ -> false
+    end
+  end
+
+  defp do_sweep do
+    ports = Enum.filter(:recon.tcp(), &dead_port?/1)
+
+    Logger.notice("Closing #{length(ports)} dead port(s)")
+
+    {time, _} = :timer.tc(fn -> Enum.each(ports, &Port.close/1) end)
+
+    Logger.notice(
+      "Closed #{length(ports)} dead port(s) in #{:erlang.convert_time_unit(time, :microsecond, :millisecond)}ms"
+    )
+  end
+
+  defp schedule_sweep do
+    Process.send_after(self(), :sweep, @interval)
+  end
+end

--- a/lib/supavisor/tenant_supervisor.ex
+++ b/lib/supavisor/tenant_supervisor.ex
@@ -25,12 +25,13 @@ defmodule Supavisor.TenantSupervisor do
       |> Enum.with_index()
       |> Enum.map(fn {e, i} ->
         id = {:pool, e.replica_type, i, args.id}
+        name = {:via, Registry, {Supavisor.Registry.Tenants, id, e.replica_type}}
 
         %{
           id: {:pool, id},
           start:
             {:poolboy, :start_link,
-             [pool_spec(id, e.replica_type, min_size, e.pool_size), %{id: args.id}]},
+             [pool_spec(name, min_size, e.pool_size), %{id: args.id, pool: name}]},
           restart: :temporary,
           type: :supervisor
         }
@@ -67,10 +68,10 @@ defmodule Supavisor.TenantSupervisor do
     }
   end
 
-  @spec pool_spec(tuple, atom, integer, integer) :: Keyword.t()
-  defp pool_spec(id, replica_type, min_size, pool_size) do
+  @spec pool_spec(tuple, integer, integer) :: Keyword.t()
+  defp pool_spec(name, min_size, pool_size) do
     [
-      name: {:via, Registry, {Supavisor.Registry.Tenants, id, replica_type}},
+      name: name,
       worker_module: Supavisor.DbHandler,
       size: min_size,
       max_overflow: pool_size,

--- a/mix.exs
+++ b/mix.exs
@@ -69,6 +69,7 @@ defmodule Supavisor.MixProject do
       {:cachex, "~> 3.6"},
       {:inet_cidr, "~> 1.0.0"},
       {:observer_cli, "~> 1.7"},
+      {:recon, "~> 2.5"},
 
       # pooller
       # {:poolboy, "~> 1.5.2"},

--- a/priv/repo/seeds_after_migration.exs
+++ b/priv/repo/seeds_after_migration.exs
@@ -120,6 +120,28 @@ if !Tenants.get_tenant_by_external_id("proxy_pool_tenant") do
     |> Tenants.create_tenant()
 end
 
+if !Tenants.get_tenant_by_external_id("dead_port_repro_tenant") do
+  {:ok, _} =
+    %{
+      db_host: db_conf[:hostname],
+      db_port: db_conf[:port],
+      db_database: db_conf[:database],
+      default_parameter_status: %{},
+      external_id: "dead_port_repro_tenant",
+      require_user: true,
+      users: [
+        %{
+          "db_user" => db_conf[:username],
+          "db_password" => db_conf[:password],
+          "pool_size" => 1,
+          "max_clients" => 100,
+          "mode_type" => "transaction"
+        }
+      ]
+    }
+    |> Tenants.create_tenant()
+end
+
 # Create tenants with specific prepared statements feature flag settings for transaction mode
 [
   {"proxy_tenant_ps_enabled", %{"named_prepared_statements" => true}},

--- a/test/integration/dead_client_port_test.exs
+++ b/test/integration/dead_client_port_test.exs
@@ -32,8 +32,8 @@ defmodule Supavisor.Integration.DeadClientPortTest do
     {_state, %{sock: {:gen_tcp, client_port}}} = :sys.get_state(client_pid)
 
     # This query returns >50MB. Since we aren't reading the output at all, this will
-    # eventually fill the buffers on DbHandler and cause a send timeout, which causes
-    # the socket to be killed
+    # eventually fill the tcp stack buffers and cause a send timeout, which causes
+    # the socket to be killed by the send_timeout_close option
     query = "SELECT repeat('a', 1000000) FROM generate_series(1, 50)"
     :ok = :gen_tcp.send(sock, :pgo_protocol.encode_query_message(query))
 
@@ -48,15 +48,9 @@ defmodule Supavisor.Integration.DeadClientPortTest do
 
   defp wait_for_client_handler_pid(id) do
     wait_until_present(fn ->
-      manager = Supavisor.get_local_manager(id)
-
-      if manager do
-        tid = Access.get(:sys.get_state(manager), :tid)
-
-        case :ets.tab2list(tid) do
-          [{_, client_pid, _}] -> client_pid
-          _ -> nil
-        end
+      case Registry.lookup(Supavisor.Registry.TenantClients, id) do
+        [{client_pid, _}] -> client_pid
+        _ -> nil
       end
     end)
   end

--- a/test/integration/dead_client_port_test.exs
+++ b/test/integration/dead_client_port_test.exs
@@ -1,0 +1,74 @@
+defmodule Supavisor.Integration.DeadClientPortTest do
+  use Supavisor.DataCase, async: true
+
+  require Supavisor
+
+  alias Supavisor.Support.ProtocolClient
+
+  @tenant "dead_port_repro_tenant"
+
+  test "unresponsive client is killed upon send timeout" do
+    db_conf = Application.get_env(:supavisor, Supavisor.Repo)
+    port = Application.get_env(:supavisor, :proxy_port_transaction)
+
+    id =
+      Supavisor.id(
+        type: :single,
+        tenant: @tenant,
+        user: db_conf[:username],
+        mode: :transaction,
+        db: nil
+      )
+
+    {:ok, sock} = :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false])
+
+    user = "#{db_conf[:username]}.#{@tenant}"
+    password = db_conf[:password]
+
+    ProtocolClient.authenticate(sock, user, password)
+
+    client_pid = wait_for_client_handler_pid(id)
+    ref = Process.monitor(client_pid)
+    {_state, %{sock: {:gen_tcp, client_port}}} = :sys.get_state(client_pid)
+
+    # This query returns >50MB. Since we aren't reading the output at all, this will
+    # eventually fill the buffers on DbHandler and cause a send timeout, which causes
+    # the socket to be killed
+    query = "SELECT repeat('a', 1000000) FROM generate_series(1, 50)"
+    :ok = :gen_tcp.send(sock, :pgo_protocol.encode_query_message(query))
+
+    assert :ok = wait_until(fn -> :inet.peername(client_port) == {:error, :enotconn} end, 35_000)
+
+    assert_receive {:DOWN, ^ref, :process, ^client_pid, _reason}, 5_000
+  end
+
+  defp wait_for_client_handler_pid(id) do
+    wait_until_present(fn ->
+      manager = Supavisor.get_local_manager(id)
+
+      if manager do
+        tid = Access.get(:sys.get_state(manager), :tid)
+
+        case :ets.tab2list(tid) do
+          [{_, client_pid, _}] -> client_pid
+          _ -> nil
+        end
+      end
+    end)
+  end
+
+  defp wait_until_present(fun, attempts \\ 100)
+
+  defp wait_until_present(_fun, 0), do: flunk("value never became present")
+
+  defp wait_until_present(fun, attempts) do
+    case fun.() do
+      nil ->
+        Process.sleep(50)
+        wait_until_present(fun, attempts - 1)
+
+      value ->
+        value
+    end
+  end
+end

--- a/test/integration/dead_client_port_test.exs
+++ b/test/integration/dead_client_port_test.exs
@@ -37,7 +37,11 @@ defmodule Supavisor.Integration.DeadClientPortTest do
     query = "SELECT repeat('a', 1000000) FROM generate_series(1, 50)"
     :ok = :gen_tcp.send(sock, :pgo_protocol.encode_query_message(query))
 
-    assert :ok = wait_until(fn -> :inet.peername(client_port) == {:error, :enotconn} end, 35_000)
+    assert :ok =
+             wait_until(
+               fn -> :inet.peername(client_port) in [{:error, :enotconn}, {:error, :einval}] end,
+               35_000
+             )
 
     assert_receive {:DOWN, ^ref, :process, ^client_pid, _reason}, 5_000
   end

--- a/test/integration/protocol_integration_test.exs
+++ b/test/integration/protocol_integration_test.exs
@@ -2,6 +2,7 @@ defmodule Supavisor.Integration.ProtocolIntegrationTest do
   use Supavisor.DataCase, async: false
 
   alias Supavisor.Protocol.Server
+  alias Supavisor.Support.ProtocolClient
   require Server
 
   @tenants ["proxy_tenant_ps_enabled", "proxy_tenant_ps_disabled"]
@@ -90,7 +91,7 @@ defmodule Supavisor.Integration.ProtocolIntegrationTest do
         Supavisor.Protocol.split_pkts(auth_data)
 
       {:ok, ^server_proof} = :pgo_scram.parse_server_final(server_final)
-      recv_until_ready_for_query(sock, auth_data)
+      ProtocolClient.recv_until_ready_for_query(sock, auth_data)
 
       # Verify the connection defaults to the correct database
       :ok = :gen_tcp.send(sock, :pgo_protocol.encode_query_message("SELECT current_database()"))
@@ -213,16 +214,5 @@ defmodule Supavisor.Integration.ProtocolIntegrationTest do
     #   # 3 = AuthenticationCleartextPassword
     #   assert auth_type == 3
     # end
-  end
-
-  defp recv_until_ready_for_query(sock, buf) do
-    {pkts, ""} = Supavisor.Protocol.split_pkts(buf)
-
-    if Enum.any?(pkts, &match?(<<?Z, _::binary>>, &1)) do
-      :ok
-    else
-      {:ok, more} = :gen_tcp.recv(sock, 0, 5000)
-      recv_until_ready_for_query(sock, more)
-    end
   end
 end

--- a/test/supavisor/dead_port_sweeper_test.exs
+++ b/test/supavisor/dead_port_sweeper_test.exs
@@ -1,0 +1,144 @@
+defmodule Supavisor.DeadPortSweeperTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  alias Supavisor.DeadPortSweeper
+
+  describe "dead_port?/1" do
+    test "is true for a socket whose peer is gone but the port is still open" do
+      server = make_dead_port()
+
+      assert DeadPortSweeper.dead_port?(server)
+    end
+
+    test "is false for a healthy connected socket" do
+      {client, server} = sockpair()
+
+      refute DeadPortSweeper.dead_port?(client)
+      refute DeadPortSweeper.dead_port?(server)
+    end
+
+    test "is false for a listening socket" do
+      {:ok, listen} = :gen_tcp.listen(0, mode: :binary, active: false)
+
+      refute DeadPortSweeper.dead_port?(listen)
+    end
+
+    test "is false for a non-tcp port" do
+      port = Port.open({:spawn, "cat"}, [:binary])
+
+      refute DeadPortSweeper.dead_port?(port)
+    end
+  end
+
+  describe "sweep/0" do
+    test "closes dead ports and logs how many were closed" do
+      dead = make_dead_port()
+      {client, server} = sockpair()
+
+      log =
+        capture_log(fn ->
+          DeadPortSweeper.sweep()
+          wait_until_closed(dead)
+        end)
+
+      assert log =~ "Closing 1 dead port(s)"
+      assert log =~ ~r/Closed 1 dead port\(s\) in \d+ms/
+      refute Port.info(dead)
+
+      assert Port.info(client)
+      assert Port.info(server)
+    end
+
+    test "logs zero when there is nothing to sweep" do
+      log =
+        capture_log(fn ->
+          DeadPortSweeper.sweep()
+          Process.sleep(50)
+        end)
+
+      assert log =~ "Closing 0 dead port(s)"
+      assert log =~ ~r/Closed 0 dead port\(s\) in \d+ms/
+    end
+  end
+
+  # Reproduces the documented Erlang bug this sweeper works around: a TCP
+  # socket configured with send_timeout + send_timeout_close closes its
+  # underlying connection on a send timeout, but the port itself is left
+  # open, so :inet.peername/1 reports :enotconn forever after.
+  defp make_dead_port do
+    {:ok, listen} =
+      :gen_tcp.listen(0,
+        mode: :binary,
+        active: false,
+        send_timeout: 100,
+        send_timeout_close: true
+      )
+
+    {:ok, {address, port}} = :inet.sockname(listen)
+    this = self()
+    ref = make_ref()
+
+    spawn(fn ->
+      {:ok, server} = :gen_tcp.accept(listen)
+      :gen_tcp.controlling_process(server, this)
+      send(this, {ref, server})
+    end)
+
+    {:ok, _client} = :gen_tcp.connect(address, port, mode: :binary, active: false)
+    assert_receive {^ref, server}
+
+    # The client never reads, so the server's send buffer fills and the
+    # configured send_timeout fires, killing the connection underneath the
+    # still-open server port.
+    flood_until_dead(server)
+
+    server
+  end
+
+  defp flood_until_dead(server, attempts \\ 200)
+
+  defp flood_until_dead(_server, 0) do
+    flunk("gave up waiting for the send-timeout bug to leave the port dead")
+  end
+
+  defp flood_until_dead(server, attempts) do
+    chunk = :crypto.strong_rand_bytes(65_536)
+
+    case :gen_tcp.send(server, chunk) do
+      :ok -> flood_until_dead(server, attempts - 1)
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp wait_until_closed(port, attempts \\ 50)
+
+  defp wait_until_closed(_port, 0), do: flunk("port was not closed by the sweep")
+
+  defp wait_until_closed(port, attempts) do
+    if Port.info(port) do
+      Process.sleep(20)
+      wait_until_closed(port, attempts - 1)
+    else
+      :ok
+    end
+  end
+
+  defp sockpair do
+    {:ok, listen} = :gen_tcp.listen(0, mode: :binary, active: false)
+    {:ok, {address, port}} = :inet.sockname(listen)
+    this = self()
+    ref = make_ref()
+
+    spawn(fn ->
+      {:ok, server} = :gen_tcp.accept(listen)
+      :gen_tcp.controlling_process(server, this)
+      send(this, {ref, server})
+    end)
+
+    {:ok, client} = :gen_tcp.connect(address, port, mode: :binary, active: false)
+    assert_receive {^ref, server}
+
+    {client, server}
+  end
+end

--- a/test/supavisor/dead_port_sweeper_test.exs
+++ b/test/supavisor/dead_port_sweeper_test.exs
@@ -62,7 +62,7 @@ defmodule Supavisor.DeadPortSweeperTest do
     end
   end
 
-  # Reproduces the documented Erlang bug this sweeper works around: a TCP
+  # Reproduces the documented Erlang behaviour this sweeper works around: a TCP
   # socket configured with send_timeout + send_timeout_close closes its
   # underlying connection on a send timeout, but the port itself is left
   # open, so :inet.peername/1 reports :enotconn forever after.

--- a/test/support/protocol_client.ex
+++ b/test/support/protocol_client.ex
@@ -1,0 +1,56 @@
+defmodule Supavisor.Support.ProtocolClient do
+  @moduledoc """
+  Minimal raw-socket Postgres wire protocol helpers, for tests that need a
+  real proxied connection without going through Postgrex/pgo.
+  """
+
+  @doc """
+  Performs the SCRAM-SHA-256 handshake on `sock` and reads until
+  ReadyForQuery. `sock` must already be connected, in passive mode.
+  """
+  def authenticate(sock, user, password) do
+    startup = :pgo_protocol.encode_startup_message([{"user", user}])
+    :ok = :gen_tcp.send(sock, startup)
+
+    {:ok, <<?R, _::32, 10::32, _methods_bin::binary>>} = :gen_tcp.recv(sock, 0, 5000)
+
+    nonce = :pgo_scram.get_nonce(16)
+    client_first = :pgo_scram.get_client_first(user, nonce)
+    client_first_size = :erlang.iolist_size(client_first)
+    sasl_initial = ["SCRAM-SHA-256", 0, <<client_first_size::32>>, client_first]
+    :ok = :gen_tcp.send(sock, :pgo_protocol.encode_scram_response_message(sasl_initial))
+
+    {:ok, <<?R, _::32, 11::32, server_first::binary>>} = :gen_tcp.recv(sock, 0, 5000)
+    server_first_parts = :pgo_scram.parse_server_first(server_first, nonce)
+
+    {client_final, server_proof} =
+      :pgo_scram.get_client_final(server_first_parts, nonce, user, password)
+
+    :ok = :gen_tcp.send(sock, :pgo_protocol.encode_scram_response_message(client_final))
+
+    {:ok, auth_data} = :gen_tcp.recv(sock, 0, 5000)
+    recv_until_ready_for_query(sock, auth_data)
+
+    server_proof
+  end
+
+  @doc """
+  Reads from `sock` until a ReadyForQuery packet is seen in the accumulated
+  buffer, starting from an already-received `buf`.
+  """
+  def recv_until_ready_for_query(sock, buf) do
+    case Supavisor.Protocol.split_pkts(buf) do
+      {pkts, ""} ->
+        if Enum.any?(pkts, &match?(<<?Z, _::binary>>, &1)) do
+          :ok
+        else
+          {:ok, more} = :gen_tcp.recv(sock, 0, 5000)
+          recv_until_ready_for_query(sock, more)
+        end
+
+      _ ->
+        {:ok, more} = :gen_tcp.recv(sock, 0, 5000)
+        recv_until_ready_for_query(sock, buf <> more)
+    end
+  end
+end


### PR DESCRIPTION
When the timeout closes ({send_timeout_close, true} (a ranch default)) are triggered in the inet backend, the underlying TCP socket is closed, but there's no notification to the owner process, and the port stays alive.

We must then make sure that when we get the timeout error from send, we adequately react and the relevant processes are terminated. The DbHandler didn't check the return value when writing to the client, and when timing out would cause zombie ports+client handlers, which could even hold a database session, and potentially create long transactions. I reproduced this scenario in a test.

This doesn't apply to the upstream sockets to database, which don't use this option.

The dead port sweeper is cherry picked from https://github.com/supabase/supavisor/pull/1056, which was the bug mitigation targeted at the current v2.9 release.

Also addresses a related race condition that could cause a DbHandler that is busy flushing data to a slow client to be checked out by another client if (and only if) the query had already completed from the DbHandler perspective. This was fixed by making the DbHandler checkin itself when its work is complete, instead of relying on the ClientHandler to check it in.I don't expect this to make much of a difference in real life, but its a more correct behaviour.