### PR TITLE
chore: rollback to v2.9.2 in ap-south-1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,7 +1,7 @@
 [
-    {upgrade_from, "2.9.2"},
+    {upgrade_from, "2.9.10"},
     {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_to, "2.9.2"},
     % list() | [<<"all">>]
     {regions, [
         <<"ap-south-1">>

--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -4,7 +4,7 @@
     {upgrade_to, "2.9.10"},
     % list() | [<<"all">>]
     {regions, [
-        <<"sa-south-1">>
+        <<"ap-south-1">>
             ]},
     % :soft | :hard
     {type, hard}

--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -4,10 +4,7 @@
     {upgrade_to, "2.9.10"},
     % list() | [<<"all">>]
     {regions, [
-        <<"sa-east-1-sec">>,
-        <<"apse21">>,
-        <<"apse11">>,
-        <<"aps11">>
+        <<"sa-south-1">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1114.

The -rb tag suffix is not required as we roll out a new AMI in this region.

Do NOT merge unless rolling back the ap-south-1 upgrade.