### PR TITLE
feat: push local metrics to a remote endpoint 

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -129,6 +129,34 @@ config :libcluster,
   debug: false,
   topologies: topologies
 
+if config_env() != :test do
+  metrics_pusher_extra_labels =
+    case System.get_env("METRICS_PUSHER_EXTRA_LABELS", "") do
+      "" ->
+        []
+
+      labels ->
+        labels
+        |> String.split(",")
+        |> Enum.map(fn pair ->
+          [k, v] = String.split(pair, "=", parts: 2)
+          {k, v}
+        end)
+    end
+
+  config :supavisor,
+    metrics_pusher_enabled: Supavisor.Helpers.get_env_bool("METRICS_PUSHER_ENABLED", false),
+    metrics_pusher_url: System.get_env("METRICS_PUSHER_URL"),
+    metrics_pusher_user: System.get_env("METRICS_PUSHER_USER", "supavisor"),
+    metrics_pusher_auth: System.get_env("METRICS_PUSHER_AUTH"),
+    metrics_pusher_interval_ms:
+      System.get_env("METRICS_PUSHER_INTERVAL_MS", "30000") |> String.to_integer(),
+    metrics_pusher_timeout_ms:
+      System.get_env("METRICS_PUSHER_TIMEOUT_MS", "15000") |> String.to_integer(),
+    metrics_pusher_compress: Supavisor.Helpers.get_env_bool("METRICS_PUSHER_COMPRESS", true),
+    metrics_pusher_extra_labels: metrics_pusher_extra_labels
+end
+
 upstream_ca =
   if path = System.get_env("GLOBAL_UPSTREAM_CA_PATH") do
     File.read!(path)

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,7 +31,10 @@ config :supavisor,
   transaction_proxy_ports:
     System.get_env("TRANSACTION_PROXY_PORTS", "12104,12105,12106,12107") |> parse_integer_list.(),
   max_pools: 10,
-  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer()
+  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer(),
+  metrics_pusher_req_options: [
+    plug: {Req.Test, Supavisor.MetricsPusher}
+  ]
 
 config :supavisor, Supavisor.Repo,
   username: "postgres",

--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -108,6 +108,7 @@ defmodule Supavisor.Application do
         Supavisor.ConnectBackoff.Janitor,
         Supavisor.DeadPortSweeper,
         {Task.Supervisor, name: Supavisor.PoolTerminator},
+        {Task.Supervisor, name: Supavisor.TaskSupervisor},
         {Registry, keys: :unique, name: Supavisor.Registry.Tenants},
         {Registry, keys: :unique, name: Supavisor.Registry.ManagerTables},
         {Registry, keys: :unique, name: Supavisor.Registry.PoolPids},
@@ -142,7 +143,9 @@ defmodule Supavisor.Application do
       if @metrics_disabled do
         children
       else
-        children ++ [PromEx, Supavisor.TenantsMetrics, Supavisor.MetricsCleaner]
+        children ++
+          [PromEx, Supavisor.TenantsMetrics, Supavisor.MetricsCleaner] ++
+          metrics_pusher_children()
       end
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -157,6 +160,14 @@ defmodule Supavisor.Application do
   def config_change(changed, _new, removed) do
     SupavisorWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp metrics_pusher_children do
+    if Application.get_env(:supavisor, :metrics_pusher_enabled) do
+      [Supavisor.MetricsPusher]
+    else
+      []
+    end
   end
 
   @spec build_shards([pos_integer()], atom()) :: term()

