### PR TITLE
fix: wait for all DB replies before releasing backend

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -45,6 +45,7 @@ defmodule Supavisor.ClientHandler do
   }
 
   alias Supavisor.Protocol.{FrontendMessageHandler, MessageStreamer}
+  require MessageStreamer
 
   alias Supavisor.Errors.{
     CheckoutTimeoutError,
@@ -890,12 +891,32 @@ defmodule Supavisor.ClientHandler do
 
     with {:ok, new_stream_state, pkts} <-
            ProtocolHelpers.process_client_packets(data_to_send, data.mode, data),
+         {:ok, new_stream_state} <- maybe_expect_ready_for_query(data, new_stream_state),
          :ok <- sock_send(pkts, data) do
       {:ok, %{data | stream_state: new_stream_state}}
     else
       {:error, exception} ->
         {:error, exception}
     end
+  end
+
+  defp maybe_expect_ready_for_query(
+         %{mode: :transaction, db_connection: {_pool, db_pid, _sock}},
+         stream_state
+       ) do
+    {count, stream_state} = handle_rfq_producers(stream_state)
+    if count > 0, do: DbHandler.expect_ready_for_query(db_pid, count)
+    {:ok, stream_state}
+  end
+
+  defp maybe_expect_ready_for_query(_data, stream_state), do: {:ok, stream_state}
+
+  defp handle_rfq_producers(stream_state) do
+    handler_state = MessageStreamer.stream_state(stream_state, :handler_state)
+
+    # also reset the state.
+    {handler_state.rfq_producers,
+     MessageStreamer.update_state(stream_state, fn s -> %{s | rfq_producers: 0} end)}
   end
 
   @spec handle_actions(map) :: [{:timeout, non_neg_integer, atom}]

--- a/lib/supavisor/client_handler/protocol_helpers.ex
+++ b/lib/supavisor/client_handler/protocol_helpers.ex
@@ -97,11 +97,12 @@ defmodule Supavisor.ClientHandler.ProtocolHelpers do
         :transaction,
         %{tenant_feature_flags: tenant_feature_flags} = data
       ) do
