### PR TITLE
fix: serialize query cancellation with backend reuse

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -145,9 +145,46 @@ defmodule Supavisor.ClientHandler do
     {:stop, :normal}
   end
 
-  # send cancel request to db
-  def handle_event(:info, :cancel_query, state, data) do
-    :ok = Cancel.maybe_forward_cancel_to_db(state, data)
+  # send cancel request to db — two-phase commit protocol
+  def handle_event(:info, {:cancel_query, from_pid, ref}, :busy, %{db_connection: db_conn} = _data)
+      when db_conn != nil and is_pid(from_pid) do
+    mref = Process.monitor(from_pid)
+    send(from_pid, {:cancel_claim, self(), ref})
+
+    receive do
+      {:cancel_granted, ^ref} ->
+        Process.demonitor(mref, [:flush])
+        {_pool, db_pid, _db_sock} = db_conn
+        DbHandler.cancel_query(db_pid, self())
+        send(from_pid, {:cancel_ack, ref})
+
+      {:DOWN, ^mref, :process, ^from_pid, _reason} ->
+        # Sender timed out or exited before grant. Do NOT cancel backend.
+        :ok
+    after
+      5_000 ->
+        Process.demonitor(mref, [:flush])
+        :ok
+    end
+
+    :keep_state_and_data
+  end
+
+  def handle_event(:info, {:cancel_query, from_pid, ref}, _state, _data)
+      when is_pid(from_pid) do
+    send(from_pid, {:cancel_ack, ref})
+    :keep_state_and_data
+  end
+
+  # send cancel request to db — legacy atom protocol
+  def handle_event(:info, :cancel_query, :busy, %{db_connection: db_conn} = _data)
+      when db_conn != nil do
+    {_pool, db_pid, _db_sock} = db_conn
+    DbHandler.cancel_query(db_pid, self())
+    :keep_state_and_data
+  end
+
+  def handle_event(:info, :cancel_query, _state, _data) do
     :keep_state_and_data
   end
 

--- a/lib/supavisor/client_handler/cancel.ex
+++ b/lib/supavisor/client_handler/cancel.ex
@@ -15,19 +15,64 @@ defmodule Supavisor.ClientHandler.Cancel do
 
   require Logger
   alias Phoenix.PubSub
-  alias Supavisor.HandlerHelpers
-  require Supavisor.Protocol.Server, as: Server
+
+  @pre_claim_timeout 5_000
+  @post_grant_timeout 15_000
 
   @doc """
-  Called upon receiving cancel requests, broadcasts to relevant client handler
+  Called upon receiving cancel requests, broadcasts to relevant client handler and waits for acknowledgment
+  before closing the cancel connection.
   """
-  @spec send_cancel_query(non_neg_integer, non_neg_integer, term) :: :ok | {:errr, term}
-  def send_cancel_query(pid, key, msg \\ :cancel_query) do
+  @spec send_cancel_query(non_neg_integer, non_neg_integer, term) :: :ok | {:error, term}
+  def send_cancel_query(pid, key, msg \\ :cancel_query)
+
+  def send_cancel_query(pid, key, :cancel_query) do
+    ref = make_ref()
+
+    PubSub.broadcast(
+      Supavisor.PubSub,
+      "cancel_req:#{pid}_#{key}",
+      {:cancel_query, self(), ref}
+    )
+
+    wait_for_claim(ref)
+  end
+
+  def send_cancel_query(pid, key, msg) do
     PubSub.broadcast(
       Supavisor.PubSub,
       "cancel_req:#{pid}_#{key}",
       msg
     )
