### PR TITLE
docs: explain citext + pgbouncer=true slowdown and its remedy

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,11 @@ subsequently should show up in your exception monitoring software.
 
 ## Does Supavisor support prepared statements?
 
-It currently supports prepared statements only in session mode.
+It supports prepared statements in session mode. In transaction mode, named
+prepared statements are supported when the `named_prepared_statements`
+feature flag is enabled, either globally with the
+`NAMED_PREPARED_STATEMENTS_ENABLED` environment variable or per tenant via
+`feature_flags`.
 
 ## Why do you route connections to a single Supavisor node when deployed as a cluster?
 

--- a/docs/orms/prisma.md
+++ b/docs/orms/prisma.md
@@ -15,6 +15,27 @@ string with Prisma.
 
 The `pgbouncer=true` connection string parameter is compatible with Supavisor.
 
+Alternatively, Supavisor supports named prepared statements in transaction
+mode when the `named_prepared_statements` feature flag is enabled, either
+globally with the `NAMED_PREPARED_STATEMENTS_ENABLED` environment variable or
+per tenant via `feature_flags`. With it enabled, Prisma can connect through
+transaction mode without `pgbouncer=true`.
+
+## Slow Queries on Tables with Extension Types
+
+With `pgbouncer=true`, Prisma does not reuse its per-connection statement and
+type caches across transactions. For columns whose types come from extensions
+(such as `citext`), Prisma then resolves the type OID with extra lookups
+against `pg_type` inside every transaction, costing two additional
+client-server round trips per column. Over high-latency connections these
+round trips dominate, and queries on such tables can be several times slower
+than on tables with only built-in types (whose OIDs are known to the client
+statically). The same slowdown occurs with PgBouncer in transaction mode; it
+is client behavior, not work done by the pooler.
+
+To avoid it, enable the `named_prepared_statements` feature flag and connect
+without `pgbouncer=true`, or use session mode.
+
 ## Prisma Connection Management
 
 Make sure to review the [Prisma connection management guide](https://www.prisma.io/docs/guides/performance-and-optimization/connection-management).


### PR DESCRIPTION
I looked into #300 and the short version is this isn't a Supavisor bug. The
slowdown is on Prisma's side, and it happens even with no pooler in the path.

Refs #300

## What kind of change does this PR introduce?

Documentation only. No change to proxy behavior.

## What is the current behavior?

If you've got `citext` columns (or any extension type) and you're using Prisma
with `pgbouncer=true`, queries in transaction mode are way slower than the same
table with plain `text` columns that's what #300 is about. The docs don't
explain it, and the FAQ still says prepared statements only work in session
mode, which isn't true anymore.

Here's what's actually going on. `citext`'s type OID gets assigned when you run
`CREATE EXTENSION`, so unlike `text` the client doesn't know it up front. With
`pgbouncer=true`, Prisma throws away its statement and type caches on every
transaction (`DEALLOCATE ALL`), so it has to look the OID back up with
`SELECT ... FROM pg_type`  once per citext column, every single transaction.
Add latency and those round trips are basically the whole query time. I
confirmed it's not us two ways: it reproduces hitting Postgres directly with no
pooler, and profiling the client/db handlers with `:eprof` during the slow
query shows under 1% of the time is actually spent in Supavisor. We're just
passing the round trips through.

## What is the new behavior?

The fix is already in Supavisor, it just wasn't documented  turn on the
`named_prepared_statements` flag and drop `pgbouncer=true`, and Prisma keeps its
caches so the lookups happen once instead of every transaction. Session mode
works too.

- `docs/orms/prisma.md` documents the flag as the alternative to
  `pgbouncer=true`, plus a section on why extension-typed columns get slow and
  how to avoid it.
- `docs/faq.md`  fixes the stale "session mode only" answer.
- `test/integration/prepared_statements_test.exs` — new test that prepares and
  runs a statement returning a citext column through transaction mode.
- `priv/repo/seeds_after_migration.exs` — sets up the citext extension and a
  test table for it. (The `supabase_admin` role bit is there because the image's
  extension scripts expect that role and the CI compose setup skips the init
  that'd create it.)

Numbers from a local repro, ~70ms round-trip latency, Prisma 6.19.3, 3 citext
columns (p50):

| setup | citext | text |
|---|---|---|
| transaction + `pgbouncer=true` (before) | 796ms | 363ms |
| transaction + `named_prepared_statements`, no `pgbouncer=true` (after) | 82ms | 79ms |
| direct connection | 74ms | — |

## Additional context

Those numbers are from a local toxiproxy setup with injected latency, not a real
WAN, but they line up with what's reported in #300 and the round-trip counts
don't depend on latency anyway. Full `mix test` passes the same as the base
branch (the handful of failures are pre-existing cluster/metrics stuff,
unrelated); the new citext test passes.