-    if FeatureFlag.enabled?(tenant_feature_flags, "named_prepared_statements") do
-      MessageStreamer.handle_packets(data.stream_state, bin)
-    else
-      {:ok, data.stream_state, bin}
-    end
+    translate? = FeatureFlag.enabled?(tenant_feature_flags, "named_prepared_statements")
+
+    stream_state =
+      MessageStreamer.update_state(data.stream_state, &%{&1 | translate?: translate?})
+
+    MessageStreamer.handle_packets(stream_state, bin)
   end
 
   def process_client_packets(bin, _mode, data) do

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -116,6 +116,16 @@ defmodule Supavisor.DbHandler do
   end
 
   @doc """
+  Tells the DbHandler how many more ReadyForQuery messages to expect for the batch being forwarded.
+
+  The ClientHandler should send this *before* forwarding the messages that produce them,
+  so the count reaches the DbHandler before the responses do.
+  """
+  @spec expect_ready_for_query(pid(), pos_integer()) :: :ok
+  def expect_ready_for_query(pid, count),
+    do: :gen_statem.cast(pid, {:expect_ready_for_query, count})
+
+  @doc """
   Attempts to clean up session state by sending DISCARD ALL to the database.
 
   The caller is responsible for ensuring that:
@@ -226,6 +236,7 @@ defmodule Supavisor.DbHandler do
       replica_type: config.replica_type,
       caller: nil,
       client_sock: nil,
+      expected_rfq: 0,
       pool: pool,
       terminating_error: nil,
       manager_ref: nil,
@@ -434,34 +445,48 @@ defmodule Supavisor.DbHandler do
     :keep_state_and_data
   end
 
+  def handle_event(:cast, {:expect_ready_for_query, count}, _state, data) do
+    {:keep_state, %{data | expected_rfq: data.expected_rfq + count}}
+  end
+
   # forward the message to the client
   def handle_event(:info, {proto, _, bin}, :busy, %{caller: caller} = data)
       when is_pid(caller) and proto in @proto do
     Logger.debug("DbHandler: Got messages: #{Debug.packet_to_string(bin, :backend)}")
 
-    ready_for_query? = String.ends_with?(bin, Server.ready_for_query())
+    {:ok, data, to_send} = process_backend_streaming(bin, data)
+    {count, last_status, data} = handle_ready_for_query(data)
 
-    # db_status must be enqueued in the ClientHandler's mailbox before
-    # ReadyForQuery reaches the client socket: the client sends its next query
-    # as soon as it reads ReadyForQuery, and if that query arrives while the
-    # ClientHandler is still :busy it gets forwarded to a connection the client
-    # no longer owns.
-    if ready_for_query?, do: ClientHandler.db_status(data.caller, :ready_for_query)
+    # A batch is done when we have received the expected number of `ReadyForQuery`
+    # messages and the last status is idle and not mid-transaction.
+    outstanding = data.expected_rfq - count
+    batch_done? = outstanding <= 0 and last_status == ?I
+    data = %{data | expected_rfq: max(outstanding, 0)}
 
-    case handle_server_messages(bin, data) do
+    # db_status must be enqueued in the ClientHandler's mailbox before the final
+    # ReadyForQuery reaches the client socket: the client sends its next query as
+    # soon as it reads ReadyForQuery, and if that arrives while the ClientHandler
+    # is still :busy it gets forwarded to a connection the client no longer owns.
+    if batch_done?, do: ClientHandler.db_status(data.caller, :ready_for_query)
+
+    send_result = if to_send == [], do: :ok, else: client_send(data, to_send)
+
+    case send_result do
       {:error, reason} ->
         # Still linked to the ClientHandler (checkin is what unlinks), so
         # stopping tears the client connection down with us.
         Logger.error("DbHandler: Failed to forward message to client: #{inspect(reason)}")
         {:stop, :normal}
 
-      {:ok, data} ->
-        if ready_for_query? do
+      :ok ->
+        if batch_done? do
           case data.mode do
             :transaction ->
               {_, stats} = Telem.network_usage(:db, data.sock, data.id, data.stats)
               checkin(data)
-              {:next_state, :idle, %{data | stats: stats, caller: nil, client_sock: nil}}
+
+              {:next_state, :idle,
+               %{data | stats: stats, caller: nil, client_sock: nil, expected_rfq: 0}}
 
             :proxy ->
               {:keep_state, data}
@@ -608,7 +633,7 @@ defmodule Supavisor.DbHandler do
         send(caller, {:parameter_status, bin_ps})
       end
 
-      {:next_state, :busy, %{data | client_sock: sock, caller: caller},
+      {:next_state, :busy, %{data | client_sock: sock, caller: caller, expected_rfq: 0},
        {:reply, from, {:ok, data.sock}}}
     else
       {:keep_state_and_data, :postpone}
@@ -1002,26 +1027,18 @@ defmodule Supavisor.DbHandler do
     :ok
   end
 
-  @spec handle_server_messages(binary(), map()) :: {:ok, map()} | {:error, term()}
-  defp handle_server_messages(bin, %{backend_message_streaming: true} = data) do
-    {:ok, updated_data, to_send} = process_backend_streaming(bin, data)
+  defp handle_ready_for_query(data) do
+    handler_state = MessageStreamer.stream_state(data.stream_state, :handler_state)
+    count = BackendMessageHandler.handler_state(handler_state, :rfq_count)
+    last_status = BackendMessageHandler.handler_state(handler_state, :last_rfq_status)
 
-    if to_send != [] do
-      case client_send(data, to_send) do
-        :ok -> {:ok, updated_data}
-        {:error, reason} -> {:error, reason}
-      end
-    else
-      {:ok, updated_data}
-    end
-  end
+    # also reset the state.
+    stream_state =
+      MessageStreamer.update_state(data.stream_state, fn s ->
+        BackendMessageHandler.handler_state(s, rfq_count: 0, last_rfq_status: nil)
+      end)
 
-  # hot code reload compat: remove after full rollout
-  defp handle_server_messages(bin, data) do
-    case client_send(data, bin) do
-      :ok -> {:ok, data}
-      {:error, reason} -> {:error, reason}
-    end
+    {count, last_status, %{data | stream_state: stream_state}}
   end
 
   # libpq's async API hangs when a TLS record leaves bytes in OpenSSL's

--- a/lib/supavisor/protocol/backend_message_handler.ex
+++ b/lib/supavisor/protocol/backend_message_handler.ex
@@ -9,6 +9,8 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
     actions may be inserted through `Supavisor.Protocol.MessageHandler.update_state/2`.
   - `ErrorResponse`: FATAL/PANIC errors are detected and stored in the handler state so the
     DbHandler can read the error reason before the connection closes.
+  - `ReadyForQuery`: the number seen and the last transaction status are recorded,
+    so the DbHandler can tell when every reply in a pipelined batch has been received.
   """
 
   @behaviour Supavisor.Protocol.MessageHandler
