### PR TITLE
chore: rollback ap-northeast-1 to v2.9.0

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,11 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},     % hard-deploy base of the cluster
-    {upgrade_previous, "2.9.8"}, % version currently running (relup is built from this)
-    {upgrade_to, "2.9.10"},       % target version
+    {upgrade_from, "2.9.10"},
+    {upgrade_previous, "2.9.0"},
+    {upgrade_to, "2.9.0"},
     % list() | [<<"all">>]
     {regions, [
-        <<"apne21">>,
-        <<"euw31">>
+        <<"ap-northeast-1">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1096.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the ap-northeast-1 upgrade.**