### PR TITLE
chore: upgrade to v2.9.10 in ap-southeast-1-sec and ap-southeast-2-sec

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,9 +1,14 @@
 [
-    {upgrade_from, "x.x.x"},
-    {upgrade_to, "x.x.x"},
-    % list() | [:all]
-    {regions, ["ap-southeast-1"]},
+    {upgrade_from, "2.9.4"},     % hard-deploy base of the cluster
+    {upgrade_previous, "2.9.4"}, % version currently running (relup is built from this)
+    {upgrade_to, "2.9.10"},       % target version
+    % list() | [<<"all">>]
+    {regions, [
+        <<"ap-southeast-1-sec">>,
+        <<"ap-southeast-2-sec">>
+            ]},
     % :soft | :hard
-    {type, soft}
+    {type, hard}
 ].
 % supavisor_soft_all-1_1.1.13_1.1.39
+% vi: ft=erlang


### PR DESCRIPTION
https://linear.app/supabase/issue/POOLER-542/roll-out-v298-to-ap-southeast-1-sec-from-v294
https://linear.app/supabase/issue/POOLER-405/roll-out-v298-to-ap-southeast-2-sec-from-v290

## TODO

- [ ] Disable `elx_updater` on both ap-southeast-1-sec and ap-southeast-2-sec clusters **before** merging this PR so the updater does not install the release immediately

## Rollback plan

If the upgrade needs to be reverted after this PR merges:

* rollback ap-southeast-1-sec to v2.9.4: #1101
* rollback ap-southeast-2-sec to v2.9.0: #1102