### PR TITLE
ci: publish Docker Hub releases from release tags

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,27 +1,84 @@
 name: Release on Dockerhub
 
+# Version bumps land on the release line (e.g. the v2.9 branch), not main, so
+# the old "push to main when VERSION changes" trigger stopped publishing after
+# 2.9.7. Publishing is now driven by the release tag itself:
+#
+#   - Pushing a tag v<version> publishes supabase/supavisor:<version> built
+#     from that tag's tree. GitHub reads the workflow from the pushed tag, so
+#     this only fires for tags whose tree contains this file: it must live on
+#     each active release branch (e.g. v2.9), not just main.
+#   - Tags cut before this trigger existed can be backfilled with a manual
+#     dispatch from main: the version input decides what is built and
+#     published; the dispatched ref is only used to locate this file.
+#
+# Both paths check out refs/tags/v<version> and verify it against the VERSION
+# file at that tag, so a run can never rebuild a published version from the
+# wrong tree.
+
 on:
   push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/publish_docker.yml"
-      - "VERSION"
-  # VERSION bumps after 2.9.7 land on the release-tag line, not main, so
-  # path-filtered pushes never publish those tags (Hub still ends at 2.9.7).
+    tags:
+      - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release to publish, without the leading v (e.g. 2.9.8). Must match an existing v<version> tag."
+        required: true
+        type: string
+      otp_version:
+        description: "Optional OTP_VERSION build-arg override. Tags up to v2.9.12 pin OTP 27.2.1, which can no longer fetch from builds.hex.pm (key_usage_mismatch); pass 27.3.4 for those."
+        required: false
+        type: string
+      debian_version:
+        description: "Optional DEBIAN_VERSION build-arg override (e.g. bullseye-20260610-slim); needed alongside otp_version for old tags."
+        required: false
+        type: string
 
 jobs:
   settings:
     runs-on: ubuntu-latest
     outputs:
-      docker_version: ${{ steps.settings.outputs.result }}
-      image_tag: supabase/supavisor:${{ steps.settings.outputs.result }}
+      docker_version: ${{ steps.settings.outputs.version }}
+      image_tag: supabase/supavisor:${{ steps.settings.outputs.version }}
+      git_ref: refs/tags/v${{ steps.settings.outputs.version }}
+      build_args: ${{ steps.settings.outputs.build_args }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: settings
-        # Remove spaces to get the raw version string
-        run: echo "result=$(sed -r 's/\s+//g' VERSION)" >> $GITHUB_OUTPUT
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_OTP_VERSION: ${{ inputs.otp_version }}
+          INPUT_DEBIAN_VERSION: ${{ inputs.debian_version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            version="${INPUT_VERSION#v}"
+          else
+            version="${GITHUB_REF_NAME#v}"
+          fi
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::'$version' does not look like a release version (expected e.g. 2.9.8 or 2.9.6-rc.0)"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          {
+            echo "build_args<<BUILD_ARGS"
+            if [ -n "$INPUT_OTP_VERSION" ]; then echo "OTP_VERSION=$INPUT_OTP_VERSION"; fi
+            if [ -n "$INPUT_DEBIAN_VERSION" ]; then echo "DEBIAN_VERSION=$INPUT_DEBIAN_VERSION"; fi
+            echo "BUILD_ARGS"
+          } >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/tags/v${{ steps.settings.outputs.version }}
+      - name: Verify tag against VERSION file
+        env:
+          VERSION_TO_PUBLISH: ${{ steps.settings.outputs.version }}
+        run: |
+          file_version="$(sed -r 's/\s+//g' VERSION)"
+          if [ "$file_version" != "$VERSION_TO_PUBLISH" ]; then
+            echo "::error::VERSION at tag v$VERSION_TO_PUBLISH is '$file_version'; refusing to publish a mismatched image"
+            exit 1
+          fi
 
   build_image:
     needs: settings
@@ -37,6 +94,9 @@ jobs:
     outputs:
       image_digest: ${{ steps.build.outputs.digest }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.settings.outputs.git_ref }}
       - run: docker context create builders
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
@@ -48,11 +108,14 @@ jobs:
       - id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
+          # Build the checked-out tag, not the Git context of the triggering ref
+          context: .
           push: true
           tags: ${{ needs.settings.outputs.image_tag }}_${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.arch }}
+          build-args: ${{ needs.settings.outputs.build_args }}
+          cache-from: type=gha,scope=v${{ needs.settings.outputs.docker_version }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=v${{ needs.settings.outputs.docker_version }}-${{ matrix.arch }}
 
   merge_manifest:
     needs: [settings, build_image]

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - ".github/workflows/publish_docker.yml"
       - "VERSION"
+  # VERSION bumps after 2.9.7 land on the release-tag line, not main, so
+  # path-filtered pushes never publish those tags (Hub still ends at 2.9.7).
+  workflow_dispatch:
 
 jobs:
   settings:


### PR DESCRIPTION
## Summary
- `Release on Dockerhub` only ran on pushes to `main` when `VERSION` changed. Version bumps now land on the release line (the `v2.9` branch), so Hub never got 2.9.8–2.9.11 (2.9.12 was published manually from a side branch). The old trigger was also a footgun: it path-filtered on the workflow file itself, so merging any change to it — including the previous version of this PR — would have rebuilt the stale 2.9.7 from main's much newer tree and overwritten the published Hub tag, then mirrored that to ECR/GHCR.
- Replace it with tag-anchored publishing:
  - `push` on `v*` tags publishes the tagged version automatically as releases happen. GitHub reads the workflow from the pushed tag, so this file must also be cherry-picked to the `v2.9` branch to cover future tags cut there — merging to main alone is not enough.
  - `workflow_dispatch` with a required `version` input backfills tags cut before the trigger existed. The dispatched ref is only used to locate the workflow file; the validated input decides what gets built.
- Every run checks out `refs/tags/v<version>` explicitly (the build jobs previously used the Git context of the triggering ref) and refuses to publish if the tag's `VERSION` file disagrees with the version being published.
- Optional `otp_version` / `debian_version` dispatch inputs override the Dockerfile `ARG`s for old tags whose pinned OTP 27.2.1 can no longer fetch from builds.hex.pm (`key_usage_mismatch`), so backfills don't need patched side branches.

## Test plan
- [x] actionlint passes (only pre-existing warning is the custom `arm-runner` label)
- [x] Version-derivation logic tested locally: tag push, dispatch input with/without leading `v`, build-arg emission, and rejection of non-version inputs (`main`, shell metacharacters)
- [ ] Merge this to main, then cherry-pick the same commit to `v2.9` so future tags auto-publish
- [ ] Backfill the missing releases: `gh workflow run publish_docker.yml --ref main -f version=2.9.8 -f otp_version=27.3.4 -f debian_version=bullseye-20260610-slim` (repeat for 2.9.9, 2.9.10, 2.9.11)
- [ ] Confirm `docker.io/supabase/supavisor:2.9.8`–`2.9.11` exist (amd64 + arm64) and are mirrored to ECR/GHCR
- [ ] Next release: push the `v2.9.13` tag and confirm the workflow runs with no manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvYtYTmAonGS6aw3rLQRfD