### PR TITLE
feat: add message queue watchdog and metric

### DIFF
--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -103,6 +103,7 @@ defmodule Supavisor.Application do
       [
         {Cachex, name: Supavisor.Cache},
         Supavisor.ErlSysMon,
+        Supavisor.MessageQueueWatchdog,
         Supavisor.Health,
         Supavisor.ClientAuthentication.RefreshLimiter,
         Supavisor.CircuitBreaker.Janitor,

--- a/lib/supavisor/message_queue_watchdog.ex
+++ b/lib/supavisor/message_queue_watchdog.ex
@@ -1,0 +1,90 @@
+defmodule Supavisor.MessageQueueWatchdog do
+  @moduledoc """
+  Periodically checks message queue lengths of relevant singleton processes.
+
+  Logs a warning when a queue exceeds 20k messages. Shuts down the node
+  when the queue of a process the system cannot operate without exceeds
+  500k messages.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @check_interval :timer.seconds(10)
+
+  @warn_queue_len 20_000
+  @shutdown_queue_len 500_000
+  @shutdown_processes ["tls_connection_sup", "inet_gethost_native"]
+
+  @processes [
+    :tls_connection_sup,
+    :ssl_manager,
+    :ssl_pem_cache,
+    :inet_gethost_native,
+    :rex,
+    :syn_registry_tenants,
+    :syn_pg_tenants,
+    :syn_registry_availability_zone,
+    :syn_pg_availability_zone,
+    Supavisor.ErlSysMon,
+    Supavisor.PoolTerminator,
+    :"Elixir.Supavisor.Cache_courier"
+  ]
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @doc """
+  Reads the current message queue lengths of the watched processes that
+  are running, keyed by a printable process name.
+  """
+  @spec queue_lengths() :: [{String.t(), non_neg_integer()}]
+  def queue_lengths do
+    for name <- @processes,
+        pid = Process.whereis(name),
+        {:message_queue_len, len} <- [Process.info(pid, :message_queue_len)] do
+      {format_name(name), len}
+    end
+  end
+
+  @impl true
+  def init(_args) do
+    schedule_check()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info(:check, state) do
+    Enum.each(queue_lengths(), fn {name, len} -> check_queue_len(name, len) end)
+    schedule_check()
+    {:noreply, state}
+  end
+
+  defp check_queue_len(name, len)
+       when name in @shutdown_processes and len > @shutdown_queue_len do
+    Logger.critical(
+      "#{__MODULE__}: #{name} message queue length is #{len}, shutting down node"
+    )
+
+    System.stop()
+  end
+
+  defp check_queue_len(name, len) when len > @warn_queue_len do
+    Logger.warning("#{__MODULE__}: #{name} message queue length is #{len}")
+  end
+
+  defp check_queue_len(_name, _len), do: :ok
+
+  defp format_name(name) do
+    case Atom.to_string(name) do
+      "Elixir." <> rest -> rest
+      other -> other
+    end
+  end
+
+  defp schedule_check do
+    Process.send_after(self(), :check, @check_interval)
+  end
+end

--- a/lib/supavisor/monitoring/message_queue.ex
+++ b/lib/supavisor/monitoring/message_queue.ex
@@ -1,0 +1,40 @@
+defmodule Supavisor.PromEx.Plugins.MessageQueue do
+  @moduledoc """
+  Polls message queue lengths of relevant singleton processes.
+  """
+
+  use PromEx.Plugin
+
+  alias Supavisor.MessageQueueWatchdog
+
+  @event [:supavisor, :prom_ex, :process]
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate)
+
+    [
+      Polling.build(
+        :supavisor_message_queue_events,
+        poll_rate,
+        {__MODULE__, :execute_metrics, []},
+        [
+          last_value(
+            @event ++ [:message_queue_len],
+            event_name: @event,
+            description: "The number of messages in the process mailbox.",
+            measurement: :message_queue_len,
+            tags: [:name]
+          )
+        ]
+      )
+    ]
+  end
+
+  @spec execute_metrics() :: :ok
+  def execute_metrics do
+    Enum.each(MessageQueueWatchdog.queue_lengths(), fn {name, len} ->
+      :telemetry.execute(@event, %{message_queue_len: len}, %{name: name})
+    end)
+  end
+end

--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -14,7 +14,7 @@ defmodule Supavisor.Monitoring.PromEx do
   alias PromEx.Plugins
   alias Supavisor.PeepStorage
   alias Supavisor.PeepStorage.PrometheusCached
-  alias Supavisor.PromEx.Plugins.{Cluster, NetStat, OsMon, Ranch, Tenant}
+  alias Supavisor.PromEx.Plugins.{Cluster, MessageQueue, NetStat, OsMon, Ranch, Tenant}
   alias Telemetry.Metrics
 
   defmodule Store do
@@ -69,7 +69,8 @@ defmodule Supavisor.Monitoring.PromEx do
       {NetStat, poll_rate: poll_rate},
       {Ranch, poll_rate: poll_rate},
       {Tenant, poll_rate: poll_rate},
-      {Cluster, poll_rate: poll_rate}
+      {Cluster, poll_rate: poll_rate},
+      {MessageQueue, poll_rate: poll_rate}
     ]
   end
 

--- a/test/supavisor/monitoring/message_queue_test.exs
+++ b/test/supavisor/monitoring/message_queue_test.exs
@@ -1,0 +1,96 @@
+defmodule Supavisor.PromEx.Plugins.MessageQueueTest do
+  use Supavisor.E2ECase, async: false
+
+  alias Supavisor.PromEx.Plugins.MessageQueue
+
+  @moduletag telemetry: true
+
+  describe "polling_metrics/1" do
+    test "properly exports metrics" do
+      for polling_metric <- MessageQueue.polling_metrics([]) do
+        assert %PromEx.MetricTypes.Polling{metrics: [_ | _]} = polling_metric
+        {m, f, a} = polling_metric.measurements_mfa
+        assert function_exported?(m, f, length(a))
+
+        for telemetry_metric <- polling_metric.metrics do
+          assert Enum.any?(
+                   [
+                     Telemetry.Metrics.Distribution,
+                     Telemetry.Metrics.Counter,
+                     Telemetry.Metrics.LastValue,
+                     Telemetry.Metrics.Sum
+                   ],
+                   fn struct -> is_struct(telemetry_metric, struct) end
+                 )
+
+          assert telemetry_metric.description
+        end
+      end
+    end
+
+    test "uses poll rate option" do
+      for polling_metric <- MessageQueue.polling_metrics(poll_rate: 1000) do
+        assert %{poll_rate: 1000} = polling_metric
+      end
+    end
+
+    test "reports message queue length as a gauge tagged by process name" do
+      metrics =
+        MessageQueue.polling_metrics([])
+        |> Enum.flat_map(& &1.metrics)
+
+      name = [:supavisor, :prom_ex, :process, :message_queue_len]
+      metric = Enum.find(metrics, &(&1.name == name))
+
+      assert metric, "expected a message queue metric named #{inspect(name)}"
+      assert is_struct(metric, Telemetry.Metrics.LastValue)
+      assert metric.tags == [:name]
+    end
+  end
+
+  describe "execute_metrics/0" do
+    test "emits one event per running process tagged by name" do
+      ref = attach_handler([:supavisor, :prom_ex, :process])
+
+      assert :ok = MessageQueue.execute_metrics()
+
+      for name <- [
+            "rex",
+            "syn_registry_tenants",
+            "syn_pg_tenants",
+            "syn_registry_availability_zone",
+            "syn_pg_availability_zone",
+            "Supavisor.ErlSysMon",
+            "Supavisor.PoolTerminator",
+            "Supavisor.Cache_courier"
+          ] do
+        assert_receive {^ref,
+                        {[:supavisor, :prom_ex, :process], measurement, %{name: ^name}}}
+
+        assert %{message_queue_len: len} = measurement
+        assert is_integer(len) and len >= 0
+      end
+    end
+  end
+
+  def handle_event(event_name, measurement, meta, {pid, ref}) do
+    send(pid, {ref, {event_name, measurement, meta}})
+  end
+
+  defp attach_handler(event) do
+    ref = make_ref()
+
+    :telemetry.attach(
+      {ref, :test},
+      event,
+      &__MODULE__.handle_event/4,
+      {self(), ref}
+    )
+
+    on_exit(fn ->
+      :telemetry.detach({ref, :test})
+    end)
+
+    ref
+  end
+end


### PR DESCRIPTION
Add message queue len metrics for some core processes, including, but not limited to `tls_connection_sup` and `inet_gethost_native`. Logs if any of these message queues are above a threshold of 20k[1]. Shuts down the node if `tls_connection_sup` or `inet_gethost_native` have over 500k messages in queue (debatable).

[1] This should be covered by ErlSysMon. But we have noticed some missing logs on ErlSysMon, so I'm adding this for sanity
