### PR TITLE
chore: rollback eu-central-1-ter to v2.9.5

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,13 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
-    {upgrade_previous, "2.9.2"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_from, "2.9.10"},
+    {upgrade_previous, "2.9.5"},
+    {upgrade_to, "2.9.5"},
     % list() | [<<"all">>]
     {regions, [
-        <<"sa-east-1-sec">>,
-        <<"apse21">>,
-        <<"apse11">>,
-        <<"aps11">>
+        <<"eu-central-1-ter">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1118.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the eu-central-1-ter upgrade.**