### PR TITLE
feat(monitoring): expose disk space usage via os_mon

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -42,6 +42,7 @@ The exposed metrics include the following:
   * CPU utilization
   * RAM usage
   * Load average (LA)
+  * Disk space usage (per mountpoint)
 
 ## Tenant metrics
 

--- a/lib/supavisor/monitoring/osmon.ex
+++ b/lib/supavisor/monitoring/osmon.ex
@@ -10,6 +10,7 @@ defmodule Supavisor.PromEx.Plugins.OsMon do
   @event_ram_usage [:prom_ex, :plugin, :osmon, :ram_usage]
   @event_cpu_util [:prom_ex, :plugin, :osmon, :cpu_util]
   @event_cpu_la [:prom_ex, :plugin, :osmon, :cpu_avg1]
+  @event_disk [:prom_ex, :plugin, :osmon, :disk]
   @prefix [:supavisor, :prom_ex]
 
   @impl true
@@ -99,6 +100,29 @@ defmodule Supavisor.PromEx.Plugins.OsMon do
           event_name: @event_cpu_la,
           description: "The average system load in the last 15 minutes.",
           measurement: :avg15
+        ),
+        last_value(
+          @prefix ++ [:osmon, :disk, :total],
+          event_name: @event_disk,
+          description: "The total size of the file system.",
+          unit: :bytes,
+          measurement: :total,
+          tags: [:mountpoint]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :disk, :available],
+          event_name: @event_disk,
+          description: "The available space on the file system.",
+          unit: :bytes,
+          measurement: :available,
+          tags: [:mountpoint]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :disk, :used_percent],
+          event_name: @event_disk,
+          description: "The percentage of used space on the file system.",
+          measurement: :capacity,
+          tags: [:mountpoint]
         )
       ]
     )
@@ -109,10 +133,17 @@ defmodule Supavisor.PromEx.Plugins.OsMon do
     execute_metrics(@event_ram_usage, %{ram: ram_usage()})
     execute_metrics(@event_cpu_util, %{cpu: cpu_util()})
     execute_metrics(@event_cpu_la, cpu_la())
+    execute_disk_metrics()
   end
 
   def execute_metrics(event, metrics) do
     :telemetry.execute(event, metrics, %{})
+  end
+
+  def execute_disk_metrics do
+    Enum.each(disk(), fn {mountpoint, measurements} ->
+      :telemetry.execute(@event_disk, measurements, %{mountpoint: mountpoint})
+    end)
   end
 
   @spec ram_usage() :: float()
@@ -147,5 +178,17 @@ defmodule Supavisor.PromEx.Plugins.OsMon do
   @spec cpu_util() :: float() | {:error, term()}
   def cpu_util do
     :cpu_sup.util()
+  end
+
+  @spec disk() :: [{String.t(), %{total: integer(), available: integer(), capacity: integer()}}]
+  def disk do
+    for {id, total_kib, available_kib, capacity} <- :disksup.get_disk_info() do
+      {to_string(id),
+       %{
+         total: total_kib * 1024,
+         available: available_kib * 1024,
+         capacity: capacity
+       }}
+    end
   end
 end

