### PR TITLE
chore: rollback ap-southeast-1-sec to v2.9.4

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.1"},     % hard-deploy base of the cluster
-    {upgrade_previous, "2.9.1"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.10"},       % target version
+    {upgrade_from, "2.9.10"},     % hard-deploy base of the cluster
+    {upgrade_previous, "2.9.4"}, % version currently running (relup is built from this)
+    {upgrade_to, "2.9.4"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"eu-north-1">>
+        <<"ap-southeast-1-sec">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for supabase/supavisor#1062.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the ap-southeast-1-sec upgrade.**