### PR TITLE
feat(monitoring): add more procfs network metrics (POOLER-524)

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -45,6 +45,7 @@ The exposed metrics include the following:
   * Load average (LA)
   * Disk space usage (per mountpoint)
   * Network counters (listen drops, listen overflows)
+  * TCP socket usage (in-use, orphaned, TIME_WAIT, allocated, memory pages)
 
 ## Tenant metrics
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -44,7 +44,7 @@ The exposed metrics include the following:
   * RAM usage
   * Load average (LA)
   * Disk space usage (per mountpoint)
-  * Network counters (listen drops, listen overflows)
+  * Network counters (listen drops, listen overflows, TCP aborts, SYN retransmits, connection attempt failures, established resets, segment errors)
   * TCP socket usage (in-use, orphaned, TIME_WAIT, allocated, memory pages)
 
 ## Tenant metrics

--- a/lib/supavisor/monitoring/net_stat.ex
+++ b/lib/supavisor/monitoring/net_stat.ex
@@ -7,9 +7,11 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
 
   @event_net_stat [:supavisor, :prom_ex, :osmon, :net_stat]
   @event_sock_stat [:supavisor, :prom_ex, :osmon, :sock_stat]
+  @event_snmp_stat [:supavisor, :prom_ex, :osmon, :snmp_stat]
   @prefix [:supavisor, :prom_ex]
   @proc_net_netstat "/proc/net/netstat"
   @proc_net_sockstat "/proc/net/sockstat"
+  @proc_net_snmp "/proc/net/snmp"
 
   @impl true
   def polling_metrics(opts) do
@@ -17,7 +19,8 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
 
     [
       net_stat_metrics(poll_rate),
-      sock_stat_metrics(poll_rate)
+      sock_stat_metrics(poll_rate),
+      snmp_stat_metrics(poll_rate)
     ]
   end
 
@@ -40,6 +43,51 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
           description: "Cumulative number of times the listen backlog of a socket overflowed.",
           measurement: :listen_overflows,
           reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_abort_on_timeout],
+          event_name: @event_net_stat,
+          description: "Cumulative number of connections aborted due to a retransmit timeout.",
+          measurement: :tcp_abort_on_timeout,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_abort_on_close],
+          event_name: @event_net_stat,
+          description:
+            "Cumulative number of connections aborted because the application closed them with unread data pending.",
+          measurement: :tcp_abort_on_close,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_abort_on_data],
+          event_name: @event_net_stat,
+          description:
+            "Cumulative number of connections aborted because data arrived on an already-closed socket.",
+          measurement: :tcp_abort_on_data,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_abort_on_memory],
+          event_name: @event_net_stat,
+          description: "Cumulative number of connections aborted due to low socket memory.",
+          measurement: :tcp_abort_on_memory,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_abort_on_linger],
+          event_name: @event_net_stat,
+          description:
+            "Cumulative number of connections aborted while in a lingering close state.",
+          measurement: :tcp_abort_on_linger,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_syn_retrans],
+          event_name: @event_net_stat,
+          description: "Cumulative number of retransmitted TCP SYN packets.",
+          measurement: :tcp_syn_retrans,
+          reporter_options: [prometheus_type: "counter"]
         )
       ]
     )
@@ -59,13 +107,30 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
     end
   end
 
+  def execute_snmp_stat_metrics(path \\ @proc_net_snmp) do
+    case snmp_stat(path) do
+      {:ok, stats} -> execute_metrics(@event_snmp_stat, stats)
+      :error -> :ok
+    end
+  end
+
   defp execute_metrics(event, metrics) do
     :telemetry.execute(event, metrics, %{})
   end
 
