### PR TITLE
Chore/pooler 617 rollback to 2.9.6 rc0 in euc11 staging

### DIFF
--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,7 +1,7 @@
 [
-    {upgrade_from, "2.9.6-rc.0"}, %% base on VM, last hard
-    {upgrade_previous, "2.9.6-rc.0"}, %% current version on VM, includes soft deploys
-    {upgrade_to, "2.9.10"},
+    {upgrade_from, "2.9.10"}, %% base on VM, last hard
+    {upgrade_previous, "2.9.10"}, %% current version on VM, includes soft deploys
+    {upgrade_to, "2.9.6-rc.0"},
     % list() | [<<"all">>]
     {regions, [<<"euc11">>]},
     % :soft | :hard

--- a/deploy/upgrade/staging.config
+++ b/deploy/upgrade/staging.config
@@ -1,9 +1,9 @@
 [
-    {upgrade_from, "2.9.7"}, %% base on VM, last hard
-    {upgrade_previous, "2.9.7"}, %% current version on VM, includes soft deploys
+    {upgrade_from, "2.9.6-rc.0"}, %% base on VM, last hard
+    {upgrade_previous, "2.9.6-rc.0"}, %% current version on VM, includes soft deploys
     {upgrade_to, "2.9.10"},
     % list() | [<<"all">>]
-    {regions, [<<"ap-southeast-1-blu">>]},
+    {regions, [<<"euc11">>]},
     % :soft | :hard
     {type, hard}
 ].


### PR DESCRIPTION
POOLER-617

If necessary, rollback to v2.9.6-rc.0 in euc11 staging

https://github.com/supabase/supavisor/pull/1133
