### PR TITLE
fix: add project metadata to syn conflict resolution logs

### DIFF
--- a/lib/supavisor/syn_handler.ex
+++ b/lib/supavisor/syn_handler.ex
@@ -29,12 +29,16 @@ defmodule Supavisor.SynHandler do
   @impl true
   def resolve_registry_conflict(
         :tenants,
-        id,
+        Supavisor.id(type: type, tenant: tenant, user: user, mode: mode, db: db, search_path: _) =
+          id,
         {pid1, _, time1} = remote,
         {pid2, _, time2} = local
       ) do
+    meta = %{project: tenant, user: user, mode: mode, db_name: db, type: type}
+
     Logger.info(
-      "SynHandler: resolving #{Supavisor.inspect_id(id)} conflict: #{inspect(local)} vs #{inspect(remote)}"
+      "SynHandler: resolving #{Supavisor.inspect_id(id)} conflict: #{inspect(local)} vs #{inspect(remote)}",
+      meta
     )
 
     {keep, stop} =
@@ -67,12 +71,14 @@ defmodule Supavisor.SynHandler do
           end
 
         Logger.warning(
-          "SynHandler: Resolving #{Supavisor.inspect_id(id)} conflict, stop local pid: #{inspect(stop)}, response: #{inspect(resp)}"
+          "SynHandler: Resolving #{Supavisor.inspect_id(id)} conflict, stop local pid: #{inspect(stop)}, response: #{inspect(resp)}",
+          meta
         )
       end)
     else
       Logger.warning(
-        "SynHandler: Resolving #{Supavisor.inspect_id(id)} conflict, remote pid: #{inspect(stop)}"
+        "SynHandler: Resolving #{Supavisor.inspect_id(id)} conflict, remote pid: #{inspect(stop)}",
+        meta
       )
     end
 

--- a/lib/supavisor/syn_handler.ex
+++ b/lib/supavisor/syn_handler.ex
@@ -29,7 +29,7 @@ defmodule Supavisor.SynHandler do
   @impl true
   def resolve_registry_conflict(
         :tenants,
-        Supavisor.id(type: type, tenant: tenant, user: user, mode: mode, db: db, search_path: _) =
+        Supavisor.id(type: type, tenant: tenant, user: user, mode: mode, db: db) =
           id,
         {pid1, _, time1} = remote,
         {pid2, _, time2} = local

--- a/priv/repo/seeds_after_migration.exs
+++ b/priv/repo/seeds_after_migration.exs
@@ -34,7 +34,14 @@ if !Tenants.get_tenant_by_external_id("is_manager") do
     |> Tenants.create_tenant()
 end
 
-["proxy_tenant1", "syn_tenant", "prom_tenant", "max_pool_tenant", "metrics_tenant"]
+[
+  "proxy_tenant1",
+  "syn_tenant",
+  "syn_tenant_local_wins",
+  "prom_tenant",
+  "max_pool_tenant",
+  "metrics_tenant"
+]
 |> Enum.each(fn tenant ->
   if !Tenants.get_tenant_by_external_id(tenant) do
     {:ok, _} =
@@ -220,9 +227,11 @@ end
       |> Tenants.create_tenant()
   end
 end)
+
 # Create cluster test tenants for integration tests
 for i <- 1..10 do
   tenant_id = "cluster_pool_tenant_#{i}"
+
   if !Tenants.get_tenant_by_external_id(tenant_id) do
     {:ok, _} =
       %{

--- a/test/supavisor/syn_handler_test.exs
+++ b/test/supavisor/syn_handler_test.exs
@@ -32,12 +32,19 @@ defmodule Supavisor.SynHandlerTest do
     assert pid1 == Supavisor.get_global_sup(@id)
     assert node(pid1) == node()
 
-    true = Node.connect(node2)
-    Process.sleep(500)
+    log =
+      capture_log(fn ->
+        true = Node.connect(node2)
+        Process.sleep(500)
+      end)
 
-    msg = "Resolving syn_tenant conflict, stop local pid"
-
-    assert capture_log(fn -> Logger.warning(msg) end) =~ msg
+    assert log =~ "SynHandler: resolving"
+    assert log =~ ~s(tenant: "syn_tenant")
+    assert log =~ "SynHandler: Resolving"
+    assert log =~ "conflict, stop local pid"
+    assert log =~ "project=syn_tenant"
+    assert log =~ "user=postgres"
+    assert log =~ "mode=session"
 
     assert pid2 == Supavisor.get_global_sup(@id)
     assert node(pid2) == node2

--- a/test/supavisor/syn_handler_test.exs
+++ b/test/supavisor/syn_handler_test.exs
@@ -14,6 +14,14 @@ defmodule Supavisor.SynHandlerTest do
         db: "postgres"
       )
 
+  @id_local_wins Supavisor.id(
+                   type: :single,
+                   tenant: "syn_tenant_local_wins",
+                   user: "postgres",
+                   mode: :session,
+                   db: "postgres"
+                 )
+
   @tag cluster: true
   test "resolving conflict" do
     {:ok, peer, node2} = Cluster.start_node_unclustered(:peer.random_name())
@@ -48,6 +56,46 @@ defmodule Supavisor.SynHandlerTest do
 
     assert pid2 == Supavisor.get_global_sup(@id)
     assert node(pid2) == node2
+  end
+
+  @tag cluster: true
+  test "resolving conflict, local pid wins" do
+    {:ok, peer, node2} = Cluster.start_node_unclustered(:peer.random_name())
+
+    secret = %Supavisor.Secrets.PasswordSecrets{
+      user: "postgres",
+      password: "postgres"
+    }
+
+    # Register the local pid first so it gets the earlier timestamp, making
+    # it the pid that's kept and forcing the remote (peer) pid to be stopped.
+    assert nil == Supavisor.get_global_sup(@id_local_wins)
+    {:ok, pid_local} = Supavisor.start(@id_local_wins, secret)
+    assert pid_local == Supavisor.get_global_sup(@id_local_wins)
+    assert node(pid_local) == node()
+
+    {:ok, pid_remote} =
+      :peer.call(peer, Supavisor.FixturesHelpers, :start_pool, [@id_local_wins, secret])
+
+    assert :peer.call(peer, Supavisor, :get_global_sup, [@id_local_wins]) == pid_remote
+    assert node(pid_remote) == node2
+
+    log =
+      capture_log(fn ->
+        true = Node.connect(node2)
+        Process.sleep(500)
+      end)
+
+    assert log =~ "SynHandler: resolving"
+    assert log =~ ~s(tenant: "syn_tenant_local_wins")
+    assert log =~ "SynHandler: Resolving"
+    assert log =~ "conflict, remote pid"
+    assert log =~ "project=syn_tenant_local_wins"
+    assert log =~ "user=postgres"
+    assert log =~ "mode=session"
+
+    assert pid_local == Supavisor.get_global_sup(@id_local_wins)
+    assert node(pid_local) == node()
   end
 
   setup tags do


### PR DESCRIPTION
Attach project/user/mode/db_name/type Logger metadata to resolve_registry_conflict/4 logs, matching the existing on_process_unregistered/5 convention, so pool conflict logs can be filtered by tenant.

POOLER-605