### PR TITLE
chore: rollback euw11 to v2.9.2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,11 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},     % hard-deploy base of the cluster
+    {upgrade_from, "2.9.10"},    % hard-deploy base of the cluster
     {upgrade_previous, "2.9.2"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.10"},       % target version
+    {upgrade_to, "2.9.2"},        % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"usw11">>,
-        <<"cac11">>
+        <<"euw11">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1071.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the euw11 upgrade.**