### PR TITLE
fix(client_handler): wire in client_idle_timeout

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -418,7 +418,7 @@ defmodule Supavisor.ClientHandler do
     {:keep_state_and_data, {:next_event, :internal, {:greetings, ps}}}
   end
 
-  def handle_event(:timeout, :idle_terminate, _state, data) do
+  def handle_event(:state_timeout, :idle_terminate, _state, data) do
     Logger.warning("ClientHandler: Terminate an idle connection by #{data.idle_timeout} timeout")
     {:stop, :normal}
   end
@@ -638,23 +638,14 @@ defmodule Supavisor.ClientHandler do
         {:next_state, new_state, data}
 
       {:busy, :idle} ->
-        {:next_state, new_state, data}
+        {:next_state, new_state, data, idle_timeout_action(data)}
+
+      {_, :idle} ->
+        {:next_state, new_state, record_state_duration(old_state, new_state, data),
+         idle_timeout_action(data)}
 
       _ ->
-        now = System.monotonic_time()
-        time_in_previous_state = now - data.state_entered_at
-
-        :telemetry.execute(
-          [:supavisor, :client_handler, :state],
-          %{duration: time_in_previous_state},
-          %{
-            from_state: old_state,
-            to_state: new_state,
-            tenant: data.tenant
-          }
-        )
-
-        {:next_state, new_state, %{data | state_entered_at: now}}
+        {:next_state, new_state, record_state_duration(old_state, new_state, data)}
     end
   end
 
@@ -891,14 +882,26 @@ defmodule Supavisor.ClientHandler do
 
   @spec handle_actions(map) :: [{:timeout, non_neg_integer, atom}]
   defp handle_actions(%{} = data) do
-    heartbeat =
-      if data.heartbeat_interval > 0,
-        do: [{:timeout, data.heartbeat_interval, :heartbeat_check}],
-        else: []
+    if data.heartbeat_interval > 0,
+      do: [{:timeout, data.heartbeat_interval, :heartbeat_check}],
+      else: []
+  end
 
-    idle = if data.idle_timeout > 0, do: [{:timeout, data.idle_timeout, :idle_timeout}], else: []
+  defp idle_timeout_action(%{idle_timeout: timeout}) when timeout > 0,
+    do: [{:state_timeout, timeout, :idle_terminate}]
 
-    idle ++ heartbeat
+  defp idle_timeout_action(_data), do: []
+
+  defp record_state_duration(old_state, new_state, data) do
+    now = System.monotonic_time()
+
+    :telemetry.execute(
+      [:supavisor, :client_handler, :state],
+      %{duration: now - data.state_entered_at},
+      %{from_state: old_state, to_state: new_state, tenant: data.tenant}
+    )
+
+    %{data | state_entered_at: now}
   end
 
   @spec client_sock_send(map(), iodata(), :handshake | :idle) ::

