### PR TITLE
security: upgrade erlang, openssl, postgresql; strip vim from runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #   - Ex: hexpm/elixir:1.14.0-erlang-25.0.3-debian-bullseye-20210902-slim
 #
 ARG ELIXIR_VERSION=1.18.4
-ARG OTP_VERSION=27.3.4.12
+ARG OTP_VERSION=27.3.4.15
 ARG DEBIAN_VERSION=trixie-20260518-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
@@ -64,7 +64,8 @@ RUN mix release supavisor
 # Start a new build stage for the final image
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses6 locales vim curl htop postgresql-contrib sudo tini cmake libclang-dev \
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses6 locales curl htop postgresql-contrib sudo tini \
+  && apt-get upgrade -y openssl \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale

--- a/priv/jit/postgres/Dockerfile
+++ b/priv/jit/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:17.5
+FROM postgres:17.10
 
 
 COPY init.sh /docker-entrypoint-initdb.d/ssl-config.sh


### PR DESCRIPTION
## Security: Upgrade dependencies to fix critical/high CVEs

### Changes
- **Erlang/OTP 27.3.4.12 → 27.3.4.15** — fixes 40 CVEs (critical), including CVE-2025-32433 (SSH RCE)
- **Removed vim, cmake, libclang-dev from runtime image** — 347 findings eliminated (dev/build tools in production)
- **Added `apt-get upgrade -y openssl`** in runtime stage to ensure latest OpenSSL patches (58 findings, critical)
- **JIT PostgreSQL 17.5 → 17.10** — fixes 16 high-severity PostgreSQL CVEs

### Findings addressed
| Package | Findings | Severity | Fix |
|---------|----------|----------|-----|
| erlang | 40 | 🔴 Critical | Version bump to 27.3.4.15 |
| openssl | 58 | 🔴 Critical | apt-get upgrade in runtime stage |
| vim/vim-common/xxd | 347+ | 🟠 High | Removed from runtime image |
| postgresql | 16 | 🟠 High | Base image bump to 17.10 |

### Triage source
Generated by [Latent Defense](https://latentdefense.ai) structural triage — findings grouped by shared precondition (root-cause package), fixes target the precondition rather than individual CVEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)