### PR TITLE
fix: remove dead cache invalidation in SecretChecker.do_update_credentials

### DIFF
--- a/lib/supavisor/secret_checker.ex
+++ b/lib/supavisor/secret_checker.ex
@@ -151,13 +151,6 @@ defmodule Supavisor.SecretChecker do
 
     AuthQuery.stop_connection_async(state.conn)
 
-    # No cache invalidation needed here: this only rotates the manager/auth_query
-    # service account's own login, not state.user's password. A prior version of this
-    # line deleted `{:secrets, state.tenant, state.user}`, which was likely meant to be
-    # `{:secrets_for_validation, ...}` -- but even corrected, invalidating state.user's
-    # validation secret on a manager-credential rotation wouldn't be meaningful, since
-    # the two secrets are unrelated.
-
     Logger.info("SecretChecker: Successfully changed auth_query user")
     {:reply, :ok, %{state | manager_secrets: new_manager, conn: new_conn}}
   end

--- a/lib/supavisor/secret_checker.ex
+++ b/lib/supavisor/secret_checker.ex
@@ -151,8 +151,12 @@ defmodule Supavisor.SecretChecker do
 
     AuthQuery.stop_connection_async(state.conn)
 
-    # Clear the secrets cache for this tenant/user
-    Cachex.del(Supavisor.Cache, {:secrets, state.tenant, state.user})
+    # No cache invalidation needed here: this only rotates the manager/auth_query
+    # service account's own login, not state.user's password. A prior version of this
+    # line deleted `{:secrets, state.tenant, state.user}`, which was likely meant to be
+    # `{:secrets_for_validation, ...}` -- but even corrected, invalidating state.user's
+    # validation secret on a manager-credential rotation wouldn't be meaningful, since
+    # the two secrets are unrelated.
 
     Logger.info("SecretChecker: Successfully changed auth_query user")
     {:reply, :ok, %{state | manager_secrets: new_manager, conn: new_conn}}


### PR DESCRIPTION
## What

`SecretChecker.do_update_credentials/1` (the manager/auth_query credential hot-swap handler) had:

```elixir
# Clear the secrets cache for this tenant/user
Cachex.del(Supavisor.Cache, {:secrets, state.tenant, state.user})
```

`{:secrets, tenant, user}` is never written anywhere in the codebase — the real validation-secrets cache is keyed `{:secrets_for_validation, tenant, user}`. So this call was a no-op.

## Why not just fix the key

Even corrected to `{:secrets_for_validation, ...}`, invalidating `state.user`'s (the pooled role's) validation secret here wouldn't be meaningful: this handler only rotates the manager/auth_query service account's own login credentials, used to run the query that fetches other roles' secrets. That rotation has no bearing on whether `state.user`'s own SCRAM verifier is stale — the two secrets are unrelated. 
Found while investigating SU-447169 / [POOLER-689](https://linear.app/supabase/issue/POOLER-689).

## Verification

- `grep -rn "{:secrets," lib/` confirms zero other readers/writers of the old key.
- No existing tests reference `:update_credentials`/`do_update_credentials`, so nothing asserts on the removed call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)