--- a/lib/supavisor/metrics_pusher.ex
+++ b/lib/supavisor/metrics_pusher.ex
@@ -1,0 +1,177 @@
+defmodule Supavisor.MetricsPusher do
+  @moduledoc """
+  GenServer that periodically pushes Prometheus metrics to an endpoint.
+
+  Only starts if `url` is configured.
+  Pushes metrics every 30 seconds (configurable) to the configured URL endpoint.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Supavisor.Monitoring.PromEx
+
+  @type t :: %__MODULE__{
+          push_ref: reference() | nil,
+          interval: pos_integer() | nil,
+          req_options: keyword() | nil
+        }
+
+  defstruct [:push_ref, :interval, :req_options]
+
+  @spec start_link(keyword()) :: {:ok, pid()} | :ignore
+  def start_link(opts) do
+    url = Keyword.get(opts, :url, Application.get_env(:supavisor, :metrics_pusher_url))
+
+    if is_binary(url) do
+      GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    else
+      Logger.warning("MetricsPusher not started: url must be configured")
+
+      :ignore
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    url = Keyword.get(opts, :url, Application.get_env(:supavisor, :metrics_pusher_url))
+
+    user =
+      Keyword.get(opts, :user, Application.get_env(:supavisor, :metrics_pusher_user, "supavisor"))
+
+    auth = Keyword.get(opts, :auth, Application.get_env(:supavisor, :metrics_pusher_auth))
+
+    interval =
+      Keyword.get(
+        opts,
+        :interval,
+        Application.get_env(:supavisor, :metrics_pusher_interval_ms, :timer.seconds(30))
+      )
+
+    timeout =
+      Keyword.get(
+        opts,
+        :timeout,
+        Application.get_env(:supavisor, :metrics_pusher_timeout_ms, :timer.seconds(15))
+      )
+
+    compress =
+      Keyword.get(
+        opts,
+        :compress,
+        Application.get_env(:supavisor, :metrics_pusher_compress, true)
+      )
+
+    extra_labels =
+      Keyword.get(
+        opts,
+        :extra_labels,
+        Application.get_env(:supavisor, :metrics_pusher_extra_labels, [])
+      )
+
+    params = Enum.map(extra_labels, fn {k, v} -> {:extra_label, "#{k}=#{v}"} end)
+
+    Logger.info(
+      "Starting MetricsPusher (url: #{url}, interval: #{interval}ms, compress: #{compress})"
+    )
+
+    headers = [{"content-type", "text/plain"}]
+
+    basic_auth = if auth, do: [auth: {:basic, "#{user}:#{auth}"}], else: []
+
+    req_options =
+      [
+        method: :post,
+        url: url,
+        headers: headers,
+        compress_body: compress,
+        receive_timeout: timeout,
+        params: params
+      ]
+      |> Keyword.merge(basic_auth)
+      |> Keyword.merge(Application.get_env(:supavisor, :metrics_pusher_req_options, []))
+
+    state = %__MODULE__{
+      push_ref: schedule_push(interval),
+      interval: interval,
+      req_options: req_options
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:push, state) do
+    {exec_time, _} = :timer.tc(fn -> push(state.req_options) end, :millisecond)
+
+    if exec_time > :timer.seconds(5) do
+      Logger.warning("Metrics push took: #{exec_time} ms")
+    end
+
+    {:noreply, %{state | push_ref: schedule_push(state.interval)}}
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    Logger.error("MetricsPusher received unexpected message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  defp schedule_push(delay), do: Process.send_after(self(), :push, delay)
+
+  # Unlike realtime, which keeps separate global and per-tenant PromEx trees,
+  # supavisor keeps every plugin (Application, Beam, Ecto, OsMon, NetStat,
+  # Tenant, Cluster) in a single collector. PromEx.get_metrics/0 is this node's
+  # own local export (no cross-node RPC fan-out) and already includes any
+  # tenant-tagged series for tenants attached to this node, so one push per
+  # tick is enough. Each node pushing only its own metrics (tagged with its
+  # node identity via global_tags) avoids the O(n^2) RPC fan-out that
+  # PromEx.get_cluster_metrics/0 would cause if every node in the cluster
+  # pushed on its own interval.
+  defp push(req_options) do
+    task =
+      Task.Supervisor.async_nolink(Supavisor.TaskSupervisor, fn -> push_metrics(req_options) end)
+
+    case Task.yield(task, :timer.minutes(1)) do
+      nil ->
+        Task.shutdown(task, :brutal_kill)
+        Logger.error("MetricsPusher: Task timed out: #{inspect(task)}")
+
+      {:exit, reason} ->
+        Logger.error("MetricsPusher: Task exited with reason: #{inspect(reason)}")
+
+      {:ok, _} ->
+        :ok
+    end
+  end
+
+  defp push_metrics(req_options) do
+    case send_metrics(req_options, PromEx.get_metrics()) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "MetricsPusher: Failed to push metrics to #{req_options[:url]}: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  rescue
+    error ->
+      Logger.error("MetricsPusher: Exception during push: #{inspect(error)}")
+      :ok
+  end
+
+  defp send_metrics(req_options, metrics) do
+    [{:body, metrics} | req_options] |> Req.request() |> handle_response()
+  end
+
+  defp handle_response({:ok, %{status: status}}) when status in 200..299, do: :ok
+
+  defp handle_response({:ok, %{status: status} = response}),
+    do: {:error, {:http_error, status, response.body}}
+
+  defp handle_response({:error, reason}), do: {:error, reason}
+end

--- a/test/supavisor/metrics_pusher_test.exs
+++ b/test/supavisor/metrics_pusher_test.exs
@@ -56,13 +56,14 @@ defmodule Supavisor.MetricsPusherTest do
                  "Basic #{Base.encode64("supavisor:hunter2")}"
                ]
 
-        assert Conn.get_req_header(conn, "content-encoding") == ["gzip"]
         assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
 
+        # Req.Test's plug adapter transparently decompresses gzip'd request
+        # bodies (and strips content-encoding) before the plug sees them, so
+        # the body here is already plaintext regardless of `compress: true`.
         {:ok, body, conn} = Conn.read_body(conn)
-        decompressed_body = :zlib.gunzip(body)
 
-        send(parent, {:req_called, decompressed_body})
+        send(parent, {:req_called, body})
         Req.Test.text(conn, "")
       end)
 

--- a/test/supavisor/metrics_pusher_test.exs
+++ b/test/supavisor/metrics_pusher_test.exs
@@ -1,0 +1,224 @@
+defmodule Supavisor.MetricsPusherTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  require Supavisor
+
+  alias Plug.Conn
+  alias Supavisor.MetricsPusher
+  alias Supavisor.Monitoring.Telem
+
+  setup {Req.Test, :verify_on_exit!}
+
+  # Helper function to start MetricsPusher and allow it to use Req.Test
+  defp start_and_allow_pusher(opts) do
+    opts = Keyword.put(opts, :interval, :timer.minutes(5))
+    pid = start_supervised!({MetricsPusher, opts})
+    Req.Test.allow(MetricsPusher, self(), pid)
+    send(pid, :push)
+    {:ok, pid}
+  end
+
+  describe "start_link/1" do
+    test "does not start when URL is missing" do
+      opts = [enabled: true]
+      assert :ignore = MetricsPusher.start_link(opts)
+    end
+
+    test "sends request successfully" do
+      opts = [
+        url: "https://example.com:8428/api/v1/import/prometheus",
+        user: "supavisor",
+        auth: "hunter2",
+        compress: true,
+        timeout: 5000
+      ]
+
+      tenant = "metrics_pusher_test_tenant"
+
+      Telem.client_join(
+        :ok,
+        Supavisor.id(type: :single, tenant: tenant, user: "u", mode: :session, db: "db")
+      )
+
+      parent = self()
+
+      # A single request carrying this node's local metrics: both node-wide
+      # (beam/OS-level) and tenant-tagged series live in the same collector.
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        assert conn.method == "POST"
+        assert conn.scheme == :https
+        assert conn.host == "example.com"
+        assert conn.port == 8428
+        assert conn.request_path == "/api/v1/import/prometheus"
+
+        assert Conn.get_req_header(conn, "authorization") == [
+                 "Basic #{Base.encode64("supavisor:hunter2")}"
+               ]
+
+        assert Conn.get_req_header(conn, "content-encoding") == ["gzip"]
+        assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
+
+        {:ok, body, conn} = Conn.read_body(conn)
+        decompressed_body = :zlib.gunzip(body)
+
+        send(parent, {:req_called, decompressed_body})
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+
+      assert_receive {:req_called, body}, 300
+
+      assert body =~ "beam_stats_run_queue_count"
+      assert body =~ "supavisor_client_joins_ok"
+      assert body =~ ~s(tenant="#{tenant}")
+    end
+
+    test "sends request successfully without auth header" do
+      opts = [
+        url: "http://localhost:8428/api/v1/import/prometheus",
+        compress: true,
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        assert Conn.get_req_header(conn, "authorization") == []
+
+        send(parent, :req_called)
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+      assert_receive :req_called, 300
+    end
+
+    test "sends request body untouched when compress=false" do
+      opts = [
+        url: "http://localhost:8428/api/v1/import/prometheus",
+        user: "hunter2",
+        auth: "supavisor",
+        compress: false,
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        assert Conn.get_req_header(conn, "content-encoding") == []
+        assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
+
+        send(parent, :req_called)
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+      assert_receive :req_called, 300
+    end
+
+    test "when request receives non 2XX response" do
+      opts = [
+        url: "https://example.com:8428/api/v1/import/prometheus",
+        auth: "hunter2",
+        compress: true,
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      log =
+        capture_log(fn ->
+          Req.Test.expect(MetricsPusher, 1, fn conn ->
+            send(parent, :req_called)
+            Conn.send_resp(conn, 500, "")
+          end)
+
+          {:ok, pid} = start_and_allow_pusher(opts)
+          assert_receive :req_called, 300
+          assert Process.alive?(pid)
+          # Wait enough for the log to be captured
+          Process.sleep(100)
+        end)
+
+      assert log =~ "MetricsPusher: Failed to push"
+      assert log =~ "metrics to"
+    end
+
+    test "when an error is raised" do
+      opts = [
+        url: "https://example.com:8428/api/v1/import/prometheus",
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      log =
+        capture_log(fn ->
+          Req.Test.expect(MetricsPusher, 1, fn _conn ->
+            send(parent, :req_called)
+            raise RuntimeError, "unexpected error"
+          end)
+
+          {:ok, pid} = start_and_allow_pusher(opts)
+          assert_receive :req_called, 300
+          assert Process.alive?(pid)
+          # Wait enough for the log to be captured
+          Process.sleep(100)
+        end)
+
+      assert log =~ "MetricsPusher: Exception during"
+      assert log =~ "push: %RuntimeError{message: \"unexpected error\"}"
+    end
+
+    test "appends extra_label query params to URL" do
+      opts = [
+        url: "http://localhost:8428/api/v1/import/prometheus",
+        compress: false,
+        timeout: 5000,
+        extra_labels: [{"region", "us-east-1"}, {"env", "prod"}]
+      ]
+
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        send(parent, {:req_called, conn.query_string})
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+      assert_receive {:req_called, query_string}, 300
+
+      decoded_params = query_string |> String.split("&") |> Enum.map(&URI.decode_www_form/1)
+      assert "extra_label=region=us-east-1" in decoded_params
+      assert "extra_label=env=prod" in decoded_params
+    end
+
+    test "logs unexpected messages and stays alive" do
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        send(parent, :push_happened)
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, pid} =
+        start_and_allow_pusher(
+          url: "http://localhost:8428/api/v1/import/prometheus",
+          timeout: 5000
+        )
+
+      assert_receive :push_happened, 500
+
+      log =
+        capture_log(fn ->
+          send(pid, :unexpected_message)
+          Process.sleep(50)
+          assert Process.alive?(pid)
+        end)
+
+      assert log =~ "MetricsPusher received unexpected message: :unexpected_message"
+    end
+  end
+end


### PR DESCRIPTION
Adds Supavisor.MetricsPusher, a GenServer that periodically POSTs this node's own PromEx export to a configurable URL, adapted from realtime's equivalent. Only starts one push per node (no cluster RPC fan-out) since supavisor keeps a single PromEx tree covering both node-wide and tenant-tagged metrics, unlike realtime's separate global/tenant trees.

Configured via METRICS_PUSHER_* env vars, _gated_ behind METRICS_PUSHER_ENABLED and guarded out of config/runtime.exs during tests to avoid picking up stray env vars from the shell.

POOLER-638