### PR TITLE
feat: add per-listener ranch connection metrics

### DIFF
--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -14,7 +14,7 @@ defmodule Supavisor.Monitoring.PromEx do
   alias PromEx.Plugins
   alias Supavisor.PeepStorage
   alias Supavisor.PeepStorage.PrometheusCached
-  alias Supavisor.PromEx.Plugins.{Cluster, NetStat, OsMon, Tenant}
+  alias Supavisor.PromEx.Plugins.{Cluster, NetStat, OsMon, Ranch, Tenant}
   alias Telemetry.Metrics
 
   defmodule Store do
@@ -67,6 +67,7 @@ defmodule Supavisor.Monitoring.PromEx do
       # Custom PromEx metrics plugins
       {OsMon, poll_rate: poll_rate},
       {NetStat, poll_rate: poll_rate},
+      {Ranch, poll_rate: poll_rate},
       {Tenant, poll_rate: poll_rate},
       {Cluster, poll_rate: poll_rate}
     ]

--- a/lib/supavisor/monitoring/ranch.ex
+++ b/lib/supavisor/monitoring/ranch.ex
@@ -1,0 +1,80 @@
+defmodule Supavisor.PromEx.Plugins.Ranch do
+  @moduledoc """
+  Polls ranch connection counters for all running ranch listeners.
+  """
+
+  use PromEx.Plugin
+
+  @event [:supavisor, :prom_ex, :ranch]
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate)
+
+    [
+      Polling.build(
+        :supavisor_ranch_events,
+        poll_rate,
+        {__MODULE__, :execute_ranch_metrics, []},
+        [
+          last_value(
+            @event ++ [:connections, :accepted],
+            event_name: @event,
+            description: "Cumulative number of connections accepted by the listener.",
+            measurement: :accepted,
+            tags: [:listener],
+            reporter_options: [prometheus_type: "counter"]
+          ),
+          last_value(
+            @event ++ [:connections, :terminated],
+            event_name: @event,
+            description: "Cumulative number of connections terminated by the listener.",
+            measurement: :terminated,
+            tags: [:listener],
+            reporter_options: [prometheus_type: "counter"]
+          )
+        ]
+      )
+    ]
+  end
+
+  @spec execute_ranch_metrics() :: :ok
+  def execute_ranch_metrics do
+    Enum.each(:ranch_server.get_listener_sups(), fn {ref, _pid} ->
+      emit_listener_metrics(ref)
+    end)
+  end
+
+  # ranch keeps one {accept, terminate} counter pair per conns_sup; it only
+  # exposes them via ranch:info/1, which also makes a gen_server call into
+  # every conns_sup, so read the counters directly instead
+  defp emit_listener_metrics(ref) do
+    counters = :ranch_server.get_stats_counters(ref)
+    %{size: size} = :counters.info(counters)
+
+    # ranch bumps accept before terminate for every connection, so reading each
+    # sup's terminate counter before its accept counter keeps accepted >= terminated
+    {accepted, terminated} =
+      1..size//1
+      |> Stream.chunk_every(2)
+      |> Enum.reduce({0, 0}, fn [accept_idx, terminate_idx], {accepted, terminated} ->
+        terminated = terminated + :counters.get(counters, terminate_idx)
+        accepted = accepted + :counters.get(counters, accept_idx)
+        {accepted, terminated}
+      end)
+
+    :telemetry.execute(
+      @event,
+      %{accepted: accepted, terminated: terminated},
+      %{listener: format_ref(ref)}
+    )
+  rescue
+    # listener stopped between enumeration and counter lookup
+    ArgumentError -> :ok
+  end
+
+  @spec format_ref(:ranch.ref()) :: String.t()
+  def format_ref({:pg_proxy_internal, mode, shard}), do: "pg_proxy_internal_#{mode}_#{shard}"
+  def format_ref(ref) when is_atom(ref), do: Atom.to_string(ref)
+  def format_ref(ref), do: inspect(ref)
+end

