### PR TITLE
chore: rollback cac11 to v2.9.2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,11 +1,10 @@
 [
-    {upgrade_from, "2.9.4"},     % hard-deploy base of the cluster
+    {upgrade_from, "2.9.10"},     % hard-deploy base of the cluster
     {upgrade_previous, "2.9.4"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.10"},       % target version
+    {upgrade_to, "2.9.4"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"ap-southeast-1-sec">>,
-        <<"ap-southeast-2-sec">>
+        <<"cac11">>
             ]},
     % :soft | :hard
     {type, hard}

--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,7 +1,7 @@
 [
     {upgrade_from, "2.9.10"},     % hard-deploy base of the cluster
-    {upgrade_previous, "2.9.4"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.4"},       % target version
+    {upgrade_previous, "2.9.2"}, % version currently running (relup is built from this)
+    {upgrade_to, "2.9.2"},       % target version
     % list() | [<<"all">>]
     {regions, [
         <<"cac11">>


### PR DESCRIPTION
Standby rollback for https://github.com/supabase/supavisor/pull/1065.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the cac11 upgrade.**