### PR TITLE
chore: upgrade to v2.9.10 in us-west-1-sec

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.7"},
-    {upgrade_previous, "2.9.4"},
+    {upgrade_from, "2.9.6"},
+    {upgrade_previous, "2.9.6"},
     {upgrade_to, "2.9.10"},
     % list() | [<<"all">>]
     {regions, [
-        <<"ap-northeast-2">>
+        <<"us-west-1-sec">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
upgrade us-west-1-sec to supavisor v2.9.10 from 2.9.6

POOLER_544

platform https://github.com/supabase/platform/pull/36183