### PR TITLE
chore(monitoring): backport net stat counters to v2.9

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -3,6 +3,7 @@ main modules involved in this implementation are:
 
 - `Supavisor.Monitoring.PromEx`
 - `Supavisor.PromEx.Plugins.OsMon`
+- `Supavisor.PromEx.Plugins.NetStat`
 - `Supavisor.PromEx.Plugins.Tenant`
 - `Supavisor.Monitoring.Telem`
 
@@ -42,6 +43,7 @@ The exposed metrics include the following:
   * CPU utilization
   * RAM usage
   * Load average (LA)
+  * Network counters (listen drops, listen overflows)
 
 ## Tenant metrics
 

--- a/lib/supavisor/monitoring/net_stat.ex
+++ b/lib/supavisor/monitoring/net_stat.ex
@@ -1,0 +1,90 @@
+defmodule Supavisor.PromEx.Plugins.NetStat do
+  @moduledoc """
+  Polls system-wide network counters via procfs.
+  """
+
+  use PromEx.Plugin
+
+  @event_net_stat [:supavisor, :prom_ex, :osmon, :net_stat]
+  @prefix [:supavisor, :prom_ex]
+  @proc_net_netstat "/proc/net/netstat"
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate)
+
+    [
+      net_stat_metrics(poll_rate)
+    ]
+  end
+
+  defp net_stat_metrics(poll_rate) do
+    Polling.build(
+      :supavisor_osmon_net_stat_events,
+      poll_rate,
+      {__MODULE__, :execute_net_stat_metrics, []},
+      [
+        last_value(
+          @prefix ++ [:osmon, :net, :listen_drops],
+          event_name: @event_net_stat,
+          description: "Cumulative number of connections dropped due to a full accept queue.",
+          measurement: :listen_drops,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :listen_overflows],
+          event_name: @event_net_stat,
+          description: "Cumulative number of times the listen backlog of a socket overflowed.",
+          measurement: :listen_overflows,
+          reporter_options: [prometheus_type: "counter"]
+        )
+      ]
+    )
+  end
+
+  def execute_net_stat_metrics(path \\ @proc_net_netstat) do
+    case net_stat(path) do
+      {:ok, stats} -> execute_metrics(@event_net_stat, stats)
+      :error -> :ok
+    end
+  end
+
+  defp execute_metrics(event, metrics) do
+    :telemetry.execute(event, metrics, %{})
+  end
+
+  # sobelow_skip ["Traversal.FileModule"]
+  @spec net_stat(Path.t()) ::
+          {:ok, %{listen_drops: non_neg_integer(), listen_overflows: non_neg_integer()}} | :error
+  def net_stat(path \\ @proc_net_netstat) do
+    with {:ok, content} <- File.read(path),
+         {:ok, stats} <- parse_net_stat(content) do
+      {:ok, stats}
+    else
+      _ -> :error
+    end
+  end
+
+  @spec parse_net_stat(String.t()) ::
+          {:ok, %{listen_drops: non_neg_integer(), listen_overflows: non_neg_integer()}} | :error
+  def parse_net_stat(content) do
+    content
+    |> String.split("\n", trim: true)
+    |> Enum.chunk_every(2)
+    |> Enum.find_value(fn
+      ["TcpExt: " <> _ = header, values] ->
+        keys = header |> String.split() |> tl()
+        vals = values |> String.split() |> tl() |> Enum.map(&String.to_integer/1)
+        counters = Enum.zip(keys, vals) |> Map.new()
+
+        {:ok,
+         %{
+           listen_drops: Map.get(counters, "ListenDrops", 0),
+           listen_overflows: Map.get(counters, "ListenOverflows", 0)
+         }}
+
+      _ ->
+        nil
+    end) || :error
+  end
+end

--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -14,7 +14,7 @@ defmodule Supavisor.Monitoring.PromEx do
   alias PromEx.Plugins
   alias Supavisor.PeepStorage
   alias Supavisor.PeepStorage.PrometheusCached
-  alias Supavisor.PromEx.Plugins.{Cluster, OsMon, Tenant}
+  alias Supavisor.PromEx.Plugins.{Cluster, NetStat, OsMon, Tenant}
   alias Telemetry.Metrics
 
   defmodule Store do
@@ -66,6 +66,7 @@ defmodule Supavisor.Monitoring.PromEx do
 
       # Custom PromEx metrics plugins
       {OsMon, poll_rate: poll_rate},
+      {NetStat, poll_rate: poll_rate},
       {Tenant, poll_rate: poll_rate},
       {Cluster, poll_rate: poll_rate}
     ]

