### PR TITLE
feat(monitoring): add TCP active/passive opens metrics (POOLER-524)

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -44,7 +44,7 @@ The exposed metrics include the following:
   * RAM usage
   * Load average (LA)
   * Disk space usage (per mountpoint)
-  * Network counters (listen drops, listen overflows, TCP aborts, SYN retransmits, connection attempt failures, established resets, segment errors)
+  * Network counters (listen drops, listen overflows, TCP aborts, SYN retransmits, active/passive opens, connection attempt failures, established resets, segment errors)
   * TCP socket usage (in-use, orphaned, TIME_WAIT, allocated, memory pages)
 
 ## Tenant metrics

--- a/lib/supavisor/monitoring/net_stat.ex
+++ b/lib/supavisor/monitoring/net_stat.ex
@@ -270,6 +270,20 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
       {__MODULE__, :execute_snmp_stat_metrics, []},
       [
         last_value(
+          @prefix ++ [:osmon, :net, :tcp_active_opens],
+          event_name: @event_snmp_stat,
+          description: "Cumulative number of TCP connections opened actively (outbound).",
+          measurement: :tcp_active_opens,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
+          @prefix ++ [:osmon, :net, :tcp_passive_opens],
+          event_name: @event_snmp_stat,
+          description: "Cumulative number of TCP connections opened passively (inbound).",
+          measurement: :tcp_passive_opens,
+          reporter_options: [prometheus_type: "counter"]
+        ),
+        last_value(
           @prefix ++ [:osmon, :net, :tcp_attempt_fails],
           event_name: @event_snmp_stat,
           description: "Cumulative number of TCP connection attempts that failed.",
@@ -295,6 +309,8 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
   end
 
   @type snmp_stat_counters :: %{
+          tcp_active_opens: non_neg_integer(),
+          tcp_passive_opens: non_neg_integer(),
           tcp_attempt_fails: non_neg_integer(),
           tcp_estab_resets: non_neg_integer(),
           tcp_in_errs: non_neg_integer()
@@ -324,6 +340,8 @@ defmodule Supavisor.PromEx.Plugins.NetStat do
 
         {:ok,
          %{
+           tcp_active_opens: Map.get(counters, "ActiveOpens", 0),
+           tcp_passive_opens: Map.get(counters, "PassiveOpens", 0),
            tcp_attempt_fails: Map.get(counters, "AttemptFails", 0),
            tcp_estab_resets: Map.get(counters, "EstabResets", 0),
            tcp_in_errs: Map.get(counters, "InErrs", 0)

--- a/test/supavisor/monitoring/net_stat_test.exs
+++ b/test/supavisor/monitoring/net_stat_test.exs
@@ -99,7 +99,13 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
         NetStat.polling_metrics([])
         |> Enum.flat_map(& &1.metrics)
 
-      for suffix <- [:tcp_attempt_fails, :tcp_estab_resets, :tcp_in_errs] do
+      for suffix <- [
+            :tcp_active_opens,
+            :tcp_passive_opens,
+            :tcp_attempt_fails,
+            :tcp_estab_resets,
+            :tcp_in_errs
+          ] do
         name = [:supavisor, :prom_ex, :osmon, :net, suffix]
         metric = Enum.find(metrics, &(&1.name == name))
 
@@ -234,9 +240,15 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
   end
 
   describe "parse_snmp_stat/1" do
-    test "extracts AttemptFails, EstabResets and InErrs" do
-      assert {:ok, %{tcp_attempt_fails: 12, tcp_estab_resets: 7, tcp_in_errs: 3}} =
-               NetStat.parse_snmp_stat(@snmp_fixture)
+    test "extracts ActiveOpens, PassiveOpens, AttemptFails, EstabResets and InErrs" do
+      assert {:ok,
+              %{
+                tcp_active_opens: 500,
+                tcp_passive_opens: 300,
+                tcp_attempt_fails: 12,
+                tcp_estab_resets: 7,
+                tcp_in_errs: 3
+              }} = NetStat.parse_snmp_stat(@snmp_fixture)
     end
 
     test "defaults missing counters to 0" do
@@ -245,8 +257,14 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
       Tcp: 1
       """
 
-      assert {:ok, %{tcp_attempt_fails: 0, tcp_estab_resets: 0, tcp_in_errs: 0}} =
-               NetStat.parse_snmp_stat(content)
+      assert {:ok,
+              %{
+                tcp_active_opens: 0,
+                tcp_passive_opens: 0,
+                tcp_attempt_fails: 0,
+                tcp_estab_resets: 0,
+                tcp_in_errs: 0
+              }} = NetStat.parse_snmp_stat(content)
     end
 
     test "returns error for empty content" do
@@ -268,7 +286,13 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
     test "reads real /proc/net/snmp on linux" do
       assert {:ok, stats} = NetStat.snmp_stat()
 
-      for key <- [:tcp_attempt_fails, :tcp_estab_resets, :tcp_in_errs] do
+      for key <- [
+            :tcp_active_opens,
+            :tcp_passive_opens,
+            :tcp_attempt_fails,
+            :tcp_estab_resets,
+            :tcp_in_errs
+          ] do
         assert is_integer(Map.fetch!(stats, key))
       end
     end
@@ -298,7 +322,9 @@ defmodule Supavisor.PromEx.Plugins.NetStatTest do
       assert :ok = NetStat.execute_snmp_stat_metrics(path)
 
       assert_receive {^ref, {[:supavisor, :prom_ex, :osmon, :snmp_stat], measurement, %{}}}
-      assert %{tcp_attempt_fails: 12, tcp_estab_resets: 7, tcp_in_errs: 3} = measurement
+
+      assert %{tcp_active_opens: 500, tcp_passive_opens: 300, tcp_attempt_fails: 12} =
+               measurement
     end
 
     test "returns ok and emits nothing when file does not exist" do


### PR DESCRIPTION
## Summary
- Extends the `NetStat` PromEx plugin (`lib/supavisor/monitoring/net_stat.ex`) with two more counters from the `Tcp:` line of `/proc/net/snmp`, alongside the existing `tcp_attempt_fails`/`tcp_estab_resets`/`tcp_in_errs`:
  - `tcp_active_opens` — connections this host initiated (outbound, e.g. to Postgres upstream)
  - `tcp_passive_opens` — connections this host accepted (inbound, e.g. from clients)
- Basic connection-churn signal to pair with the existing point-in-time `tcp_inuse`/`tcp_time_wait` gauges.

## Test plan
- [x] `mix compile` succeeds
- [x] `mix credo --strict` clean on changed files
- [x] `mix sobelow` — no new findings on `net_stat.ex`
- [x] `mix test test/supavisor/monitoring/net_stat_test.exs` — 27/27 pass
- [x] `mix test` full suite — same 4 pre-existing unrelated failures (local TLS download issue in `prom_ex_test.exs`), no new failures
- [x] Verified the new assertions fail when the underlying parse logic is broken