### PR TITLE
chore: rollback to v2.9.2 in eu-central-2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,13 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
+    {upgrade_from, "2.9.10"},
     {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_to, "2.9.2"},
     % list() | [<<"all">>]
     {regions, [
-        <<"sa-east-1-sec">>,
-        <<"apse21">>,
-        <<"apse11">>,
-        <<"aps11">>
+        <<"eu-central-2">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Rollback for supavisor https://github.com/supabase/supavisor/pull/1116

Do not merge unless rolling back 2.9.10 in eu-central-2
