### PR TITLE
chore: rollback sa-east-1-sec to v2.9.4

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,12 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
-    {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_from, "2.9.10"},
+    {upgrade_previous, "2.9.4"},
+    {upgrade_to, "2.9.4"},
     % list() | [<<"all">>]
     {regions, [
-        <<"eu-west-1">>,
-        <<"us-west-2">>,
-        <<"eun11">>
+        <<"sa-east-1-sec">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1108.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the sa-east-1-sec upgrade.**