### PR TITLE
chore: rollback eu-west-2-sec to v2.9.8

### DIFF
--- a/deploy/upgrade/prod.config
+++ b/deploy/upgrade/prod.config
@@ -1,10 +1,10 @@
 [
-    {upgrade_from, "2.9.6"},
-    {upgrade_previous, "2.9.6"},
-    {upgrade_to, "2.9.10"},
+    {upgrade_from, "2.9.10"},
+    {upgrade_previous, "2.9.8"},
+    {upgrade_to, "2.9.8"},
     % list() | [<<"all">>]
     {regions, [
-        <<"use11-ter">>
+        <<"eu-west-2-sec">>
             ]},
     % :soft | :hard
     {type, hard}


### PR DESCRIPTION
Standby rollback for #1143.

The `-rb` tag suffix is not required as we roll out a new AMI in this region.

**Do NOT merge unless rolling back the eu-west-2-sec upgrade.**