### PR TITLE
feat: add node IPv6 address metric via getifaddrs

### DIFF
--- a/lib/supavisor/monitoring/cluster.ex
+++ b/lib/supavisor/monitoring/cluster.ex
@@ -71,6 +71,19 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
             tags: [:version]
           )
         ]
+      ),
+      Manual.build(
+        :supavisor_node_ipv6_manual_metrics,
+        {__MODULE__, :emit_node_ipv6, []},
+        [
+          last_value(
+            [:supavisor, :prom_ex, :node, :ipv6, :info],
+            event_name: [:supavisor, :prom_ex, :node, :ipv6],
+            measurement: :status,
+            description: "The IPv6 address of the node.",
+            tags: [:address]
+          )
+        ]
       )
     ]
   end
@@ -124,6 +137,46 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
         :ok
     end
   end
+
+  @spec emit_node_ipv6() :: :ok
+  def emit_node_ipv6 do
+    case node_ipv6_address() do
+      nil ->
+        :ok
+
+      address ->
+        :telemetry.execute(
+          [:supavisor, :prom_ex, :node, :ipv6],
+          %{status: 1},
+          %{address: address}
+        )
+    end
+  end
+
+  @spec node_ipv6_address() :: String.t() | nil
+  def node_ipv6_address do
+    case :inet.getifaddrs() do
+      {:ok, addrs} ->
+        addrs
+        |> Enum.flat_map(fn {_ifname, opts} -> Keyword.get_values(opts, :addr) end)
+        |> Enum.find(&global_ipv6?/1)
+        |> case do
+          nil -> nil
+          addr -> addr |> :inet.ntoa() |> List.to_string()
+        end
+
+      {:error, _reason} ->
+        nil
+    end
+  end
+
+  @spec global_ipv6?(:inet.ip_address()) :: boolean()
+  # Loopback (::1)
+  def global_ipv6?({0, 0, 0, 0, 0, 0, 0, 1}), do: false
+  # Link-local (fe80::/10)
+  def global_ipv6?({a, _, _, _, _, _, _, _}) when a >= 0xFE80 and a <= 0xFEBF, do: false
+  def global_ipv6?(addr) when tuple_size(addr) == 8, do: true
+  def global_ipv6?(_addr), do: false
 
   @spec emit_erpc_latency() :: :ok
   def emit_erpc_latency do

--- a/lib/supavisor/monitoring/cluster.ex
+++ b/lib/supavisor/monitoring/cluster.ex
@@ -52,6 +52,20 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
             tags: [:current, :permanent, :base, :previous]
           )
         ]
+      ),
+      Polling.build(
+        :supavisor_node_ipv6_events,
+        poll_rate,
+        {__MODULE__, :emit_node_ipv6, []},
+        [
+          last_value(
+            [:supavisor, :prom_ex, :node, :ipv6, :info],
+            event_name: [:supavisor, :prom_ex, :node, :ipv6],
+            measurement: :status,
+            description: "The IPv6 address of the node.",
+            tags: [:address]
+          )
+        ]
       )
     ]
   end
@@ -69,19 +83,6 @@ defmodule Supavisor.PromEx.Plugins.Cluster do
             measurement: :status,
             description: "The AMI version the node is running on.",
             tags: [:version]
-          )
-        ]
-      ),
-      Manual.build(
-        :supavisor_node_ipv6_manual_metrics,
-        {__MODULE__, :emit_node_ipv6, []},
-        [
-          last_value(
-            [:supavisor, :prom_ex, :node, :ipv6, :info],
-            event_name: [:supavisor, :prom_ex, :node, :ipv6],
-            measurement: :status,
-            description: "The IPv6 address of the node.",
-            tags: [:address]
           )
         ]
       )

--- a/test/supavisor/monitoring/cluster_test.exs
+++ b/test/supavisor/monitoring/cluster_test.exs
@@ -121,6 +121,57 @@ defmodule Supavisor.PromEx.Plugins.ClusterTest do
     end
   end
 
+  describe "emit_node_ipv6/0" do
+    test "emits node ipv6 event when a global IPv6 address is available" do
+      ref = attach_handler([:supavisor, :prom_ex, :node, :ipv6])
+
+      assert :ok = Cluster.emit_node_ipv6()
+
+      case Cluster.node_ipv6_address() do
+        nil ->
+          refute_receive {^ref, {[:supavisor, :prom_ex, :node, :ipv6], _measurement, _meta}}
+
+        expected_address ->
+          assert_receive {^ref, {[:supavisor, :prom_ex, :node, :ipv6], measurement, meta}}
+          assert %{status: 1} = measurement
+          assert %{address: ^expected_address} = meta
+      end
+    end
+  end
+
+  describe "global_ipv6?/1" do
+    test "rejects the loopback address" do
+      refute Cluster.global_ipv6?({0, 0, 0, 0, 0, 0, 0, 1})
+    end
+
+    test "rejects link-local addresses (fe80::/10)" do
+      refute Cluster.global_ipv6?({0xFE80, 0, 0, 0, 0, 0, 0, 1})
+
+      refute Cluster.global_ipv6?(
+               {0xFEBF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF}
+             )
+    end
+
+    test "accepts global and unique-local IPv6 addresses" do
+      assert Cluster.global_ipv6?({0x2406, 0xDA18, 0x4FD, 0x9B02, 0xF1F7, 0x7026, 0x5CDA, 0xEE90})
+
+      assert Cluster.global_ipv6?(
+               {0xFD10, 0x3D6F, 0x1A98, 0x4B8C, 0x1442, 0xBF82, 0xF7AF, 0x9E3C}
+             )
+
+      # Just outside the fe80::/10 range on either side
+      assert Cluster.global_ipv6?(
+               {0xFE7F, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF}
+             )
+
+      assert Cluster.global_ipv6?({0xFEC0, 0, 0, 0, 0, 0, 0, 1})
+    end
+
+    test "rejects non-IPv6 (e.g. IPv4) addresses" do
+      refute Cluster.global_ipv6?({127, 0, 0, 1})
+    end
+  end
+
   describe "emit_erpc_latency/0" do
     test "emits ERPC latency events for all nodes" do
       ref = attach_handler([:supavisor, :prom_ex, :cluster, :erpc_ping, :stop])


### PR DESCRIPTION
Reports the node's IPv6 address as a PromEx gauge, discovered locally via :inet.getifaddrs/0 since the ENI's IPv6 doesn't change during the life of a running instance and doesn't require an AWS-specific lookup.

POOLER-631

