### PR TITLE
chore: rollback to v2.9.7 in ap-northeast-2

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.6"},
+    {upgrade_from, "2.9.10"},
     {upgrade_previous, "2.9.4"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_to, "2.9.7"},
     % list() | [<<"all">>]
     {regions, [
-        <<"ca-central-1">>
+        <<"ap-northeast-2">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1126.

The -rb tag suffix is not required as we roll out a new AMI in this region.

Do NOT merge unless rolling back the ap-northeast-2 upgrade.