### PR TITLE
feat: add server_idle_timeout

### DIFF
--- a/docs/configuration/tenants.md
+++ b/docs/configuration/tenants.md
@@ -44,4 +44,6 @@ connection
 
 `client_idle_timeout` - the maximum duration of an idle client connection
 
+`server_idle_timeout` - the maximum duration of an idle database connection
+
 `allow_list` - a list of CIDR ranges which are allowed to connect

--- a/lib/supavisor.ex
+++ b/lib/supavisor.ex
@@ -373,7 +373,9 @@ defmodule Supavisor do
                 %{
                   replica_type: type,
                   pool_size:
-                    if(first_user, do: first_user.pool_size, else: tenant.default_pool_size)
+                    if(first_user, do: first_user.pool_size, else: tenant.default_pool_size),
+                  server_idle_timeout:
+                    if(first_user, do: first_user.server_idle_timeout, else: 300_000)
                 }
 
               %Tenants.Tenant{} = tenant ->
@@ -382,7 +384,9 @@ defmodule Supavisor do
                 %{
                   replica_type: :write,
                   pool_size:
-                    if(first_user, do: first_user.pool_size, else: tenant.default_pool_size)
+                    if(first_user, do: first_user.pool_size, else: tenant.default_pool_size),
+                  server_idle_timeout:
+                    if(first_user, do: first_user.server_idle_timeout, else: 300_000)
                 }
             end
           end)

--- a/lib/supavisor/tenant_supervisor.ex
+++ b/lib/supavisor/tenant_supervisor.ex
@@ -31,7 +31,10 @@ defmodule Supavisor.TenantSupervisor do
           id: {:pool, id},
           start:
             {:poolboy, :start_link,
-             [pool_spec(name, min_size, e.pool_size), %{id: args.id, pool: name}]},
+             [
+               pool_spec(name, min_size, e.pool_size, e.server_idle_timeout),
+               %{id: args.id, pool: name}
+             ]},
           restart: :temporary,
           type: :supervisor
         }
@@ -68,15 +71,15 @@ defmodule Supavisor.TenantSupervisor do
     }
   end
 
-  @spec pool_spec(tuple, integer, integer) :: Keyword.t()
-  defp pool_spec(name, min_size, pool_size) do
+  @spec pool_spec(tuple, integer, integer, integer) :: Keyword.t()
+  defp pool_spec(name, min_size, pool_size, server_idle_timeout) do
     [
       name: name,
       worker_module: Supavisor.DbHandler,
       size: min_size,
       max_overflow: pool_size,
       strategy: :lifo,
-      idle_timeout: :timer.minutes(5)
+      idle_timeout: server_idle_timeout
     ]
   end
 end

--- a/lib/supavisor/tenants/user.ex
+++ b/lib/supavisor/tenants/user.ex
@@ -16,6 +16,7 @@ defmodule Supavisor.Tenants.User do
     field(:mode_type, Ecto.Enum, values: [:transaction, :session])
     field(:pool_size, :integer)
     field(:pool_checkout_timeout, :integer, default: 60_000)
+    field(:server_idle_timeout, :integer, default: 300_000)
     field(:max_clients, :integer)
     belongs_to(:tenant, Supavisor.Tenants.Tenant, foreign_key: :tenant_external_id, type: :string)
     timestamps()
@@ -39,6 +40,7 @@ defmodule Supavisor.Tenants.User do
       :mode_type,
       :is_manager,
       :pool_checkout_timeout,
+      :server_idle_timeout,
       :max_clients
     ])
     |> validate_required([

--- a/priv/repo/migrations/20260803175558_add_server_idle_timeout_to_users.exs
+++ b/priv/repo/migrations/20260803175558_add_server_idle_timeout_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Supavisor.Repo.Migrations.AddServerIdleTimeoutToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table("users", prefix: "_supavisor") do
+      add(:server_idle_timeout, :integer, null: false, default: 300_000)
+    end
+  end
+end

--- a/test/supavisor/tenants_test.exs
+++ b/test/supavisor/tenants_test.exs
@@ -122,6 +122,7 @@ defmodule Supavisor.TenantsTest do
       assert user.db_password == "some db_password"
       assert user.db_user == "some db_user"
       assert user.pool_size == 3
+      assert user.server_idle_timeout == 300_000
     end
 
     test "create_tenant/1 with invalid data returns error changeset" do


### PR DESCRIPTION
Exposes the hardcoded poolboy idle_timeout as a new `server_idle_timeout` user config option. This mirrors the behavior of pgbouncer's `server_idle_timeout` config option. Above the minimum warm pool, each idle connections is closed once their timeout completes (preserves the existing 5 minutes as default).