### PR TITLE
chore: rollback to v2.9.6 in ca-central-1

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.2"},
+    {upgrade_from, "2.9.10"},
     {upgrade_previous, "2.9.4"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_to, "2.9.6"},
     % list() | [<<"all">>]
     {regions, [
-        <<"ap-south-1">>
+        <<"ca-central-1">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1123.

The -rb tag suffix is not required as we roll out a new AMI in this region.

Do NOT merge unless rolling back the ca-central-1 upgrade.
