### PR TITLE
chore: upgrade to v2.9.10 in apne21 and euw31

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,12 +1,11 @@
 [
     {upgrade_from, "2.9.2"},     % hard-deploy base of the cluster
-    {upgrade_previous, "2.9.2"}, % version currently running (relup is built from this)
+    {upgrade_previous, "2.9.8"}, % version currently running (relup is built from this)
     {upgrade_to, "2.9.10"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"euw21">>,
-        <<"euc21">>,
-        <<"apne11">>
+        <<"apne21">>,
+        <<"euw31">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Hard upgrade apne21 and euw31 to v2.9.10.

- apne21: hard base v2.9.2
- euw31: hard base v2.9.0

platform:
- apne21: https://github.com/supabase/platform/pull/35767
- euw31: https://github.com/supabase/platform/pull/35768