### PR TITLE
chore: rollback us-west-2 to v2.9.1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,12 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
-    {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_from, "2.9.10"},
+    {upgrade_previous, "2.9.1"},
+    {upgrade_to, "2.9.1"},
     % list() | [<<"all">>]
     {regions, [
-        <<"ap-northeast-1">>,
-        <<"sae11">>,
-        <<"euc11">>
+        <<"us-west-2">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1104.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the us-west-2 upgrade.**