### PR TITLE
chore: rollback to v2.9.2 in us-east-1-ter

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.6"},
+    {upgrade_from, "2.9.10"},
     {upgrade_previous, "2.9.6"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_to, "2.9.6"},
     % list() | [<<"all">>]
     {regions, [
-        <<"us-west-1-sec">>
+        <<"us-east-1-ter">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1131.

The -rb tag suffix is not required as we roll out a new AMI in this region.

Do NOT merge unless rolling back the us-east-1-ter upgrade.