--- a/test/supavisor/monitoring/ranch_test.exs
+++ b/test/supavisor/monitoring/ranch_test.exs
@@ -1,0 +1,107 @@
+defmodule Supavisor.PromEx.Plugins.RanchTest do
+  use Supavisor.E2ECase, async: false
+
+  alias Supavisor.PromEx.Plugins.Ranch
+
+  @moduletag telemetry: true
+
+  describe "polling_metrics/1" do
+    test "properly exports metrics" do
+      for polling_metric <- Ranch.polling_metrics([]) do
+        assert %PromEx.MetricTypes.Polling{metrics: [_ | _]} = polling_metric
+        {m, f, a} = polling_metric.measurements_mfa
+        assert function_exported?(m, f, length(a))
+
+        for telemetry_metric <- polling_metric.metrics do
+          assert Enum.any?(
+                   [
+                     Telemetry.Metrics.Distribution,
+                     Telemetry.Metrics.Counter,
+                     Telemetry.Metrics.LastValue,
+                     Telemetry.Metrics.Sum
+                   ],
+                   fn struct -> is_struct(telemetry_metric, struct) end
+                 )
+
+          assert telemetry_metric.description
+        end
+      end
+    end
+
+    test "uses poll rate option" do
+      for polling_metric <- Ranch.polling_metrics(poll_rate: 1000) do
+        assert %{poll_rate: 1000} = polling_metric
+      end
+    end
+
+    test "reports accepted and terminated as counters tagged by listener" do
+      metrics =
+        Ranch.polling_metrics([])
+        |> Enum.flat_map(& &1.metrics)
+
+      for suffix <- [:accepted, :terminated] do
+        name = [:supavisor, :prom_ex, :ranch, :connections, suffix]
+        metric = Enum.find(metrics, &(&1.name == name))
+
+        assert metric, "expected a ranch #{suffix} metric named #{inspect(name)}"
+        assert metric.reporter_options[:prometheus_type] == "counter"
+        assert metric.tags == [:listener]
+      end
+    end
+  end
+
+  describe "execute_ranch_metrics/0" do
+    test "emits one event per running listener with a listener tag" do
+      ref = attach_handler([:supavisor, :prom_ex, :ranch])
+
+      assert :ok = Ranch.execute_ranch_metrics()
+
+      for {listener_ref, _pid} <- :ranch_server.get_listener_sups() do
+        listener = Ranch.format_ref(listener_ref)
+
+        assert_receive {^ref,
+                        {[:supavisor, :prom_ex, :ranch], measurement, %{listener: ^listener}}}
+
+        assert %{accepted: accepted, terminated: terminated} = measurement
+        assert is_integer(accepted) and accepted >= 0
+        assert is_integer(terminated) and terminated >= 0
+        assert accepted >= terminated
+      end
+    end
+  end
+
+  describe "format_ref/1" do
+    test "formats atom refs" do
+      assert Ranch.format_ref(:pg_proxy) == "pg_proxy"
+      assert Ranch.format_ref(:pg_proxy_session) == "pg_proxy_session"
+    end
+
+    test "formats internal shard refs" do
+      assert Ranch.format_ref({:pg_proxy_internal, :session, 0}) == "pg_proxy_internal_session_0"
+
+      assert Ranch.format_ref({:pg_proxy_internal, :transaction, 3}) ==
+               "pg_proxy_internal_transaction_3"
+    end
+  end
+
+  def handle_event(event_name, measurement, meta, {pid, ref}) do
+    send(pid, {ref, {event_name, measurement, meta}})
+  end
+
+  defp attach_handler(event) do
+    ref = make_ref()
+
+    :telemetry.attach(
+      {ref, :test},
+      event,
+      &__MODULE__.handle_event/4,
+      {self(), ref}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach({ref, :test})
+    end)
+
+    ref
+  end
+end


### PR DESCRIPTION
Poll ranch stats counters for all listeners and export cumulative
accepted/terminated counters tagged by listener, including internal
proxy shards.