+  @type net_stat_counters :: %{
+          listen_drops: non_neg_integer(),
+          listen_overflows: non_neg_integer(),
+          tcp_abort_on_timeout: non_neg_integer(),
+          tcp_abort_on_close: non_neg_integer(),
+          tcp_abort_on_data: non_neg_integer(),
+          tcp_abort_on_memory: non_neg_integer(),
+          tcp_abort_on_linger: non_neg_integer(),
+          tcp_syn_retrans: non_neg_integer()
+        }
+
   # sobelow_skip ["Traversal.FileModule"]
-  @spec net_stat(Path.t()) ::
-          {:ok, %{listen_drops: non_neg_integer(), listen_overflows: non_neg_integer()}} | :error
+  @spec net_stat(Path.t()) :: {:ok, net_stat_counters()} | :error
   def net_stat(path \\ @proc_net_netstat) do
     with {:ok, content} <- File.read(path),
          {:ok, stats} <- parse_net_stat(content) do
@@ -75,8 +140,7 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
     end
   end
 
-  @spec parse_net_stat(String.t()) ::
-          {:ok, %{listen_drops: non_neg_integer(), listen_overflows: non_neg_integer()}} | :error
+  @spec parse_net_stat(String.t()) :: {:ok, net_stat_counters()} | :error
   def parse_net_stat(content) do
     content
     |> String.split("\n", trim: true)
@@ -90,7 +154,13 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
         {:ok,
          %{
            listen_drops: Map.get(counters, "ListenDrops", 0),
-           listen_overflows: Map.get(counters, "ListenOverflows", 0)
+           listen_overflows: Map.get(counters, "ListenOverflows", 0),
+           tcp_abort_on_timeout: Map.get(counters, "TCPAbortOnTimeout", 0),
+           tcp_abort_on_close: Map.get(counters, "TCPAbortOnClose", 0),
+           tcp_abort_on_data: Map.get(counters, "TCPAbortOnData", 0),
+           tcp_abort_on_memory: Map.get(counters, "TCPAbortOnMemory", 0),
+           tcp_abort_on_linger: Map.get(counters, "TCPAbortOnLinger", 0),
+           tcp_syn_retrans: Map.get(counters, "TCPSynRetrans", 0)
          }}
 
       _ ->
@@ -186,6 +256,77 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
            tcp_time_wait: Map.get(counters, "tw", 0),
            tcp_alloc: Map.get(counters, "alloc", 0),
            tcp_mem_pages: Map.get(counters, "mem", 0)
