### PR TITLE
chore: rollback aps11 to v2.9.2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,12 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
+    {upgrade_from, "2.9.10"},
     {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_to, "2.9.2"},
     % list() | [<<"all">>]
     {regions, [
-        <<"eu-west-1">>,
-        <<"us-west-2">>,
-        <<"eun11">>
+        <<"aps11">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1108.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the aps11 upgrade.**