### PR TITLE
feat(monitoring): add metric for AMI version

### DIFF
--- a/lib/supavisor/monitoring/cluster.ex
+++ b/lib/supavisor/monitoring/cluster.ex
@@ -52,10 +52,15 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
             tags: [:current, :permanent, :base, :previous]
           )
         ]
-      ),
-      Polling.build(
-        :supavisor_ami_version_events,
-        poll_rate,
+      )
+    ]
+  end
+
+  @impl true
+  def manual_metrics(_opts) do
+    [
+      Manual.build(
+        :supavisor_ami_version_manual_metrics,
         {__MODULE__, :emit_ami_version, []},
         [
           last_value(
@@ -106,13 +111,18 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
 
   @spec emit_ami_version() :: :ok
   def emit_ami_version do
-    version = System.get_env("AMI_VERSION") || ""
+    case System.get_env("AMI_VERSION") do
+      version when is_binary(version) and version != "" ->
+        :telemetry.execute(
+          [:supavisor, :prom_ex, :ami, :version],
+          %{status: 1},
+          %{version: version}
+        )
 
-    :telemetry.execute(
-      [:supavisor, :prom_ex, :ami, :version],
-      %{status: 1},
-      %{version: version}
-    )
+      # Don't emit for deployments (e.g. self-hosted) that don't set AMI_VERSION.
+      _ ->
+        :ok
+    end
   end
 
   @spec emit_erpc_latency() :: :ok

--- a/lib/supavisor/monitoring/cluster.ex
+++ b/lib/supavisor/monitoring/cluster.ex
@@ -52,6 +52,20 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
             tags: [:current, :permanent, :base, :previous]
           )
         ]
+      ),
+      Polling.build(
+        :supavisor_ami_version_events,
+        poll_rate,
+        {__MODULE__, :emit_ami_version, []},
+        [
+          last_value(
+            [:supavisor, :prom_ex, :ami, :version, :info],
+            event_name: [:supavisor, :prom_ex, :ami, :version],
+            measurement: :status,
+            description: "The AMI version the node is running on.",
+            tags: [:version]
+          )
+        ]
       )
     ]
   end
@@ -87,6 +101,17 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
       [:supavisor, :prom_ex, :application, :version],
       %{status: 1},
       %{current: current, permanent: permanent, base: base, previous: previous}
+    )
+  end
+
+  @spec emit_ami_version() :: :ok
+  def emit_ami_version do
+    version = System.get_env("AMI_VERSION") || ""
+
+    :telemetry.execute(
+      [:supavisor, :prom_ex, :ami, :version],
+      %{status: 1},
+      %{version: version}
     )
   end
 

--- a/test/supavisor/monitoring/cluster_test.exs
+++ b/test/supavisor/monitoring/cluster_test.exs
@@ -69,6 +69,35 @@ defmodule Supavisor.PromEx.Plugins.ClusterTest do
     end
   end
 
+  describe "emit_ami_version/0" do
+    test "emits AMI version event from AMI_VERSION env var" do
+      ref = attach_handler([:supavisor, :prom_ex, :ami, :version])
+
+      System.put_env("AMI_VERSION", "2024.01.01")
+      on_exit(fn -> System.delete_env("AMI_VERSION") end)
+
+      assert :ok = Cluster.emit_ami_version()
+
+      assert_receive {^ref, {[:supavisor, :prom_ex, :ami, :version], measurement, meta}}
+
+      assert %{status: 1} = measurement
+      assert %{version: "2024.01.01"} = meta
+    end
+
+    test "defaults to empty version when AMI_VERSION is unset" do
+      ref = attach_handler([:supavisor, :prom_ex, :ami, :version])
+
+      System.delete_env("AMI_VERSION")
+
+      assert :ok = Cluster.emit_ami_version()
+
+      assert_receive {^ref, {[:supavisor, :prom_ex, :ami, :version], measurement, meta}}
+
+      assert %{status: 1} = measurement
+      assert %{version: ""} = meta
+    end
+  end
+
   describe "emit_erpc_latency/0" do
     test "emits ERPC latency events for all nodes" do
       ref = attach_handler([:supavisor, :prom_ex, :cluster, :erpc_ping, :stop])

--- a/test/supavisor/monitoring/cluster_test.exs
+++ b/test/supavisor/monitoring/cluster_test.exs
@@ -35,6 +35,21 @@ defmodule Supavisor.PromEx.Plugins.ClusterTest do
     end
   end
 
+  describe "manual_metrics/1" do
+    test "properly exports metrics" do
+      for manual_metric <- Cluster.manual_metrics([]) do
+        assert %PromEx.MetricTypes.Manual{metrics: [_ | _]} = manual_metric
+        {m, f, a} = manual_metric.measurements_mfa
+        assert function_exported?(m, f, length(a))
+
+        for telemetry_metric <- manual_metric.metrics do
+          assert is_struct(telemetry_metric, Telemetry.Metrics.LastValue)
+          assert telemetry_metric.description
+        end
+      end
+    end
+  end
+
   describe "emit_cluster_size/0" do
     test "emits cluster size event" do
       ref = attach_handler([:supavisor, :prom_ex, :cluster])
@@ -84,17 +99,25 @@ defmodule Supavisor.PromEx.Plugins.ClusterTest do
       assert %{version: "2024.01.01"} = meta
     end
 
-    test "defaults to empty version when AMI_VERSION is unset" do
+    test "does not emit when AMI_VERSION is unset" do
       ref = attach_handler([:supavisor, :prom_ex, :ami, :version])
 
       System.delete_env("AMI_VERSION")
 
       assert :ok = Cluster.emit_ami_version()
 
-      assert_receive {^ref, {[:supavisor, :prom_ex, :ami, :version], measurement, meta}}
+      refute_receive {^ref, {[:supavisor, :prom_ex, :ami, :version], _measurement, _meta}}
+    end
 
-      assert %{status: 1} = measurement
-      assert %{version: ""} = meta
+    test "does not emit when AMI_VERSION is empty" do
+      ref = attach_handler([:supavisor, :prom_ex, :ami, :version])
+
+      System.put_env("AMI_VERSION", "")
+      on_exit(fn -> System.delete_env("AMI_VERSION") end)
+
+      assert :ok = Cluster.emit_ami_version()
+
+      refute_receive {^ref, {[:supavisor, :prom_ex, :ami, :version], _measurement, _meta}}
     end
   end
 


### PR DESCRIPTION
Expose the node's AMI version as a Prometheus info metric (supavisor_prom_ex_ami_version_info) with the version carried in a `version` label, mirroring the existing app-version metric pattern. The value is read from the AMI_VERSION env var, defaulting to "" when unset.

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Doesn't put AMI version in metrics

## What is the new behavior?

Add AMI version to metrics

## Additional context

Add any other context or screenshots.

https://linear.app/supabase/issue/POOLER-554/add-metric-for-ami-version