### PR TITLE
chore(supavisor-staging): rollback ap-southeast-1-blu to v2.9.7 

### DIFF
--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,9 +1,9 @@
 [
-    {upgrade_from, "2.9.0"}, %% base on VM, last hard
-    {upgrade_previous, "2.9.0"}, %% current version on VM, includes soft deploys
-    {upgrade_to, "2.9.6-rc.0"},
+    {upgrade_from, "2.9.7"}, %% base on VM, last hard
+    {upgrade_previous, "2.9.7"}, %% current version on VM, includes soft deploys
+    {upgrade_to, "2.9.10"},
     % list() | [<<"all">>]
-    {regions, [<<"euc11">>]},
+    {regions, [<<"ap-southeast-1-blu">>]},
     % :soft | :hard
     {type, hard}
 ].

--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,7 +1,7 @@
 [
-    {upgrade_from, "2.9.7"}, %% base on VM, last hard
-    {upgrade_previous, "2.9.7"}, %% current version on VM, includes soft deploys
-    {upgrade_to, "2.9.10"},
+    {upgrade_from, "2.9.10"}, %% base on VM, last hard
+    {upgrade_previous, "2.9.10"}, %% current version on VM, includes soft deploys
+    {upgrade_to, "2.9.7"},
     % list() | [<<"all">>]
     {regions, [<<"ap-southeast-1-blu">>]},
     % :soft | :hard


### PR DESCRIPTION
Standby rollback to https://github.com/supabase/supavisor/pull/1086.

The -rb tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the ap-southeast-1-blu upgrade.**