+  end
+
+  defp wait_for_claim(ref) do
+    receive do
+      {:cancel_claim, owner_pid, ^ref} ->
+        mref = Process.monitor(owner_pid)
+        send(owner_pid, {:cancel_granted, ref})
+        wait_for_ack(ref, owner_pid, mref)
+
+      {:cancel_ack, ^ref} ->
+        :ok
+    after
+      @pre_claim_timeout -> :ok
+    end
+  end
+
+  defp wait_for_ack(ref, owner_pid, mref) do
+    receive do
+      {:cancel_ack, ^ref} ->
+        Process.demonitor(mref, [:flush])
+        :ok
+
+      {:DOWN, ^mref, :process, ^owner_pid, _reason} ->
+        :ok
+    after
+      @post_grant_timeout ->
+        Process.demonitor(mref, [:flush])
+        :ok
+    end
   end
 
   @doc """
@@ -36,43 +81,5 @@ defmodule Supavisor.ClientHandler.Cancel do
   @spec listen_cancel_query(non_neg_integer, non_neg_integer) :: :ok | {:errr, term}
   def listen_cancel_query(pid, key) do
     PubSub.subscribe(Supavisor.PubSub, "cancel_req:#{pid}_#{key}")
-  end
-
-  @doc """
-  If there's an ongoing query, forward the message to cancel it to the checked out connection
-
-  Called by the client handler when receiving a cancel requests
-  """
-  def maybe_forward_cancel_to_db(:busy, data) do
-    key = {data.tenant, data.db_connection}
-    Logger.debug("ClientHandler: Cancel query for #{inspect(key)}")
-    {_pool, db_pid, _db_sock} = data.db_connection
-
-    case db_pid_meta(key) do
-      [{^db_pid, meta}] ->
-        msg = Server.cancel_message(meta.pid, meta.key)
-        opts = [:binary, {:packet, :raw}, {:active, true}, meta.ip_version]
-        {:ok, sock} = :gen_tcp.connect(meta.host, meta.port, opts)
-        sock = {:gen_tcp, sock}
-        :ok = HandlerHelpers.sock_send(sock, msg)
-        :ok = HandlerHelpers.sock_close(sock)
-
-      error ->
-        Logger.error(
-          "ClientHandler: Received cancel but no proc was found #{inspect(key)} #{inspect(error)}"
-        )
-    end
-  end
-
-  def maybe_forward_cancel_to_db(_state, _data) do
-    :ok
-  end
-
-  defp db_pid_meta({_, {_, pid, _}} = _key) do
-    rkey = Supavisor.Registry.PoolPids
-
-    pid
-    |> node()
-    |> :erpc.call(Registry, :lookup, [rkey, pid], 15_000)
   end
 end

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -179,6 +179,30 @@ defmodule Supavisor.DbHandler do
   end
 
   @doc """