--- a/test/integration/client_idle_timeout_test.exs
+++ b/test/integration/client_idle_timeout_test.exs
@@ -1,0 +1,106 @@
+defmodule Supavisor.Integration.ClientIdleTimeoutTest do
+  use Supavisor.DataCase, async: false
+
+  @moduletag :integration
+
+  @idle_timeout_ms 1000
+
+  setup do
+    %{db_conf: Application.get_env(:supavisor, Supavisor.Repo)}
+  end
+
+  test "server disconnects a client that sits idle past client_idle_timeout", %{db_conf: db_conf} do
+    {:gen_tcp, sock} = db_conf |> idle_tenant() |> scram_connect()
+
+    assert {:error, :closed} = :gen_tcp.recv(sock, 0, @idle_timeout_ms * 5)
+  end
+
+  # Creates a require_user tenant with client_idle_timeout set.
+  defp idle_tenant(db_conf) do
+    suffix = :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
+    tenant_id = "idle_timeout_#{System.unique_integer([:positive])}_#{suffix}"
+
+    {:ok, _} =
+      Supavisor.Tenants.create_tenant(%{
+        db_host: db_conf[:hostname],
+        db_port: db_conf[:port],
+        db_database: db_conf[:database],
+        external_id: tenant_id,
+        require_user: true,
+        default_parameter_status: %{"server_version" => "15.0"},
+        client_idle_timeout: @idle_timeout_ms,
+        client_heartbeat_interval: 0,
+        users: [
+          %{
+            "db_user" => db_conf[:username],
+            "db_password" => db_conf[:password],
+            "pool_size" => 2,
+            "max_clients" => 10,
+            "mode_type" => "transaction",
+            "is_manager" => true
+          }
+        ]
+      })
+
+    on_exit(fn -> Supavisor.Tenants.delete_tenant_by_external_id(tenant_id) end)
+
+    %{
+      tenant: tenant_id,
+      port: Application.get_env(:supavisor, :proxy_port_transaction),
+      user: db_conf[:username],
+      password: db_conf[:password],
+      database: to_string(db_conf[:database])
+    }
+  end
+
+  defp scram_connect(%{tenant: tenant, port: port, user: user, password: password, database: db}) do
+    {:ok, sock} = :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false])
+
+    startup =
+      :pgo_protocol.encode_startup_message([{"user", "#{user}.#{tenant}"}, {"database", db}])
+
+    :ok = :gen_tcp.send(sock, startup)
+
+    # SASL auth request
+    {:ok, <<?R, _::32, 10::32, _methods::binary>>} = :gen_tcp.recv(sock, 0, 5000)
+
+    # SCRAM client-first
+    nonce = :pgo_scram.get_nonce(16)
+    client_first = :pgo_scram.get_client_first(user, nonce)
+    client_first_size = :erlang.iolist_size(client_first)
+    sasl_initial = ["SCRAM-SHA-256", 0, <<client_first_size::32>>, client_first]
+    :ok = :gen_tcp.send(sock, :pgo_protocol.encode_scram_response_message(sasl_initial))
+
+    # SCRAM server-first
+    {:ok, <<?R, _::32, 11::32, server_first::binary>>} = :gen_tcp.recv(sock, 0, 5000)
+    server_first_parts = :pgo_scram.parse_server_first(server_first, nonce)
+
+    # SCRAM client-final
+    {client_final, server_proof} =
+      :pgo_scram.get_client_final(server_first_parts, nonce, user, password)
+
+    :ok = :gen_tcp.send(sock, :pgo_protocol.encode_scram_response_message(client_final))
+
+    # SCRAM server-final + auth ok + params + ReadyForQuery
+    {:ok, auth_data} = :gen_tcp.recv(sock, 0, 5000)
+
+    {[<<?R, _::32, 12::32, server_final::binary>> | _], ""} =
+      Supavisor.Protocol.split_pkts(auth_data)
+
+    {:ok, ^server_proof} = :pgo_scram.parse_server_final(server_final)
+    recv_until_ready_for_query(sock, auth_data)
+
+    {:gen_tcp, sock}
+  end
+
+  defp recv_until_ready_for_query(sock, buf) do
+    {pkts, ""} = Supavisor.Protocol.split_pkts(buf)
+
+    if Enum.any?(pkts, &match?(<<?Z, _::binary>>, &1)) do
+      :ok
+    else
+      {:ok, more} = :gen_tcp.recv(sock, 0, 5000)
+      recv_until_ready_for_query(sock, more)
+    end
+  end
+end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: Fixes and wires in the broken `client_idle_timeout` functionality.

## What is the current behavior?

`client_idle_timeout` silently does nothing. Idle connections are never being closed. The client_handler gen_statem has been firing a mismatched timeout event since #377.

## What is the new behavior?

Fixed the mismatch and also decoupled the timer to a state timeout, which makes more sense semantically and avoids the messy mix-up with the heartbeat timer. The heartbeat timer keeps using the event timeout.

## Additional context

Also stitched a simple integration test for this, taking help from helpers in `protocol_integration_test.exs`.