--- a/test/supavisor/monitoring/osmon_test.exs
+++ b/test/supavisor/monitoring/osmon_test.exs
@@ -1,0 +1,123 @@
+defmodule Supavisor.PromEx.Plugins.OsMonTest do
+  use Supavisor.E2ECase, async: false
+
+  alias Supavisor.PromEx.Plugins.OsMon
+
+  @moduletag telemetry: true
+
+  describe "polling_metrics/1" do
+    test "properly exports metrics" do
+      for polling_metric <- OsMon.polling_metrics([]) do
+        assert %PromEx.MetricTypes.Polling{metrics: [_ | _]} = polling_metric
+        {m, f, a} = polling_metric.measurements_mfa
+        assert function_exported?(m, f, length(a))
+
+        for telemetry_metric <- polling_metric.metrics do
+          assert Enum.any?(
+                   [
+                     Telemetry.Metrics.Distribution,
+                     Telemetry.Metrics.Counter,
+                     Telemetry.Metrics.LastValue,
+                     Telemetry.Metrics.Sum
+                   ],
+                   fn struct -> is_struct(telemetry_metric, struct) end
+                 )
+
+          assert telemetry_metric.description
+        end
+      end
+    end
+
+    test "uses poll rate option" do
+      for polling_metric <- OsMon.polling_metrics(poll_rate: 1000) do
+        assert %{poll_rate: 1000} = polling_metric
+      end
+    end
+  end
+
+  describe "disk metric definitions" do
+    test "defines total/available/used_percent tagged by mountpoint" do
+      metrics =
+        OsMon.polling_metrics([])
+        |> Enum.flat_map(& &1.metrics)
+
+      for suffix <- [:total, :available, :used_percent] do
+        name = [:supavisor, :prom_ex, :osmon, :disk, suffix]
+        metric = Enum.find(metrics, &(&1.name == name))
+
+        assert metric, "expected a disk #{suffix} metric named #{inspect(name)}"
+        assert metric.tags == [:mountpoint]
+      end
+    end
+  end
+
+  describe "disk/0" do
+    test "returns byte totals and capacity per mountpoint" do
+      assert [_ | _] = disks = OsMon.disk()
+
+      for {mountpoint, measurements} <- disks do
+        assert is_binary(mountpoint)
+
+        assert %{total: total, available: available, capacity: capacity} = measurements
+        assert is_integer(total) and total >= 0
+        assert is_integer(available) and available >= 0
+        assert available <= total
+        assert capacity in 0..100
+      end
+    end
+  end
+
+  describe "execute_disk_metrics/0" do
+    test "emits one disk event per filesystem, each tagged with its mountpoint" do
+      ref = attach_handler([:prom_ex, :plugin, :osmon, :disk])
+
+      assert :ok = OsMon.execute_disk_metrics()
+
+      events = drain_events(ref)
+      assert length(events) >= 1
+
+      for {measurement, meta} <- events do
+        assert %{total: total, available: available, capacity: capacity} = measurement
+        assert is_integer(total)
+        assert is_integer(available)
+        assert capacity in 0..100
+
+        assert %{mountpoint: mountpoint} = meta
+        assert is_binary(mountpoint)
+      end
+
+      mountpoints = Enum.map(events, fn {_measurement, meta} -> meta.mountpoint end)
+      assert mountpoints == Enum.uniq(mountpoints), "expected one event per distinct mountpoint"
+    end
+  end
+
+  def handle_event(event_name, measurement, meta, {pid, ref}) do
+    send(pid, {ref, {event_name, measurement, meta}})
+  end
+
+  defp drain_events(ref, acc \\ []) do
+    receive do
+      {^ref, {[:prom_ex, :plugin, :osmon, :disk], measurement, meta}} ->
+        drain_events(ref, [{measurement, meta} | acc])
+    after
+      100 -> Enum.reverse(acc)
+    end
+  end
+
+  defp attach_handler(event) do
+    ref = make_ref()
+
+    :telemetry.attach(
+      {ref, :test},
+      event,
+      &__MODULE__.handle_event/4,
+      {self(), ref}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach({ref, :test})
+    end)
+
+    ref
+  end
+end


### PR DESCRIPTION
Add per-mountpoint disk metrics to the OsMon PromEx plugin, alongside the existing memory and CPU metrics, sourced live from :disksup.get_disk_info/0 on every poll:

- supavisor_prom_ex_osmon_disk_total_bytes
- supavisor_prom_ex_osmon_disk_available_bytes
- supavisor_prom_ex_osmon_disk_used_percent

Each is labeled by `mountpoint`. Includes tests for the OsMon plugin and a docs update to the metrics reference.

## What kind of change does this PR introduce?

Add metrics for disk space.

## What is the current behavior?

No metrics for disk space.

## What is the new behavior?

Metrics get added, but not yet used anywhere.

## Additional context

https://linear.app/supabase/issue/POOLER-150