--- a/test/supavisor/monitoring/net_stat_test.exs
+++ b/test/supavisor/monitoring/net_stat_test.exs
@@ -1,0 +1,140 @@
+defmodule Supavisor.PromEx.Plugins.NetStatTest do
+  use Supavisor.E2ECase, async: false
+
+  alias Supavisor.PromEx.Plugins.NetStat
+
+  @moduletag telemetry: true
+
+  @netstat_fixture """
+  TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPPrequeued TCPDirectCopyFromBacklog TCPDirectCopyFromPrequeue TCPPrequeueDropped TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSchedulerFailed TCPRcvCollapsed TCPBacklogCoalesce TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPSchedulerFailed2
+  TcpExt: 0 0 0 0 0 0 0 0 0 0 1234 0 0 0 567 89012 345 678 42 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+  IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
+  IpExt: 0 0 0 0 0 0 123456789 987654321 0 0 0 0 0 0 0 0 0 0
+  """
+
+  describe "polling_metrics/1" do
+    test "properly exports metrics" do
+      for polling_metric <- NetStat.polling_metrics([]) do
+        assert %PromEx.MetricTypes.Polling{metrics: [_ | _]} = polling_metric
+        {m, f, a} = polling_metric.measurements_mfa
+        assert function_exported?(m, f, length(a))
+
+        for telemetry_metric <- polling_metric.metrics do
+          assert Enum.any?(
+                   [
+                     Telemetry.Metrics.Distribution,
+                     Telemetry.Metrics.Counter,
+                     Telemetry.Metrics.LastValue,
+                     Telemetry.Metrics.Sum
+                   ],
+                   fn struct -> is_struct(telemetry_metric, struct) end
+                 )
+
+          assert telemetry_metric.description
+        end
+      end
+    end
+
+    test "uses poll rate option" do
+      for polling_metric <- NetStat.polling_metrics(poll_rate: 1000) do
+        assert %{poll_rate: 1000} = polling_metric
+      end
+    end
+
+    test "reports listen_drops and listen_overflows as counters" do
+      metrics =
+        NetStat.polling_metrics([])
+        |> Enum.flat_map(& &1.metrics)
+
+      for suffix <- [:listen_drops, :listen_overflows] do
+        name = [:supavisor, :prom_ex, :osmon, :net, suffix]
+        metric = Enum.find(metrics, &(&1.name == name))
+
+        assert metric, "expected a net #{suffix} metric named #{inspect(name)}"
+        assert metric.reporter_options[:prometheus_type] == "counter"
+      end
+    end
+  end
+
+  describe "parse_net_stat/1" do
+    test "extracts ListenDrops and ListenOverflows" do
+      assert {:ok, %{listen_drops: 17, listen_overflows: 42}} =
+               NetStat.parse_net_stat(@netstat_fixture)
+    end
+
+    test "defaults missing counters to 0" do
+      content = """
+      TcpExt: SyncookiesSent
+      TcpExt: 0
+      """
+
+      assert {:ok, %{listen_drops: 0, listen_overflows: 0}} = NetStat.parse_net_stat(content)
+    end
+
+    test "returns error for empty content" do
+      assert :error = NetStat.parse_net_stat("")
+    end
+
+    test "returns error when TcpExt section is missing" do
+      content = """
+      IpExt: InNoRoutes InTruncatedPkts
+      IpExt: 0 0
+      """
+
+      assert :error = NetStat.parse_net_stat(content)
+    end
+  end
+
+  describe "net_stat/1" do
+    @tag :linux
+    test "reads real /proc/net/netstat on linux" do
+      assert {:ok, %{listen_drops: drops, listen_overflows: overflows}} = NetStat.net_stat()
+      assert is_integer(drops)
+      assert is_integer(overflows)
+    end
+  end
+
+  describe "execute_net_stat_metrics/1" do
+    test "emits net_stat telemetry event when file exists" do
+      path = write_netstat_fixture(@netstat_fixture)
+      ref = attach_handler([:supavisor, :prom_ex, :osmon, :net_stat])
+
+      assert :ok = NetStat.execute_net_stat_metrics(path)
+
+      assert_receive {^ref, {[:supavisor, :prom_ex, :osmon, :net_stat], measurement, %{}}}
+      assert %{listen_drops: 17, listen_overflows: 42} = measurement
+    end
+
+    test "returns ok and emits nothing when file does not exist" do
+      assert :ok = NetStat.execute_net_stat_metrics("/nonexistent/path")
+    end
+  end
+
+  defp write_netstat_fixture(content) do
+    path = Path.join(System.tmp_dir!(), "netstat_#{:erlang.unique_integer([:positive])}")
+    File.write!(path, content)
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+
+  def handle_event(event_name, measurement, meta, {pid, ref}) do
+    send(pid, {ref, {event_name, measurement, meta}})
+  end
+
+  defp attach_handler(event) do
+    ref = make_ref()
+
+    :telemetry.attach(
+      {ref, :test},
+      event,
+      &__MODULE__.handle_event/4,
+      {self(), ref}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach({ref, :test})
+    end)
+
+    ref
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,13 +22,17 @@ logs =
       false
   end
 
+linux_excludes =
+  if :os.type() != {:unix, :linux}, do: [linux: true], else: []
+
 ExUnit.start(
   capture_log: logs,
-  exclude: [
-    flaky: true,
-    integration: true,
-    integration_docker: true
-  ]
+  exclude:
+    [
+      flaky: true,
+      integration: true,
+      integration_docker: true
+    ] ++ linux_excludes
 )
 
 Ecto.Adapters.SQL.Sandbox.mode(Supavisor.Repo, :auto)


### PR DESCRIPTION
## Summary
- Backports the system network counter metrics (PromEx `NetStat` plugin, procfs-based listen drops/overflows) from merge commit 00afba2f78f80127b60f3d813a884a80cd3cc71f (PR #1080) onto `v2.9`.
- That merge squashed 5 commits from `pooler-524-add-tracking-for-system-network-counters-via-procfs`:
  - 3b7d893 feat(monitoring): add system network counter metrics via procfs
  - 128a950 fix: suppress Sobelow directory traversal false positive in net_stat/1
  - d685794 style: run mix format
  - ed07d6b refactor: extract net_stat metrics into their own PromEx plugin
  - 70ee4f3 docs: mention NetStat plugin and network counters in metrics.md
- Resolved one conflict in `docs/monitoring/metrics.md`: kept only the "Network counters" bullet since the "Disk space usage" bullet came from unrelated main-line history not present on `v2.9`.

## Test plan
- [x] `mix compile` succeeds
- [x] `mix test test/supavisor/monitoring/net_stat_test.exs` — 10/10 pass
- [x] `mix test` full suite — same 4 pre-existing failures as plain `v2.9` (unrelated TLS/network issue downloading a test fixture in `prom_ex_test.exs`), no new failures