### PR TITLE
chore: upgrade to v2.9.10 in euc11 (staging)

### DIFF
--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,9 +1,9 @@
 [
-    {upgrade_from, "2.9.7"}, %% base on VM, last hard
-    {upgrade_previous, "2.9.7"}, %% current version on VM, includes soft deploys
+    {upgrade_from, "2.9.6-rc.0"}, %% base on VM, last hard
+    {upgrade_previous, "2.9.6-rc.0"}, %% current version on VM, includes soft deploys
     {upgrade_to, "2.9.10"},
     % list() | [<<"all">>]
-    {regions, [<<"ap-southeast-1-blu">>]},
+    {regions, [<<"euc11">>]},
     % :soft | :hard
     {type, hard}
 ].


### PR DESCRIPTION
POOLER-617

upgrade staging euc11 to v2.9.10 to test AMI_VERSION

rollback https://github.com/supabase/supavisor/pull/1134
platform https://github.com/supabase/supavisor/pull/1086