+         }}
+
+      _ ->
+        nil
+    end) || :error
+  end
+
+  defp snmp_stat_metrics(poll_rate) do
+    Polling.build(
+      :supavisor_osmon_snmp_stat_events,
+      poll_rate,
+      {__MODULE__, :execute_snmp_stat_metrics, []},
+      [
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_attempt_fails],
+          event_name: @event_snmp_stat,
+          description: "Cumulative number of TCP connection attempts that failed.",
+          measurement: :tcp_attempt_fails,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_estab_resets],
+          event_name: @event_snmp_stat,
+          description: "Cumulative number of established TCP connections that were reset.",
+          measurement: :tcp_estab_resets,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_in_errs],
+          event_name: @event_snmp_stat,
+          description: "Cumulative number of inbound TCP segments received in error.",
+          measurement: :tcp_in_errs,
+          reporter_options: [prometheus_type: "counter"]
+        )
+      ]
+    )
+  end
+
+  @type snmp_stat_counters :: %{
+          tcp_attempt_fails: non_neg_integer(),
+          tcp_estab_resets: non_neg_integer(),
+          tcp_in_errs: non_neg_integer()
+        }
+
+  # sobelow_skip ["Traversal.FileModule"]
+  @spec snmp_stat(Path.t()) :: {:ok, snmp_stat_counters()} | :error
+  def snmp_stat(path \\ @proc_net_snmp) do
+    with {:ok, content} <- File.read(path),
+         {:ok, stats} <- parse_snmp_stat(content) do
+      {:ok, stats}
+    else
+      _ -> :error
+    end
+  end
+
+  @spec parse_snmp_stat(String.t()) :: {:ok, snmp_stat_counters()} | :error
+  def parse_snmp_stat(content) do
+    content
+    |> String.split("\n", trim: true)
+    |> Enum.chunk_every(2)
+    |> Enum.find_value(fn
+      ["Tcp: " <> _ = header, values] ->
+        keys = header |> String.split() |> tl()
+        vals = values |> String.split() |> tl() |> Enum.map(&String.to_integer/1)
+        counters = Enum.zip(keys, vals) |> Map.new()
+
+        {:ok,
+         %{
+           tcp_attempt_fails: Map.get(counters, "AttemptFails", 0),
+           tcp_estab_resets: Map.get(counters, "EstabResets", 0),
+           tcp_in_errs: Map.get(counters, "InErrs", 0)
          }}
 
       _ ->

--- a/lib/supavisor/monitoring/net_stat.ex
+++ b/lib/supavisor/monitoring/net_stat.ex
@@ -6,15 +6,18 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
   use PromEx.Plugin
 
   @event_net_stat [:supavisor, :prom_ex, :osmon, :net_stat]
+  @event_sock_stat [:supavisor, :prom_ex, :osmon, :sock_stat]
   @prefix [:supavisor, :prom_ex]
   @proc_net_netstat "/proc/net/netstat"
+  @proc_net_sockstat "/proc/net/sockstat"
 
   @impl true
   def polling_metrics(opts) do
     poll_rate = Keyword.get(opts, :poll_rate)
 
     [
-      net_stat_metrics(poll_rate)
+      net_stat_metrics(poll_rate),
+      sock_stat_metrics(poll_rate)
     ]
   end
 
@@ -45,6 +48,13 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
   def execute_net_stat_metrics(path \\ @proc_net_netstat) do
     case net_stat(path) do
       {:ok, stats} -> execute_metrics(@event_net_stat, stats)
+      :error -> :ok
+    end
+  end
+
+  def execute_sock_stat_metrics(path \\ @proc_net_sockstat) do
+    case sock_stat(path) do
+      {:ok, stats} -> execute_metrics(@event_sock_stat, stats)
       :error -> :ok
     end
   end
@@ -81,6 +91,101 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
          %{
            listen_drops: Map.get(counters, "ListenDrops", 0),
            listen_overflows: Map.get(counters, "ListenOverflows", 0)
+         }}
+
+      _ ->
+        nil
+    end) || :error
+  end
+
+  defp sock_stat_metrics(poll_rate) do
+    Polling.build(
+      :supavisor_osmon_sock_stat_events,
+      poll_rate,
+      {__MODULE__, :execute_sock_stat_metrics, []},
+      [
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_inuse],
+          event_name: @event_sock_stat,
+          description: "Number of TCP sockets currently in use.",
+          measurement: :tcp_inuse
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_orphan],
+          event_name: @event_sock_stat,
+          description: "Number of orphaned (unattached to a file descriptor) TCP sockets.",
+          measurement: :tcp_orphan
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_time_wait],
+          event_name: @event_sock_stat,
+          description: "Number of TCP sockets currently in the TIME_WAIT state.",
+          measurement: :tcp_time_wait
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_alloc],
+          event_name: @event_sock_stat,
+          description: "Number of allocated TCP socket structures.",
+          measurement: :tcp_alloc
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_mem_pages],
+          event_name: @event_sock_stat,
+          description: "Number of memory pages consumed by the TCP protocol.",
+          measurement: :tcp_mem_pages
+        )
+      ]
+    )
+  end
+
+  # sobelow_skip ["Traversal.FileModule"]
+  @spec sock_stat(Path.t()) ::
+          {:ok,
+           %{
+             tcp_inuse: non_neg_integer(),
+             tcp_orphan: non_neg_integer(),
+             tcp_time_wait: non_neg_integer(),
+             tcp_alloc: non_neg_integer(),
+             tcp_mem_pages: non_neg_integer()
+           }}
+          | :error
+  def sock_stat(path \\ @proc_net_sockstat) do
+    with {:ok, content} <- File.read(path),
+         {:ok, stats} <- parse_sock_stat(content) do
+      {:ok, stats}
+    else
+      _ -> :error
+    end
+  end
+
+  @spec parse_sock_stat(String.t()) ::
+          {:ok,
+           %{
+             tcp_inuse: non_neg_integer(),
+             tcp_orphan: non_neg_integer(),
+             tcp_time_wait: non_neg_integer(),
+             tcp_alloc: non_neg_integer(),
+             tcp_mem_pages: non_neg_integer()
+           }}
+          | :error
+  def parse_sock_stat(content) do
+    content
+    |> String.split("\n", trim: true)
+    |> Enum.find_value(fn
+      "TCP: " <> rest ->
+        counters =
+          rest
+          |> String.split()
+          |> Enum.chunk_every(2)
+          |> Map.new(fn [k, v] -> {k, String.to_integer(v)} end)
+
+        {:ok,
+         %{
+           tcp_inuse: Map.get(counters, "inuse", 0),
+           tcp_orphan: Map.get(counters, "orphan", 0),
+           tcp_time_wait: Map.get(counters, "tw", 0),
+           tcp_alloc: Map.get(counters, "alloc", 0),
+           tcp_mem_pages: Map.get(counters, "mem", 0)
          }}
 
       _ ->

--- a/test/supavisor/monitoring/net_stat_test.exs
+++ b/test/supavisor/monitoring/net_stat_test.exs
@@ -6,8 +6,8 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
   @moduletag telemetry: true
 
   @netstat_fixture """
-  TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPPrequeued TCPDirectCopyFromBacklog TCPDirectCopyFromPrequeue TCPPrequeueDropped TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSchedulerFailed TCPRcvCollapsed TCPBacklogCoalesce TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPSchedulerFailed2
-  TcpExt: 0 0 0 0 0 0 0 0 0 0 1234 0 0 0 567 89012 345 678 42 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+  TcpExt: SyncookiesSent ListenOverflows ListenDrops TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPSynRetrans
+  TcpExt: 0 42 17 11 22 33 44 55 66 77
   IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
   IpExt: 0 0 0 0 0 0 123456789 987654321 0 0 0 0 0 0 0 0 0 0
   """
@@ -19,6 +19,15 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
   UDPLITE: inuse 0
   RAW: inuse 0
   FRAG: inuse 0 memory 0
+  """
+
+  @snmp_fixture """
+  Ip: Forwarding DefaultTTL InReceives InDelivers
+  Ip: 1 64 123456 123000
+  Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+  Tcp: 1 200 120000 -1 500 300 12 7 42 100000 99000 55 3 20 0
+  Udp: InDatagrams NoPorts InErrors OutDatagrams
+  Udp: 1000 5 2 900
   """
 
   describe "polling_metrics/1" do
@@ -64,6 +73,41 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
       end
     end
 
+    test "reports tcp abort and syn retrans counters" do
+      metrics =
+        NetStat.polling_metrics([])
+        |> Enum.flat_map(& &1.metrics)
+
+      for suffix <- [
+            :tcp_abort_on_timeout,
+            :tcp_abort_on_close,
+            :tcp_abort_on_data,
+            :tcp_abort_on_memory,
+            :tcp_abort_on_linger,
+            :tcp_syn_retrans
+          ] do
+        name = [:supavisor, :prom_ex, :osmon, :net, suffix]
+        metric = Enum.find(metrics, &(&1.name == name))
+
+        assert metric, "expected a net #{suffix} metric named #{inspect(name)}"
+        assert metric.reporter_options[:prometheus_type] == "counter"
+      end
+    end
+
+    test "reports snmp tcp stats as counters" do
+      metrics =
+        NetStat.polling_metrics([])
+        |> Enum.flat_map(& &1.metrics)
+
+      for suffix <- [:tcp_attempt_fails, :tcp_estab_resets, :tcp_in_errs] do
+        name = [:supavisor, :prom_ex, :osmon, :net, suffix]
+        metric = Enum.find(metrics, &(&1.name == name))
+
+        assert metric, "expected a net #{suffix} metric named #{inspect(name)}"
+        assert metric.reporter_options[:prometheus_type] == "counter"
+      end
+    end
+
     test "reports tcp socket stats as gauges" do
       metrics =
         NetStat.polling_metrics([])
@@ -80,9 +124,18 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
   end
 
   describe "parse_net_stat/1" do
-    test "extracts ListenDrops and ListenOverflows" do
-      assert {:ok, %{listen_drops: 17, listen_overflows: 42}} =
-               NetStat.parse_net_stat(@netstat_fixture)
+    test "extracts ListenDrops, ListenOverflows, abort and syn retrans counters" do
+      assert {:ok,
+              %{
+                listen_drops: 17,
+                listen_overflows: 42,
+                tcp_abort_on_data: 11,
+                tcp_abort_on_close: 22,
+                tcp_abort_on_memory: 33,
+                tcp_abort_on_timeout: 44,
+                tcp_abort_on_linger: 55,
+                tcp_syn_retrans: 77
+              }} = NetStat.parse_net_stat(@netstat_fixture)
     end
 
     test "defaults missing counters to 0" do
@@ -91,7 +144,17 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
       TcpExt: 0
       """
 
-      assert {:ok, %{listen_drops: 0, listen_overflows: 0}} = NetStat.parse_net_stat(content)
+      assert {:ok,
+              %{
+                listen_drops: 0,
+                listen_overflows: 0,
+                tcp_abort_on_data: 0,
+                tcp_abort_on_close: 0,
+                tcp_abort_on_memory: 0,
+                tcp_abort_on_timeout: 0,
+                tcp_abort_on_linger: 0,
+                tcp_syn_retrans: 0
+              }} = NetStat.parse_net_stat(content)
     end
 
     test "returns error for empty content" do
@@ -170,6 +233,47 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
     end
   end
 
+  describe "parse_snmp_stat/1" do
+    test "extracts AttemptFails, EstabResets and InErrs" do
+      assert {:ok, %{tcp_attempt_fails: 12, tcp_estab_resets: 7, tcp_in_errs: 3}} =
+               NetStat.parse_snmp_stat(@snmp_fixture)
+    end
+
+    test "defaults missing counters to 0" do
+      content = """
+      Tcp: RtoAlgorithm
+      Tcp: 1
+      """
+
+      assert {:ok, %{tcp_attempt_fails: 0, tcp_estab_resets: 0, tcp_in_errs: 0}} =
+               NetStat.parse_snmp_stat(content)
+    end
+
+    test "returns error for empty content" do
+      assert :error = NetStat.parse_snmp_stat("")
+    end
+
+    test "returns error when Tcp section is missing" do
+      content = """
+      Ip: Forwarding DefaultTTL
+      Ip: 1 64
+      """
+
+      assert :error = NetStat.parse_snmp_stat(content)
+    end
+  end
+
+  describe "snmp_stat/1" do
+    @tag :linux
+    test "reads real /proc/net/snmp on linux" do
+      assert {:ok, stats} = NetStat.snmp_stat()
+
+      for key <- [:tcp_attempt_fails, :tcp_estab_resets, :tcp_in_errs] do
+        assert is_integer(Map.fetch!(stats, key))
+      end
+    end
+  end
+
   describe "execute_net_stat_metrics/1" do
     test "emits net_stat telemetry event when file exists" do
       path = write_fixture(@netstat_fixture)
@@ -178,11 +282,27 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
       assert :ok = NetStat.execute_net_stat_metrics(path)
 
       assert_receive {^ref, {[:supavisor, :prom_ex, :osmon, :net_stat], measurement, %{}}}
-      assert %{listen_drops: 17, listen_overflows: 42} = measurement
+      assert %{listen_drops: 17, listen_overflows: 42, tcp_syn_retrans: 77} = measurement
     end
 
     test "returns ok and emits nothing when file does not exist" do
       assert :ok = NetStat.execute_net_stat_metrics("/nonexistent/path")
+    end
+  end
+
+  describe "execute_snmp_stat_metrics/1" do
+    test "emits snmp_stat telemetry event when file exists" do
+      path = write_fixture(@snmp_fixture)
+      ref = attach_handler([:supavisor, :prom_ex, :osmon, :snmp_stat])
+
+      assert :ok = NetStat.execute_snmp_stat_metrics(path)
+
+      assert_receive {^ref, {[:supavisor, :prom_ex, :osmon, :snmp_stat], measurement, %{}}}
+      assert %{tcp_attempt_fails: 12, tcp_estab_resets: 7, tcp_in_errs: 3} = measurement
+    end
+
+    test "returns ok and emits nothing when file does not exist" do
+      assert :ok = NetStat.execute_snmp_stat_metrics("/nonexistent/path")
     end
   end
 

--- a/test/supavisor/monitoring/net_stat_test.exs
+++ b/test/supavisor/monitoring/net_stat_test.exs
@@ -12,6 +12,15 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
   IpExt: 0 0 0 0 0 0 123456789 987654321 0 0 0 0 0 0 0 0 0 0
   """
 
+  @sockstat_fixture """
+  sockets: used 1391
+  TCP: inuse 32 orphan 0 tw 337 alloc 43 mem 3
+  UDP: inuse 12 mem 3
+  UDPLITE: inuse 0
+  RAW: inuse 0
+  FRAG: inuse 0 memory 0
+  """
+
   describe "polling_metrics/1" do
     test "properly exports metrics" do
       for polling_metric <- NetStat.polling_metrics([]) do
@@ -54,6 +63,20 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
         assert metric.reporter_options[:prometheus_type] == "counter"
       end
     end
+
+    test "reports tcp socket stats as gauges" do
+      metrics =
+        NetStat.polling_metrics([])
+        |> Enum.flat_map(& &1.metrics)
+
+      for suffix <- [:tcp_inuse, :tcp_orphan, :tcp_time_wait, :tcp_alloc, :tcp_mem_pages] do
+        name = [:supavisor, :prom_ex, :osmon, :net, suffix]
+        metric = Enum.find(metrics, &(&1.name == name))
+
+        assert metric, "expected a net #{suffix} metric named #{inspect(name)}"
+        refute metric.reporter_options[:prometheus_type] == "counter"
+      end
+    end
   end
 
   describe "parse_net_stat/1" do
@@ -94,9 +117,62 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
     end
   end
 
+  describe "parse_sock_stat/1" do
+    test "extracts tcp socket counters" do
+      assert {:ok,
+              %{
+                tcp_inuse: 32,
+                tcp_orphan: 0,
+                tcp_time_wait: 337,
+                tcp_alloc: 43,
+                tcp_mem_pages: 3
+              }} = NetStat.parse_sock_stat(@sockstat_fixture)
+    end
+
+    test "defaults missing counters to 0" do
+      content = """
+      sockets: used 1391
+      TCP: inuse 5
+      """
+
+      assert {:ok,
+              %{
+                tcp_inuse: 5,
+                tcp_orphan: 0,
+                tcp_time_wait: 0,
+                tcp_alloc: 0,
+                tcp_mem_pages: 0
+              }} = NetStat.parse_sock_stat(content)
+    end
+
+    test "returns error for empty content" do
+      assert :error = NetStat.parse_sock_stat("")
+    end
+
+    test "returns error when TCP section is missing" do
+      content = """
+      sockets: used 1391
+      UDP: inuse 12 mem 3
+      """
+
+      assert :error = NetStat.parse_sock_stat(content)
+    end
+  end
+
+  describe "sock_stat/1" do
+    @tag :linux
+    test "reads real /proc/net/sockstat on linux" do
+      assert {:ok, stats} = NetStat.sock_stat()
+
+      for key <- [:tcp_inuse, :tcp_orphan, :tcp_time_wait, :tcp_alloc, :tcp_mem_pages] do
+        assert is_integer(Map.fetch!(stats, key))
+      end
+    end
+  end
+
   describe "execute_net_stat_metrics/1" do
     test "emits net_stat telemetry event when file exists" do
-      path = write_netstat_fixture(@netstat_fixture)
+      path = write_fixture(@netstat_fixture)
       ref = attach_handler([:supavisor, :prom_ex, :osmon, :net_stat])
 
       assert :ok = NetStat.execute_net_stat_metrics(path)
@@ -110,8 +186,24 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
     end
   end
 
-  defp write_netstat_fixture(content) do
-    path = Path.join(System.tmp_dir!(), "netstat_#{:erlang.unique_integer([:positive])}")
+  describe "execute_sock_stat_metrics/1" do
+    test "emits sock_stat telemetry event when file exists" do
+      path = write_fixture(@sockstat_fixture)
+      ref = attach_handler([:supavisor, :prom_ex, :osmon, :sock_stat])
+
+      assert :ok = NetStat.execute_sock_stat_metrics(path)
+
+      assert_receive {^ref, {[:supavisor, :prom_ex, :osmon, :sock_stat], measurement, %{}}}
+      assert %{tcp_inuse: 32, tcp_time_wait: 337} = measurement
+    end
+
+    test "returns ok and emits nothing when file does not exist" do
+      assert :ok = NetStat.execute_sock_stat_metrics("/nonexistent/path")
+    end
+  end
+
+  defp write_fixture(content) do
+    path = Path.join(System.tmp_dir!(), "procfs_fixture_#{:erlang.unique_integer([:positive])}")
     File.write!(path, content)
     on_exit(fn -> File.rm(path) end)
     path


### PR DESCRIPTION
## Summary
Extends the `NetStat` PromEx plugin (`lib/supavisor/monitoring/net_stat.ex`, originally added in #1080) with more network-layer signals from procfs, gathered while investigating a bad-SSL-connections issue:

- **`/proc/net/sockstat`** — TCP socket usage gauges: `tcp_inuse`, `tcp_orphan`, `tcp_time_wait`, `tcp_alloc`, `tcp_mem_pages`. Useful for spotting socket exhaustion / TIME_WAIT buildup on a pooler.
- **`/proc/net/netstat` (`TcpExt`)** — new counters: `tcp_abort_on_timeout`, `tcp_abort_on_close`, `tcp_abort_on_data`, `tcp_abort_on_memory`, `tcp_abort_on_linger`, `tcp_syn_retrans`.
- **`/proc/net/snmp` (`Tcp`)** — new counters: `tcp_attempt_fails`, `tcp_estab_resets`, `tcp_in_errs`.

Note: procfs is TCP/IP-layer only and can't see TLS itself (no cert/cipher/handshake visibility in the kernel). These counters are useful as correlating signals (resets, retransmits, aborts) alongside the actual TLS handshake failure reason, which would need separate `Telem`-based instrumentation at the `:ssl.handshake`/`:ssl.connect` call sites — tracked as follow-up, not part of this PR.

## Test plan
- [x] `mix compile` succeeds
- [x] `mix credo --strict` clean on changed files
- [x] `mix sobelow` — no new findings on `net_stat.ex`
- [x] `mix test test/supavisor/monitoring/net_stat_test.exs` — 27/27 pass
- [x] `mix test` full suite — same 4 pre-existing unrelated failures (local TLS download issue in `prom_ex_test.exs`), no new failures
- [x] Verified each new assertion fails when the underlying parse logic is broken (not just passing by construction)