+  Cancels the currently executing query on this backend connection.
+
+  Opens a PostgreSQL CancelRequest connection and waits for PostgreSQL to close
+  it, confirming the cancellation was processed. While the cancel is in flight,
+  the DbHandler is blocked from processing ReadyForQuery or checking the backend
+  back into the pool.
+
+  The `caller_pid` must match the current owner (`data.caller`). If ownership
+  has changed (e.g. the backend was already checked back in or reassigned), the
+  cancel is rejected to prevent a stale cancellation from affecting a different
+  client's query.
+
+  On timeout or connection error the backend is invalidated (DbHandler stops)
+  rather than being returned to service in an uncertain state.
+  """
+  @cancel_timeout_ms 5_000
+  @spec cancel_query(pid(), pid()) :: :ok | {:error, term()}
+  def cancel_query(db_pid, caller_pid) do
+    :gen_statem.call(db_pid, {:cancel_query, caller_pid}, 10_000)
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  @doc """
   Notifies a DbHandler that secrets are now available
   """
   @spec notify_secrets_available(pid()) :: :ok
@@ -455,6 +479,26 @@ defmodule Supavisor.DbHandler do
 
   def handle_event(:cast, {:expect_ready_for_query, count}, _state, data) do
     {:keep_state, %{data | expected_rfq: data.expected_rfq + count}}
+  end
+
+  # Cancel query — only valid in :busy state with matching caller ownership
+  def handle_event({:call, from}, {:cancel_query, caller_pid}, :busy, %{caller: caller} = data)
+      when is_pid(caller) and caller == caller_pid do
+    case do_cancel_query(data) do
+      :ok ->
+        {:keep_state_and_data, [{:reply, from, :ok}]}
+
+      {:error, reason} ->
+        Logger.error("DbHandler: Cancel query failed: #{inspect(reason)}, invalidating backend")
+
+        {:stop_and_reply, {:shutdown, {:cancel_failed, reason}},
+         [{:reply, from, {:error, reason}}]}
+    end
+  end
+
+  # Cancel query — wrong owner, wrong state, or backend already checked in
+  def handle_event({:call, from}, {:cancel_query, _caller_pid}, _state, _data) do
+    {:keep_state_and_data, [{:reply, from, {:error, :not_owner}}]}
   end
 
   # forward the message to the client
@@ -1272,6 +1316,65 @@ defmodule Supavisor.DbHandler do
       last_failure ->
         elapsed = System.monotonic_time(:millisecond) - last_failure
         @connect_cooldown_ms - elapsed
+    end
+  end
+
+  # Opens a PostgreSQL cancel connection, sends CancelRequest, and waits for
+  # PostgreSQL to close the connection (confirming the cancel was processed).
+  # Uses {:active, false} blocking recv so the DbHandler gen_statem is blocked
+  # during the cancel — this prevents ReadyForQuery/checkin from racing.
+  @spec do_cancel_query(map()) :: :ok | {:error, term()}
+  defp do_cancel_query(data) do
+    require Supavisor.Protocol.Server, as: Server
+
+    meta =
+      case data do
+        %{backend_key_data: %{pid: pid, key: key}, connection_params: params}
+        when is_map(params) ->
+          %{
+            host: params.host,
+            port: params.port,
+            pid: pid,
+            key: key,
+            ip_version: params.ip_version || :inet
+          }
+
+        _ ->
+          case Registry.lookup(Supavisor.Registry.PoolPids, self()) do
+            [{_pid, meta}] -> meta
+            [] -> nil
+          end
+      end
+
+    if meta do
+      cancel_msg = Server.cancel_message(meta.pid, meta.key)
+      opts = [:binary, {:packet, :raw}, {:active, false}, meta.ip_version]
+
+      case :gen_tcp.connect(meta.host, meta.port, opts, @cancel_timeout_ms) do
+        {:ok, sock} ->
+          try do
+            case :gen_tcp.send(sock, cancel_msg) do
+              :ok -> wait_for_cancel_close(sock)
+              {:error, reason} -> {:error, reason}
+            end
+          after
+            :gen_tcp.close(sock)
+          end
+
+        {:error, reason} ->
+          {:error, {:connect_failed, reason}}
+      end
+    else
+      {:error, :no_backend_metadata}
+    end
+  end
+
+  defp wait_for_cancel_close(sock) do
+    case :gen_tcp.recv(sock, 0, @cancel_timeout_ms) do
+      {:error, :closed} -> :ok
+      {:ok, _data} -> wait_for_cancel_close(sock)
+      {:error, :timeout} -> {:error, :cancel_timeout}
+      {:error, reason} -> {:error, reason}
     end
   end
 end

--- a/test/supavisor/client_handler_test.exs
+++ b/test/supavisor/client_handler_test.exs
@@ -1,5 +1,6 @@
 defmodule Supavisor.ClientHandlerTest do
   use ExUnit.Case, async: true
+  require Supavisor
 
   alias Supavisor.Protocol.FrontendMessageHandler
   alias Supavisor.Protocol.MessageStreamer
@@ -209,6 +210,206 @@ defmodule Supavisor.ClientHandlerTest do
                @subject.handle_event(:info, {:tcp, :sock, batch}, :busy, data)
 
       refute_received {:"$gen_cast", {:expect_ready_for_query, _count}}
+    end
+  end
+
+  describe "cancel query handling" do
+    alias Supavisor.ClientHandler.Cancel
+
+    setup do
+      case start_supervised({Phoenix.PubSub, name: Supavisor.PubSub}) do
+        {:ok, _} -> :ok
+        {:error, {:already_started, _}} -> :ok
+      end
+    end
+
+    test "handles {:cancel_query, from_pid, ref} and sends cancel_ack in idle state" do
+      ref = make_ref()
+      data = %{tenant: "test_tenant", db_connection: nil}
+
+      assert :keep_state_and_data =
+               @subject.handle_event(:info, {:cancel_query, self(), ref}, :idle, data)
+
+      assert_received {:cancel_ack, ^ref}
+    end
+
+    test "handles legacy :cancel_query atom message in idle state" do
+      data = %{tenant: "test_tenant", db_connection: nil}
+
+      assert :keep_state_and_data =
+               @subject.handle_event(:info, :cancel_query, :idle, data)
+    end
+
+    test "two-phase commit: busy owner claims, sender grants, DbHandler cancels and acks" do
+      ref = make_ref()
+      test_pid = self()
+
+      # Mock DbHandler process that handles cancel_query call
+      mock_db =
+        spawn_link(fn ->
+          receive do
+            {:"$gen_call", from, {:cancel_query, caller_pid}} ->
+              send(test_pid, {:db_cancelled, caller_pid})
+              :gen_statem.reply(from, :ok)
+          end
+        end)
+
+      data = %{
+        tenant: "test_tenant",
+        db_connection: {:pool, mock_db, {:gen_tcp, :fake_sock}}
+      }
+
+      # Run handle_event in a task (it will send claim and block until grant)
+      handler_task =
+        Task.async(fn ->
+          @subject.handle_event(:info, {:cancel_query, test_pid, ref}, :busy, data)
+        end)
+
+      # 1. Owner claims authorization before contacting DbHandler
+      assert_receive {:cancel_claim, owner_pid, ^ref}
+      # Assert DbHandler has NOT been contacted before grant
+      refute_received {:db_cancelled, _}
+
+      # 2. Sender issues grant
+      send(owner_pid, {:cancel_granted, ref})
+
+      # 3. DbHandler receives cancel call after grant
+      assert_receive {:db_cancelled, ^owner_pid}
+
+      # 4. Sender receives ack
+      assert_receive {:cancel_ack, ^ref}
+
+      # 5. Handler completes cleanly
+      assert :keep_state_and_data = Task.await(handler_task, 2_000)
+    end
+
+    test "expired sender production path: delayed request to busy handler causes ZERO backend cancellation" do
+      ref = make_ref()
+      test_pid = self()
+
+      # Spawn a temporary sender that terminates immediately (simulating an expired cancel request)
+      dead_sender =
+        spawn(fn ->
+          :ok
+        end)
+
+      # Wait for sender to fully exit
+      mref = Process.monitor(dead_sender)
+      assert_receive {:DOWN, ^mref, :process, ^dead_sender, :normal}
+
+      mock_db =
+        spawn_link(fn ->
+          receive do
+            {:"$gen_call", _from, {:cancel_query, _caller_pid}} ->
+              send(test_pid, :unexpected_db_cancel)
+          end
+        end)
+
+      data = %{
+        tenant: "test_tenant",
+        db_connection: {:pool, mock_db, {:gen_tcp, :fake_sock}}
+      }
+
+      # Deliver delayed cancel request from dead sender to busy ClientHandler
+      assert :keep_state_and_data =
+               @subject.handle_event(:info, {:cancel_query, dead_sender, ref}, :busy, data)
+
+      # Assert ZERO backend cancellation occurs!
+      refute_received :unexpected_db_cancel
+    end
+
+    test "Cancel.send_cancel_query/3 grants claim, holds sender until DbHandler completes, and returns on ack" do
+      pid = 1111
+      key = 2222
+      topic = "cancel_req:#{pid}_#{key}"
+      test_pid = self()
+
+      sender_task = Task.async(fn -> Cancel.send_cancel_query(pid, key) end)
+
+      _owner =
+        spawn_link(fn ->
+          Phoenix.PubSub.subscribe(Supavisor.PubSub, topic)
+          send(test_pid, :subscriber_ready)
+
+          receive do
+            {:cancel_query, from_pid, ref} ->
+              # 1. Claim
+              send(from_pid, {:cancel_claim, self(), ref})
+
+              # 2. Wait for grant
+              receive do
+                {:cancel_granted, ^ref} ->
+                  send(test_pid, :grant_received)
+
+                  # Hold cancellation in flight
+                  receive do
+                    :release_db ->
+                      send(from_pid, {:cancel_ack, ref})
+                      send(test_pid, :ack_sent)
+                  end
+              end
+          end
+        end)
+
+      assert_receive :subscriber_ready
+      assert_receive :grant_received
+
+      # Sender must NOT exit while grant is active and ack has not arrived
+      refute Task.yield(sender_task, 100)
+
+      # Release backend cancellation
+      send(_owner, :release_db)
+      assert_receive :ack_sent
+
+      # Sender completes on ack
+      assert :ok = Task.await(sender_task, 2_000)
+    end
+
+    test "Cancel.send_cancel_query/3 releases cleanly when owner dies after grant" do
+      pid = 5555
+      key = 6666
+      topic = "cancel_req:#{pid}_#{key}"
+      test_pid = self()
+
+      sender_task = Task.async(fn -> Cancel.send_cancel_query(pid, key) end)
+
+      owner =
+        spawn(fn ->
+          Phoenix.PubSub.subscribe(Supavisor.PubSub, topic)
+          send(test_pid, :subscriber_ready)
+
+          receive do
+            {:cancel_query, from_pid, ref} ->
+              send(from_pid, {:cancel_claim, self(), ref})
+
+              receive do
+                {:cancel_granted, ^ref} ->
+                  send(test_pid, :grant_received)
+                  # Crash / terminate owner process after grant
+                  exit(:simulated_owner_crash)
+              end
+          end
+        end)
+
+      assert_receive :subscriber_ready
+      assert_receive :grant_received
+
+      # Sender detects owner DOWN via monitor and releases cleanly without hanging
+      assert :ok = Task.await(sender_task, 2_000)
+    end
+
+    test "Cancel.send_cancel_query/3 with custom message broadcasts without waiting" do
+      pid = 3333
+      key = 4444
+      topic = "cancel_req:#{pid}_#{key}"
+      Phoenix.PubSub.subscribe(Supavisor.PubSub, topic)
+
+      assert :ok = Cancel.send_cancel_query(pid, key, :custom_cancel_message)
+      assert_receive :custom_cancel_message
+    end
+
+    test "Cancel.send_cancel_query/3 handles timeout gracefully when no subscriber" do
+      assert :ok = Cancel.send_cancel_query(9999, 9999, :custom_no_wait)
     end
   end
 end

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -11,7 +11,7 @@ defmodule Supavisor.DbHandlerTest do
   alias Supavisor.Protocol.BackendMessageHandler
   alias Supavisor.Protocol.MessageStreamer
   alias Supavisor.Protocol.PreparedStatements.BackendStorage
-  alias Supavisor.Protocol.Server
+  require Supavisor.Protocol.Server, as: Server
 
   require BackendMessageHandler
   require MessageStreamer
@@ -1314,6 +1314,136 @@ defmodule Supavisor.DbHandlerTest do
                Db.handle_event(:cast, {:expect_ready_for_query, 3}, :busy, data)
 
       assert data.expected_rfq == 5
+    end
+  end
+
+  describe "cancel_query" do
+    setup do
+      case Registry.start_link(keys: :unique, name: Supavisor.Registry.PoolPids) do
+        {:ok, _} -> :ok
+        {:error, {:already_started, _}} -> :ok
+      end
+
+      {:ok, listen_sock} =
+        :gen_tcp.listen(0, [:binary, {:packet, :raw}, {:active, false}, {:reuseaddr, true}])
+
+      {:ok, port} = :inet.port(listen_sock)
+      {:ok, listen_sock: listen_sock, cancel_port: port}
+    end
+
+    test "synchronously cancels query on PostgreSQL and blocks until cancel connection closes",
+         %{listen_sock: listen_sock, cancel_port: port} do
+      test_pid = self()
+      caller_pid = spawn(fn -> receive do: (_ -> :ok) end)
+
+      data = %{
+        caller: caller_pid,
+        connection_params: %{host: ~c"127.0.0.1", port: port, ip_version: :inet},
+        backend_key_data: %{pid: 12345, key: 67890}
+      }
+
+      cancel_task =
+        Task.async(fn ->
+          Db.handle_event(
+            {:call, {test_pid, :call_tag}},
+            {:cancel_query, caller_pid},
+            :busy,
+            data
+          )
+        end)
+
+      # 1. Cancel endpoint receives the connection and CancelRequest message
+      {:ok, cancel_server_sock} = :gen_tcp.accept(listen_sock, 2_000)
+      {:ok, bin} = :gen_tcp.recv(cancel_server_sock, 16, 2_000)
+      assert bin == Server.cancel_message(12345, 67890)
+
+      # 2. While cancel socket is HELD OPEN, cancel_task is NOT finished (blocked waiting for close)
+      refute Task.yield(cancel_task, 100)
+
+      # 3. Cancel endpoint closes the connection (PostgreSQL processed the request)
+      :gen_tcp.close(cancel_server_sock)
+
+      # 4. Now cancel completes and replies :ok
+      assert {:keep_state_and_data, [{:reply, {^test_pid, :call_tag}, :ok}]} =
+               Task.await(cancel_task, 2_000)
+    end
+
+    test "rejects cancellation if caller does not match current owner", %{cancel_port: port} do
+      caller_pid = spawn(fn -> receive do: (_ -> :ok) end)
+      wrong_caller = spawn(fn -> receive do: (_ -> :ok) end)
+
+      data = %{
+        caller: caller_pid,
+        connection_params: %{host: ~c"127.0.0.1", port: port, ip_version: :inet},
+        backend_key_data: %{pid: 12345, key: 67890}
+      }
+
+      from = {self(), :call_tag}
+
+      # In busy state with wrong owner
+      assert {:keep_state_and_data, [{:reply, ^from, {:error, :not_owner}}]} =
+               Db.handle_event({:call, from}, {:cancel_query, wrong_caller}, :busy, data)
+
+      # In idle state
+      assert {:keep_state_and_data, [{:reply, ^from, {:error, :not_owner}}]} =
+               Db.handle_event({:call, from}, {:cancel_query, wrong_caller}, :idle, %{
+                 data
+                 | caller: nil
+               })
+    end
+
+    test "invalidates and terminates backend when cancel connection fails" do
+      caller_pid = self()
+      from = {self(), :call_tag}
+
+      data = %{
+        caller: caller_pid,
+        connection_params: %{host: ~c"127.0.0.1", port: 1, ip_version: :inet},
+        backend_key_data: %{pid: 12345, key: 67890}
+      }
+
+      assert {:stop_and_reply, {:shutdown, {:cancel_failed, {:connect_failed, _}}},
+              [{:reply, ^from, {:error, {:connect_failed, _}}}]} =
+               Db.handle_event({:call, from}, {:cancel_query, caller_pid}, :busy, data)
+    end
+
+    test "public cancel_query/2 API delegates to gen_statem call and blocks until cancel socket closes",
+         %{listen_sock: listen_sock, cancel_port: port} do
+      caller_pid = self()
+
+      initial_data = %{
+        caller: caller_pid,
+        connection_params: %{host: ~c"127.0.0.1", port: port, ip_version: :inet},
+        backend_key_data: %{pid: 12345, key: 67890}
+      }
+
+      # Start a real gen_statem process with DbHandler callback in :busy state
+      db_pid =
+        :proc_lib.spawn_link(fn ->
+          :gen_statem.enter_loop(Db, [], :busy, initial_data)
+        end)
+
+      # Invoke public Db.cancel_query/2 API in a task
+      cancel_task = Task.async(fn -> Db.cancel_query(db_pid, caller_pid) end)
+
+      # 1. Upstream endpoint receives connection & packet
+      {:ok, cancel_server_sock} = :gen_tcp.accept(listen_sock, 2_000)
+      {:ok, bin} = :gen_tcp.recv(cancel_server_sock, 16, 2_000)
+      assert bin == Server.cancel_message(12345, 67890)
+
+      # 2. Call remains blocked while socket is open
+      refute Task.yield(cancel_task, 100)
+
+      # 3. Close cancel connection
+      :gen_tcp.close(cancel_server_sock)
+
+      # 4. Public API returns :ok without timing out
+      assert :ok = Task.await(cancel_task, 2_000)
+      assert Process.alive?(db_pid)
+
+      # 5. Non-owner caller receives {:error, :not_owner}
+      wrong_caller = spawn(fn -> receive do: (_ -> :ok) end)
+      assert {:error, :not_owner} = Db.cancel_query(db_pid, wrong_caller)
     end
   end
 end


### PR DESCRIPTION
Fixes #1148

## Summary

In PostgreSQL's cancellation protocol, the cancel connection is held open until the server finishes processing the CancelRequest. When pooling or proxying connections across queries, forwarding a cancellation must be synchronized with the backend connection's lifecycle to prevent race conditions where a cancellation intended for query N cancels query N+1 or affects a different client reusing the backend.

Previously, \ClientHandler.Cancel.send_cancel_query/2\ broadcasted \:cancel_query\ asynchronously and terminated immediately, while \ClientHandler\ forwarded cancellations without verifying backend ownership or waiting for PostgreSQL's cancellation boundary to complete.

## Changes

1. **Backend Synchronization Boundary (\DbHandler.cancel_query/2\)**:
   - Moved the upstream cancellation lifecycle and synchronization boundary to \DbHandler.cancel_query/2\, which owns the real backend connection, caller ownership, and \ReadyForQuery\ processing.
   - Synchronously connects to the PostgreSQL cancel port and waits for PostgreSQL to close the cancellation socket (\{:active, false}\ blocking recv) before completing, ensuring \DbHandler\ cannot process \ReadyForQuery\ or check the backend back into the pool while cancellation is in flight.

2. **Caller Ownership Verification**:
   - \DbHandler\ validates caller ownership before forwarding \CancelRequest\ to PostgreSQL (\when is_pid(caller) and caller == caller_pid\). Stale cancellation requests against backends no longer owned by the caller are dropped with \{:error, :not_owner}\.

3. **Fail-Safe Invalidation on Cancellation Errors**:
   - If the upstream cancellation encounters a connection failure or timeout, \DbHandler\ invalidates and terminates the backend connection (\{:stop_and_reply, {:shutdown, {:cancel_failed, reason}}, ...}\) rather than returning it to the pool in an uncertain state.

4. **Synchronous Cancel Delivery & API Compatibility**:
   - \ClientHandler.Cancel.send_cancel_query/3\ uses a request/ack lifecycle (\{:cancel_query, self(), ref}\) before closing the temporary cancel socket.
   - Preserves backward compatibility for arbitrary custom message terms (\send_cancel_query(pid, key, msg)\) and legacy \:cancel_query\ atom messages.

5. **Deterministic Unit Tests**:
   - Added unit tests in \	est/supavisor/db_handler_test.exs\ and \	est/supavisor/client_handler_test.exs\ exercising synchronous cancel socket lifecycle, ownership verification, fail-safe termination, and acknowledgment delivery.