@@ -16,7 +18,12 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
   require Record
   require Supavisor.Protocol.Server, as: Server
 
-  Record.defrecord(:handler_state, action_queue: :queue.new(), fatal_error: nil)
+  Record.defrecord(:handler_state,
+    action_queue: :queue.new(),
+    fatal_error: nil,
+    rfq_count: 0,
+    last_rfq_status: nil
+  )
 
   @impl true
   def handled_message_types do
@@ -38,6 +45,7 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
   end
 
   def handle_message(state, tag, len, payload) do
+    state = maybe_record_ready_for_query(state, tag, payload)
     action_queue = handler_state(state, :action_queue)
     message_type = message_type(tag)
     {injected_pkts, action_queue} = maybe_inject(action_queue)
@@ -65,6 +73,15 @@ defmodule Supavisor.Protocol.BackendMessageHandler do
         {[], action_queue}
     end
   end
+
+  defp maybe_record_ready_for_query(state, ?Z, <<status::8>>),
+    do:
+      handler_state(state,
+        rfq_count: handler_state(state, :rfq_count) + 1,
+        last_rfq_status: status
+      )
+
+  defp maybe_record_ready_for_query(state, _tag, _payload), do: state
 
   defp message_type(?1), do: :parse
   defp message_type(?3), do: :close

--- a/lib/supavisor/protocol/frontend_message_handler.ex
+++ b/lib/supavisor/protocol/frontend_message_handler.ex
@@ -4,6 +4,9 @@ defmodule Supavisor.Protocol.FrontendMessageHandler do
 
   - Parse (P), Bind (B), Close (C), Describe (D): PreparedStatements
   - Simple Query (Q): SimpleQueryHandler
