### PR TITLE
chore: rollback euw21 to v2.9.1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,7 +1,7 @@
 [
     {upgrade_from, "2.9.10"},        % hard-deploy base of the cluster
     {upgrade_previous, "2.9.2"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.2"},       % target version
+    {upgrade_to, "2.9.1"},       % target version
     % list() | [<<"all">>]
     {regions, [
         <<"euw21">>

--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,11 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},     % hard-deploy base of the cluster
+    {upgrade_from, "2.9.10"},        % hard-deploy base of the cluster
     {upgrade_previous, "2.9.2"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.10"},       % target version
+    {upgrade_to, "2.9.2"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"euw11">>,
-        <<"usw21">>
+        <<"euw21">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1082.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the euw21 upgrade.**