### PR TITLE
chore: rollback us-east-2 to v2.9.4

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,13 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
-    {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_from, "2.9.10"},
+    {upgrade_previous, "2.9.4"},
+    {upgrade_to, "2.9.4"},
     % list() | [<<"all">>]
     {regions, [
-        <<"sa-east-1-sec">>,
-        <<"apse21">>,
-        <<"apse11">>,
-        <<"aps11">>
+        <<"us-east-2">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1118.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the us-east-2 upgrade.**