### PR TITLE
chore: rollback apne21 to v2.9.2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,12 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},     % hard-deploy base of the cluster
-    {upgrade_previous, "2.9.2"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.10"},       % target version
+    {upgrade_from, "2.9.10"},    % hard-deploy base of the cluster
+    {upgrade_previous, "2.9.8"}, % version currently running (relup is built from this)
+    {upgrade_to, "2.9.2"},       % target version
     % list() | [<<"all">>]
     {regions, [
-        <<"euw21">>,
-        <<"euc21">>,
-        <<"apne11">>
+        <<"apne21">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for apne21. Do NOT merge unless rolling back.

Rolls back from v2.9.10 to v2.9.2 (hard-deploy base).

supavisor: https://github.com/supabase/supavisor/pull/1092