### PR TITLE
Chore/pooler 544 rollback to 2.9.6 in us west 1 sec

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.7"},
-    {upgrade_previous, "2.9.4"},
+    {upgrade_from, "2.9.6"},
+    {upgrade_previous, "2.9.6"},
     {upgrade_to, "2.9.10"},
     % list() | [<<"all">>]
     {regions, [
-        <<"ap-northeast-2">>
+        <<"us-west-1-sec">>
             ]},
     % :soft | :hard
     {type, hard}

--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,7 +1,7 @@
 [
-    {upgrade_from, "2.9.6"},
+    {upgrade_from, "2.9.10"},
     {upgrade_previous, "2.9.6"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_to, "2.9.6"},
     % list() | [<<"all">>]
     {regions, [
         <<"us-west-1-sec">>


### PR DESCRIPTION
Rollback upgrade from v2.9.10 to v2.9.6 on us-west-1-sec
 
upgrade https://github.com/supabase/supavisor/pull/1128

Do not merge unless we need to rollback.
