### PR TITLE
test(monitoring): fix flaky disk metrics emission test

### DIFF
--- a/test/supavisor/monitoring/osmon_test.exs
+++ b/test/supavisor/monitoring/osmon_test.exs
@@ -68,13 +68,13 @@ defmodule Supavisor.PromEx.Plugins.OsMonTest do
   end
 
   describe "execute_disk_metrics/0" do
-    test "emits one disk event per filesystem, each tagged with its mountpoint" do
+    test "emits a disk event per filesystem, each tagged with its mountpoint" do
       ref = attach_handler([:prom_ex, :plugin, :osmon, :disk])
 
       assert :ok = OsMon.execute_disk_metrics()
 
       events = drain_events(ref)
-      assert length(events) >= 1
+      assert events != []
 
       for {measurement, meta} <- events do
         assert %{total: total, available: available, capacity: capacity} = measurement
@@ -86,8 +86,9 @@ defmodule Supavisor.PromEx.Plugins.OsMonTest do
         assert is_binary(mountpoint)
       end
 
-      mountpoints = Enum.map(events, fn {_measurement, meta} -> meta.mountpoint end)
-      assert mountpoints == Enum.uniq(mountpoints), "expected one event per distinct mountpoint"
+      received = MapSet.new(events, fn {_measurement, meta} -> meta.mountpoint end)
+      expected = MapSet.new(OsMon.disk(), fn {mountpoint, _} -> mountpoint end)
+      assert MapSet.subset?(expected, received)
     end
   end
 


### PR DESCRIPTION
execute_disk_metrics/0's test asserted that drained disk events had unique mountpoints. But the PromEx OsMon poller runs during tests (metrics_disabled is false, prom_poll_rate 500ms) and emits the same [:prom_ex, :plugin, :osmon, :disk] event on its own timer. When a poll tick lands in the test window, drain_events collects a second round of mountpoints and the uniqueness assertion fails intermittently.

Assert coverage instead of uniqueness: our explicit call emits one event per mountpoint (so expected is a subset of received deterministically), and extra poller rounds only add duplicates the subset check tolerates.

## What kind of change does this PR introduce?

make test less fragile

## What is the current behavior?

test can fail due to race condition

## What is the new behavior?

let it race, don't fail it

## Additional context


