### PR TITLE
chore: rollback ap-southeast-1-sec to v2.9.4

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,9 +1,13 @@
 [
-    {upgrade_from, "x.x.x"},
-    {upgrade_to, "x.x.x"},
-    % list() | [:all]
-    {regions, ["ap-southeast-1"]},
+    {upgrade_from, "2.9.10"},     % hard-deploy base of the cluster
+    {upgrade_previous, "2.9.4"}, % version currently running (relup is built from this)
+    {upgrade_to, "2.9.4"},       % target version
+    % list() | [<<"all">>]
+    {regions, [
+        <<"ap-southeast-1-sec">>
+            ]},
     % :soft | :hard
-    {type, soft}
+    {type, hard}
 ].
 % supavisor_soft_all-1_1.1.13_1.1.39
+% vi: ft=erlang


### PR DESCRIPTION
Standby rollback for #1100

Rollback ap-southeast-1-sec from v2.9.10 to v2.9.4 if the upgrade needs to be reverted.

https://linear.app/supabase/issue/POOLER-542/roll-out-v298-to-ap-southeast-1-sec-from-v294