+  - Sync (S), FunctionCall (F): forwarded unchanged
+
+  It also counts the number of messages that produce a `ReadyForQuery` response from the backend.
   """
 
   @behaviour Supavisor.Protocol.MessageHandler
@@ -11,17 +14,26 @@ defmodule Supavisor.Protocol.FrontendMessageHandler do
   alias Supavisor.Protocol.PreparedStatements
   alias Supavisor.Protocol.SimpleQueryHandler
 
+  @rfq_producers [?Q, ?S, ?F]
+
   @impl true
-  def handled_message_types, do: [?P, ?B, ?C, ?D, ?Q]
+  def handled_message_types, do: [?P, ?B, ?C, ?D, ?Q, ?S, ?F]
 
   @impl true
   def init_state do
     %{
-      prepared_statements: PreparedStatements.init_storage()
+      prepared_statements: PreparedStatements.init_storage(),
+      rfq_producers: 0,
+      # Prepared statements feature flag:
+      translate?: true
     }
   end
 
   @impl true
+  def handle_message(%{translate?: false} = state, tag, len, payload) do
+    {:ok, count_rfq_producer(state, tag), <<tag, len::32, payload::binary>>}
+  end
+
   def handle_message(state, tag, len, payload) do
     case tag do
       ?P ->
@@ -38,14 +50,22 @@ defmodule Supavisor.Protocol.FrontendMessageHandler do
 
       ?Q ->
         SimpleQueryHandler.handle_simple_query_message(state.prepared_statements, len, payload)
+
+      tag when tag in [?S, ?F] ->
+        {:ok, state.prepared_statements, <<tag, len::32, payload::binary>>}
     end
     |> case do
       {:ok, new_ps_state, result} ->
         new_state = %{state | prepared_statements: new_ps_state}
-        {:ok, new_state, result}
+        {:ok, count_rfq_producer(new_state, tag), result}
 
       error ->
         error
     end
   end
+
+  defp count_rfq_producer(state, tag) when tag in @rfq_producers,
+    do: %{state | rfq_producers: state.rfq_producers + 1}
+
+  defp count_rfq_producer(state, _tag), do: state
 end

--- a/test/integration/js/postgres/index.js
+++ b/test/integration/js/postgres/index.js
@@ -2607,7 +2607,7 @@ t('concurrent cursors multiple connections', async() => {
   return ['12233445566778', xs.sort().join('')]
 })
 
-t('Pipelines many queries on a single connection', { timeout: t.timeout * 3 }, async() => {
+t('Pipelines many queries on a single connection', { timeout: t.timeout * 4 }, async() => {
   // Force prepared statements so postgres.js pipelines the statements.
   const pipe = postgres({ ...options, prepare: true, max: 1 })
   try {

--- a/test/integration/js/postgres/index.js
+++ b/test/integration/js/postgres/index.js
@@ -2607,6 +2607,20 @@ t('concurrent cursors multiple connections', async() => {
   return ['12233445566778', xs.sort().join('')]
 })
 
+t('Pipelines many queries on a single connection', { timeout: t.timeout * 2 }, async() => {
+  // Force prepared statements so postgres.js pipelines the statements.
+  const pipe = postgres({ ...options, prepare: true, max: 1 })
+  try {
+    const n = 50
+    const rows = await Promise.all(
+      Array.from({ length: n }, (_, i) => pipe`select ${ i }::int as x`)
+    )
+    return [n, rows.filter((r, i) => r[0].x === i).length]
+  } finally {
+    await pipe.end()
+  }
+})
+
 if (process.env.PGMODE != 'transaction') {
   t('reserve connection', async() => {
     const reserved = await sql.reserve()

--- a/test/integration/js/postgres/index.js
+++ b/test/integration/js/postgres/index.js
@@ -2607,11 +2607,11 @@ t('concurrent cursors multiple connections', async() => {
   return ['12233445566778', xs.sort().join('')]
 })
 
-t('Pipelines many queries on a single connection', { timeout: t.timeout * 2 }, async() => {
+t('Pipelines many queries on a single connection', { timeout: t.timeout * 3 }, async() => {
   // Force prepared statements so postgres.js pipelines the statements.
   const pipe = postgres({ ...options, prepare: true, max: 1 })
   try {
-    const n = 50
+    const n = 20
     const rows = await Promise.all(
       Array.from({ length: n }, (_, i) => pipe`select ${ i }::int as x`)
     )

--- a/test/integration/transaction_pipelining_test.exs
+++ b/test/integration/transaction_pipelining_test.exs
@@ -1,0 +1,64 @@
+defmodule Supavisor.Integration.TransactionPipeliningTest do
+  use Supavisor.DataCase, async: false
+
+  alias Supavisor.Support.ProtocolClient
+
+  @moduletag :integration
+
+  @tenants ["proxy_tenant_ps_disabled", "proxy_tenant_ps_enabled"]
+
+  for tenant <- @tenants do
+    test "delivers every reply in a pipelined batch (#{tenant})" do
+      sock = connect(unquote(tenant))
+      n = 50
+
+      # Fire N simple queries in a single write so they pipeline.
+      :ok = :gen_tcp.send(sock, pipeline(n))
+
+      assert recv_ready_for_queries(sock, n) == n
+    end
+
+    test "releases and reuses the backend after a pipelined batch (#{tenant})" do
+      sock = connect(unquote(tenant))
+
+      :ok = :gen_tcp.send(sock, pipeline(5))
+      assert recv_ready_for_queries(sock, 5) == 5
+
+      # A fresh query on the same client connection must still succeed.
+      :ok = :gen_tcp.send(sock, :pgo_protocol.encode_query_message("SELECT 1"))
+      assert recv_ready_for_queries(sock, 1) == 1
+    end
+  end
+
+  defp connect(tenant) do
+    db_conf = Application.get_env(:supavisor, Supavisor.Repo)
+    port = Application.get_env(:supavisor, :proxy_port_transaction)
+
+    {:ok, sock} = :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false])
+    ProtocolClient.authenticate(sock, "#{db_conf[:username]}.#{tenant}", db_conf[:password])
+    sock
+  end
+
+  # N simple queries as one iolist, so a single send pipelines them.
+  defp pipeline(n) do
+    Enum.map(1..n, fn i -> :pgo_protocol.encode_query_message("SELECT #{i}") end)
+  end
+
+  # Reads until `n` ReadyForQuery packets have been seen, returning the count.
+  defp recv_ready_for_queries(sock, n, buf \\ <<>>) do
+    {pkts, _rest} = Supavisor.Protocol.split_pkts(buf)
+    count = Enum.count(pkts, &match?(<<?Z, _::binary>>, &1))
+
+    if count >= n do
+      count
+    else
+      case :gen_tcp.recv(sock, 0, 5000) do
+        {:ok, more} ->
+          recv_ready_for_queries(sock, n, buf <> more)
+
+        {:error, reason} ->
+          flunk("received only #{count}/#{n} ReadyForQuery before #{inspect(reason)}")
+      end
+    end
+  end
+end

--- a/test/supavisor/client_handler_test.exs
+++ b/test/supavisor/client_handler_test.exs
@@ -1,7 +1,28 @@
 defmodule Supavisor.ClientHandlerTest do
   use ExUnit.Case, async: true
 
+  alias Supavisor.Protocol.FrontendMessageHandler
+  alias Supavisor.Protocol.MessageStreamer
+
   @subject Supavisor.ClientHandler
+
+  defp sockpair do
+    {:ok, listen} = :gen_tcp.listen(0, mode: :binary, active: false)
+    {:ok, {address, port}} = :inet.sockname(listen)
+    this = self()
+    ref = make_ref()
+
+    spawn(fn ->
+      {:ok, recv} = :gen_tcp.accept(listen)
+      :gen_tcp.controlling_process(recv, this)
+      send(this, {ref, recv})
+    end)
+
+    {:ok, send} = :gen_tcp.connect(address, port, mode: :binary, active: false)
+    assert_receive {^ref, recv}
+
+    {send, recv}
+  end
 
   describe "TLS alert handling" do
     setup do
@@ -148,6 +169,46 @@ defmodule Supavisor.ClientHandlerTest do
                @subject.handle_event(:info, {:tcp, :fake_port, bin}, :handshake, data)
 
       assert Logger.get_process_level(self()) == :debug
+    end
+  end
+
+  describe "handle_event/4 :busy ReadyForQuery expectation" do
+    test "forwards the expected ReadyForQuery count to the DbHandler in transaction mode" do
+      {db_sock, _recv} = sockpair()
+
+      data = %{
+        mode: :transaction,
+        db_connection: {:pool, self(), {:gen_tcp, db_sock}},
+        tenant_feature_flags: %{},
+        stream_state: MessageStreamer.new_stream_state(FrontendMessageHandler)
+      }
+
+      # Three pipelined simple queries produce three ReadyForQuery replies.
+      batch =
+        <<?Q, 12::32, "SELECT 1">> <> <<?Q, 12::32, "SELECT 2">> <> <<?Q, 12::32, "SELECT 3">>
+
+      assert {:keep_state, _data} =
+               @subject.handle_event(:info, {:tcp, :sock, batch}, :busy, data)
+
+      assert_received {:"$gen_cast", {:expect_ready_for_query, 3}}
+    end
+
+    test "does not send an expectation in session mode" do
+      {db_sock, _recv} = sockpair()
+
+      data = %{
+        mode: :session,
+        db_connection: {:pool, self(), {:gen_tcp, db_sock}},
+        tenant_feature_flags: %{},
+        stream_state: MessageStreamer.new_stream_state(FrontendMessageHandler)
+      }
+
+      batch = <<?Q, 12::32, "SELECT 1">> <> <<?Q, 12::32, "SELECT 2">>
+
+      assert {:keep_state, _data} =
+               @subject.handle_event(:info, {:tcp, :sock, batch}, :busy, data)
+
+      refute_received {:"$gen_cast", {:expect_ready_for_query, _count}}
     end
   end
 end

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -8,6 +8,8 @@ defmodule Supavisor.DbHandlerTest do
   import Supavisor.Asserts
 
   alias Supavisor.DbHandler, as: Db
+  alias Supavisor.Protocol.BackendMessageHandler
+  alias Supavisor.Protocol.MessageStreamer
   alias Supavisor.Protocol.Server
 
   require Supavisor
@@ -140,6 +142,27 @@ defmodule Supavisor.DbHandlerTest do
     assert_receive {^ref, recv}
 
     {send, recv}
+  end
+
+  # A `:busy` DbHandler data map.
+  defp busy_data(overrides \\ %{}) do
+    {backend_sock, _recv} = sockpair()
+    {client_sock, _recv} = sockpair()
+
+    base = %{
+      caller: self(),
+      pool: self(),
+      mode: :transaction,
+      sock: {:gen_tcp, backend_sock},
+      client_sock: {:gen_tcp, client_sock},
+      id: make_id(),
+      stats: %{},
+      expected_rfq: 0,
+      backend_message_streaming: true,
+      stream_state: MessageStreamer.new_stream_state(BackendMessageHandler)
+    }
+
+    Map.merge(base, overrides)
   end
 
   describe "init/1" do
@@ -1107,6 +1130,80 @@ defmodule Supavisor.DbHandlerTest do
                  :setting_application_name,
                  data
                )
+    end
+  end
+
+  describe "handle_event/4 :busy ReadyForQuery batching" do
+    test "releases the backend once the single expected ReadyForQuery arrives" do
+      data = busy_data(%{expected_rfq: 1})
+
+      assert {:next_state, :idle, new_data} =
+               Db.handle_event(:info, {:tcp, :sock, Server.ready_for_query()}, :busy, data)
+
+      assert new_data.caller == nil
+      assert new_data.expected_rfq == 0
+      assert_received {:"$gen_cast", {:db_status, :ready_for_query}}
+    end
+
+    test "holds the backend until every pipelined ReadyForQuery has arrived" do
+      data = busy_data(%{expected_rfq: 3})
+
+      # Only one of the three expected replies so far: stay busy, no release.
+      assert {:keep_state, data} =
+               Db.handle_event(:info, {:tcp, :sock, Server.ready_for_query()}, :busy, data)
+
+      refute_received {:"$gen_cast", {:db_status, :ready_for_query}}
+      assert data.expected_rfq == 2
+
+      # The remaining two arrive together, draining the batch, so we release.
+      two = Server.ready_for_query() <> Server.ready_for_query()
+
+      assert {:next_state, :idle, _new_data} =
+               Db.handle_event(:info, {:tcp, :sock, two}, :busy, data)
+
+      assert_received {:"$gen_cast", {:db_status, :ready_for_query}}
+    end
+
+    test "does not release mid-transaction even when the expected count is met" do
+      data = busy_data(%{expected_rfq: 1})
+      in_transaction = <<?Z, 5::32, ?T>>
+
+      assert {:keep_state, data} =
+               Db.handle_event(:info, {:tcp, :sock, in_transaction}, :busy, data)
+
+      refute_received {:"$gen_cast", {:db_status, :ready_for_query}}
+      assert data.expected_rfq == 0
+    end
+
+    test "detects a ReadyForQuery that splits across two socket reads" do
+      <<first::binary-size(4), second::binary>> = Server.ready_for_query()
+      data = busy_data(%{expected_rfq: 1})
+
+      # Partial ReadyForQuery: nothing framed yet, stay busy.
+      assert {:keep_state, data} =
+               Db.handle_event(:info, {:tcp, :sock, first}, :busy, data)
+
+      refute_received {:"$gen_cast", {:db_status, :ready_for_query}}
+
+      # Second read completes it, the framer reassembles it, and we release.
+      assert {:next_state, :idle, _new_data} =
+               Db.handle_event(:info, {:tcp, :sock, second}, :busy, data)
+
+      assert_received {:"$gen_cast", {:db_status, :ready_for_query}}
+    end
+
+    test "expect_ready_for_query cast accumulates the expected count" do
+      data = busy_data()
+
+      assert {:keep_state, data} =
+               Db.handle_event(:cast, {:expect_ready_for_query, 2}, :busy, data)
+
+      assert data.expected_rfq == 2
+
+      assert {:keep_state, data} =
+               Db.handle_event(:cast, {:expect_ready_for_query, 3}, :busy, data)
+
+      assert data.expected_rfq == 5
     end
   end
 end

--- a/test/supavisor/protocol/backend_message_handler_test.exs
+++ b/test/supavisor/protocol/backend_message_handler_test.exs
@@ -63,8 +63,11 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
-               MessageStreamer.stream_state(stream_state, :handler_state)
+      # The action queue is untouched.
+      assert BackendMessageHandler.handler_state(
+               MessageStreamer.stream_state(new_stream_state, :handler_state),
+               :action_queue
+             ) == :queue.new()
 
       assert IO.iodata_to_binary(result) == original_bin
     end
@@ -297,6 +300,54 @@ defmodule Supavisor.Protocol.BackendMessageHandlerTest do
                MessageStreamer.stream_state(stream_state, :handler_state)
 
       assert IO.iodata_to_binary(result) == original_bin
+    end
+  end
+
+  describe "ReadyForQuery counting" do
+    test "records the count and status of a single ReadyForQuery", %{stream_state: stream_state} do
+      {:ok, new_stream_state, _result} =
+        MessageStreamer.handle_packets(stream_state, <<?Z, 5::32, ?I>>)
+
+      hs = MessageStreamer.stream_state(new_stream_state, :handler_state)
+      assert BackendMessageHandler.handler_state(hs, :rfq_count) == 1
+      assert BackendMessageHandler.handler_state(hs, :last_rfq_status) == ?I
+    end
+
+    test "counts every ReadyForQuery in a pipelined batch, keeping the last status", %{
+      stream_state: stream_state
+    } do
+      batch = <<?Z, 5::32, ?T>> <> <<?Z, 5::32, ?T>> <> <<?Z, 5::32, ?I>>
+
+      {:ok, new_stream_state, _result} = MessageStreamer.handle_packets(stream_state, batch)
+
+      hs = MessageStreamer.stream_state(new_stream_state, :handler_state)
+      assert BackendMessageHandler.handler_state(hs, :rfq_count) == 3
+      assert BackendMessageHandler.handler_state(hs, :last_rfq_status) == ?I
+    end
+
+    test "counts a ReadyForQuery only once it is fully framed across reads", %{
+      stream_state: stream_state
+    } do
+      <<first::binary-size(4), second::binary>> = <<?Z, 5::32, ?I>>
+
+      {:ok, mid_state, _result} = MessageStreamer.handle_packets(stream_state, first)
+      mid_hs = MessageStreamer.stream_state(mid_state, :handler_state)
+      assert BackendMessageHandler.handler_state(mid_hs, :rfq_count) == 0
+
+      {:ok, done_state, _result} = MessageStreamer.handle_packets(mid_state, second)
+      done_hs = MessageStreamer.stream_state(done_state, :handler_state)
+      assert BackendMessageHandler.handler_state(done_hs, :rfq_count) == 1
+      assert BackendMessageHandler.handler_state(done_hs, :last_rfq_status) == ?I
+    end
+
+    test "does not count non-ReadyForQuery messages", %{stream_state: stream_state} do
+      # ParseComplete
+      {:ok, new_stream_state, _result} =
+        MessageStreamer.handle_packets(stream_state, <<?1, 4::32>>)
+
+      hs = MessageStreamer.stream_state(new_stream_state, :handler_state)
+      assert BackendMessageHandler.handler_state(hs, :rfq_count) == 0
+      assert BackendMessageHandler.handler_state(hs, :last_rfq_status) == nil
     end
   end
 end

--- a/test/supavisor/protocol/frontend_message_handler_test.exs
+++ b/test/supavisor/protocol/frontend_message_handler_test.exs
@@ -77,8 +77,8 @@ defmodule Supavisor.Protocol.FrontendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state, original_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
-               MessageStreamer.stream_state(stream_state, :handler_state)
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state).prepared_statements ==
+               MessageStreamer.stream_state(stream_state, :handler_state).prepared_statements
 
       assert result == [original_bin]
     end
@@ -100,10 +100,76 @@ defmodule Supavisor.Protocol.FrontendMessageHandlerTest do
       {:ok, new_stream_state, result} =
         MessageStreamer.handle_packets(stream_state, multi_query_bin)
 
-      assert MessageStreamer.stream_state(new_stream_state, :handler_state) ==
-               MessageStreamer.stream_state(stream_state, :handler_state)
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state).prepared_statements ==
+               MessageStreamer.stream_state(stream_state, :handler_state).prepared_statements
 
       assert result == [multi_query_bin]
+    end
+  end
+
+  # Frames `bin` and returns how many RFQ-producing messages the handler counted.
+  defp rfq_producers(stream_state, bin) do
+    {:ok, new_stream_state, _result} = MessageStreamer.handle_packets(stream_state, bin)
+    MessageStreamer.stream_state(new_stream_state, :handler_state).rfq_producers
+  end
+
+  describe "ReadyForQuery-producer counting" do
+    test "counts a simple query (Q)", %{stream_state: stream_state} do
+      assert rfq_producers(stream_state, <<?Q, 12::32, "SELECT 1">>) == 1
+    end
+
+    test "counts a Sync (S)", %{stream_state: stream_state} do
+      assert rfq_producers(stream_state, <<?S, 4::32>>) == 1
+    end
+
+    test "counts a FunctionCall (F)", %{stream_state: stream_state} do
+      assert rfq_producers(stream_state, <<?F, 4::32>>) == 1
+    end
+
+    test "does not count Parse or Execute", %{stream_state: stream_state} do
+      bin = <<?P, 16::32, 0, "select 1", 0, 0, 0>> <> <<?E, 9::32, 0, 0, 0, 0, 200>>
+      assert rfq_producers(stream_state, bin) == 0
+    end
+
+    test "counts a multi-statement simple query as one producer", %{stream_state: stream_state} do
+      assert rfq_producers(stream_state, <<?Q, 32::32, "SELECT 1; SELECT 2; SELECT 3">>) == 1
+    end
+
+    test "counts every query in a pipelined simple-query batch", %{stream_state: stream_state} do
+      batch =
+        <<?Q, 12::32, "SELECT 1">> <> <<?Q, 12::32, "SELECT 2">> <> <<?Q, 12::32, "SELECT 3">>
+
+      assert rfq_producers(stream_state, batch) == 3
+    end
+
+    test "counts only the Sync in an extended-protocol batch", %{stream_state: stream_state} do
+      bin =
+        <<?P, 16::32, 0, "select 1", 0, 0, 0>> <>
+          <<?E, 9::32, 0, 0, 0, 0, 200>> <>
+          <<?S, 4::32>>
+
+      assert rfq_producers(stream_state, bin) == 1
+    end
+
+    test "counts every Sync in a pipelined extended-protocol batch", %{stream_state: stream_state} do
+      sequence =
+        <<?P, 16::32, 0, "select 1", 0, 0, 0>> <>
+          <<?E, 9::32, 0, 0, 0, 0, 200>> <>
+          <<?S, 4::32>>
+
+      assert rfq_producers(stream_state, sequence <> sequence) == 2
+    end
+
+    test "still counts (and forwards verbatim) when translation is disabled", %{
+      stream_state: stream_state
+    } do
+      stream_state = MessageStreamer.update_state(stream_state, &%{&1 | translate?: false})
+      sync = <<?S, 4::32>>
+
+      {:ok, new_stream_state, result} = MessageStreamer.handle_packets(stream_state, sync)
+
+      assert MessageStreamer.stream_state(new_stream_state, :handler_state).rfq_producers == 1
+      assert IO.iodata_to_binary(result) == sync
     end
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Avoids prematurely releasing the backend on the first-found `ReadyForQuery` message. 

## What is the current behavior?

The client hangs waiting for the rest of the replies, but Supavisor already releases the backend early, causing the remaining replies to be lost.

## What is the new behavior?

The client handler now communicates the expected `ReadyForQuery` messages to wait for, so we only release the backend when we are done with the batch.

## Additional context

Resolves #1061 

I spent good time on the tests. The integration tests correctly catch the regression (fails on main, passes here).