### PR TITLE
chore: upgrade to v2.9.10 in ap-southeast-1-sec and ap-southeast-2-sec

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,11 @@
 [
-    {upgrade_from, "2.9.1"},     % hard-deploy base of the cluster
-    {upgrade_previous, "2.9.1"}, % version currently running (relup is built from this)
+    {upgrade_from, "2.9.4"},     % hard-deploy base of the cluster
+    {upgrade_previous, "2.9.4"}, % version currently running (relup is built from this)
     {upgrade_to, "2.9.10"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"eu-north-1">>
+        <<"ap-southeast-1-sec">>,
+        <<"ap-southeast-2-sec">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
https://linear.app/supabase/issue/POOLER-542
https://linear.app/supabase/issue/POOLER-405

Hard deploy v2.9.10 to `ap-southeast-1-sec` (from v2.9.4) and `ap-southeast-2-sec` (from v2.9.0).

elx_updater is disabled — this PR only triggers artifact builds; platform PRs handle the actual instance replacement.

Rollbacks:
- ap-southeast-1-sec: https://github.com/supabase/supavisor/pull/1063
- ap-southeast-2-sec: https://github.com/supabase/supavisor/pull/1064