### PR TITLE
fix(monitoring): drop tenant label from state duration metric

### DIFF
--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -185,7 +185,7 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           event_name: [:supavisor, :client_handler, :state],
           measurement: :duration,
           description: "Duration spent in each client_handler state.",
-          tags: [:tenant, :from_state, :to_state],
+          tags: [:from_state, :to_state],
           unit: {:native, :millisecond},
           reporter_options: [
             peep_bucket_calculator: Buckets


### PR DESCRIPTION
Reduces cardinality: one series per from_state/to_state pair instead of per tenant. The tenant is still in the telemetry event metadata in case we want to use it for other purposes (e.g.: tracing).