### PR TITLE
feat: wait for a free client slot before rejecting with EMAXCONN

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,12 @@ config :supavisor,
   env: Mix.env(),
   metrics_disabled: System.get_env("METRICS_DISABLED") == "true",
   switch_active_count: System.get_env("SWITCH_ACTIVE_COUNT", "100") |> String.to_integer(),
-  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "20") |> String.to_integer()
+  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "20") |> String.to_integer(),
+  # How long a client waits for a free slot before being rejected with EMAXCONN.
+  # The total budget (retries * backoff) must stay well below the handshake state
+  # timeout, otherwise the client is dropped without an error message.
+  admission_retries: System.get_env("ADMISSION_RETRIES", "5") |> String.to_integer(),
+  admission_backoff: System.get_env("ADMISSION_BACKOFF", "300") |> String.to_integer()
 
 config :prom_ex, storage_adapter: Supavisor.Monitoring.PromEx.Store
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,6 +32,8 @@ config :supavisor,
     System.get_env("TRANSACTION_PROXY_PORTS", "12104,12105,12106,12107") |> parse_integer_list.(),
   max_pools: 10,
   subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer(),
+  admission_retries: System.get_env("ADMISSION_RETRIES", "3") |> String.to_integer(),
+  admission_backoff: System.get_env("ADMISSION_BACKOFF", "100") |> String.to_integer(),
   metrics_pusher_req_options: [
     plug: {Req.Test, Supavisor.MetricsPusher.Global}
   ],

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -17,6 +17,8 @@ defmodule Supavisor.ClientHandler do
   @proto [:tcp, :ssl]
   @switch_active_count Application.compile_env(:supavisor, :switch_active_count)
   @subscribe_retries Application.compile_env(:supavisor, :subscribe_retries)
+  @admission_retries Application.compile_env(:supavisor, :admission_retries)
+  @admission_backoff Application.compile_env(:supavisor, :admission_backoff)
   @max_checkout_retries 2
   @timeout_subscribe 500
   @ssl_handshake_timeout 2_500
@@ -54,6 +56,7 @@ defmodule Supavisor.ClientHandler do
     ClientSocketClosedError,
     DbHandlerExitedError,
     HandshakeTimeoutError,
+    MaxConnectionsError,
     PoolCheckoutError,
     PoolConfigNotFoundError,
     PoolRanchNotFoundError,
@@ -118,7 +121,8 @@ defmodule Supavisor.ClientHandler do
       heartbeat_interval: 0,
       connection_start: now,
       state_entered_at: now,
-      subscribe_retries: 0
+      subscribe_retries: 0,
+      admission_retries: 0
     }
 
     :gen_statem.enter_loop(__MODULE__, [hibernate_after: 5_000], :handshake, data, [
@@ -226,7 +230,9 @@ defmodule Supavisor.ClientHandler do
 
   def handle_event(
         :internal,
-        {:hello, {type, {user, tenant_or_alias, db_name, search_path, client_jit, client_tls}}},
+        {:hello,
+         {type, {user, tenant_or_alias, db_name, search_path, client_jit, client_tls}} =
+           hello_args},
         :handshake,
         %{sock: sock} = data
       ) do
@@ -279,6 +285,9 @@ defmodule Supavisor.ClientHandler do
           {:keep_state, new_data,
            {:next_event, :internal, {:start_authentication, auth_method, info}}}
         else
+          {:error, %MaxConnectionsError{} = exception} ->
+            wait_for_slot_or_terminate(%{data | id: id}, {:hello, hello_args}, exception)
+
           {:error, exception} when is_exception(exception) ->
             Error.terminate_with_error(%{data | id: id}, exception, :handshake)
         end
@@ -286,6 +295,12 @@ defmodule Supavisor.ClientHandler do
       {:error, exception} ->
         Error.terminate_with_error(data, exception, :handshake)
     end
+  end
+
+  # Re-runs admission after waiting for a free client slot.
+  # Named timeout: :state_timeout would cancel @handshake_timeout.
+  def handle_event({:timeout, :admission_retry}, retry_event, _state, _data) do
+    {:keep_state_and_data, {:next_event, :internal, retry_event}}
   end
 
   def handle_event(
@@ -351,6 +366,10 @@ defmodule Supavisor.ClientHandler do
         include_app_name: include_app_name?(data)
       )
 
+      # Only meaningful once we hold a slot, so it is recorded here rather than at the
+      # earlier limit check, which can still be followed by a rejection at subscribe.
+      if data.admission_retries > 0, do: Telem.client_admission(:admitted, data.id)
+
       cond do
         data.client_ready ->
           {:next_state, :idle, data, handle_actions(data)}
@@ -367,6 +386,12 @@ defmodule Supavisor.ClientHandler do
 
       {:error, %PoolConfigNotFoundError{}} ->
         timeout_subscribe_or_terminate(data)
+
+      # `check_client_limit/3` reads the pool's client table directly, so it can race with
+      # this authoritative check. Wait for a slot here too, but keep the original error so
+      # exhaustion is not reported as a subscribe failure.
+      {:error, %MaxConnectionsError{} = exception} ->
+        wait_for_slot_or_terminate(data, :subscribe, exception)
 
       {:error, exception} when is_exception(exception) ->
         Error.terminate_with_error(data, exception, :handshake)
@@ -1003,6 +1028,38 @@ defmodule Supavisor.ClientHandler do
     else
       Error.terminate_with_error(data, %SubscribeRetriesExhaustedError{}, :handshake)
     end
+  end
+
+  @doc """
+  Holds a connection that hit the client limit and re-runs admission after a backoff.
+
+  Rejecting a full pool immediately makes the client reconnect, and each reconnect pays for
+  another TLS handshake only to be rejected again - which is how a saturated pool turns
+  into a CPU outage. Retrying reuses the handshake we already paid for: the client is
+  admitted as soon as a slot frees, and one that never gets a slot receives the same error
+  it would have received immediately, just later.
+
+  `retry_event` is the internal event to replay, so this serves both the pre-auth check in
+  `:handshake` and the authoritative check during `:subscribe`.
+  """
+  @spec wait_for_slot_or_terminate(map(), term(), Exception.t()) ::
+          :gen_statem.handle_event_result()
+  def wait_for_slot_or_terminate(%{admission_retries: retries} = data, retry_event, exception) do
+    if retries < @admission_retries do
+      Logger.debug("ClientHandler: Waiting for a free client slot, attempt #{retries + 1}")
+
+      {:keep_state, %{data | admission_retries: retries + 1},
+       {{:timeout, :admission_retry}, admission_backoff(), retry_event}}
+    else
+      Telem.client_admission(:rejected, data.id)
+      Error.terminate_with_error(data, exception, :handshake)
+    end
+  end
+
+  # Jittered so that waiters woken by the same freed slot do not re-check in lockstep.
+  defp admission_backoff do
+    jitter = max(div(@admission_backoff, 4), 1)
+    max(@admission_backoff - jitter + :rand.uniform(2 * jitter), 0)
   end
 
   defp pool_checkout(pool, timeout, mode) do

--- a/lib/supavisor/client_handler/data.ex
+++ b/lib/supavisor/client_handler/data.ex
@@ -39,6 +39,7 @@ defmodule Supavisor.ClientHandler.Data do
     :connection_start,
     :state_entered_at,
     :subscribe_retries,
+    :admission_retries,
     :client_ready,
     :max_clients,
     :pool_ranch,

--- a/lib/supavisor/monitoring/telem.ex
+++ b/lib/supavisor/monitoring/telem.ex
@@ -90,6 +90,26 @@ defmodule Supavisor.Monitoring.Telem do
     Logger.debug("client_join is called with a mismatched id: #{Supavisor.inspect_id(id)}")
   end
 
+  @doc """
+  Outcome of a connection that hit the client limit and had to wait for a free slot.
+
+  `:admitted` means a slot freed up within the wait budget, so the connection would have
+  been rejected before waiting was introduced. `:rejected` means the budget was exhausted
+  and the client received EMAXCONN.
+  """
+  @spec client_admission(:admitted | :rejected, Supavisor.id() | any()) :: :ok | nil
+  def client_admission(status, Supavisor.id() = id) do
+    telemetry_execute(
+      [:supavisor, :client, :admission, status],
+      %{},
+      id_to_tags(id)
+    )
+  end
+
+  def client_admission(_status, id) do
+    Logger.debug("client_admission is called with a mismatched id: #{Supavisor.inspect_id(id)}")
+  end
+
   @spec handler_action(
           :client_handler | :db_handler,
           :started | :stopped | :db_connection,

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -169,6 +169,20 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           tags: @tags
         ),
         counter(
+          [:supavisor, :client, :admission, :admitted],
+          event_name: [:supavisor, :client, :admission, :admitted],
+          description:
+            "The total number of connections admitted after waiting for a free client slot.",
+          tags: @tags
+        ),
+        counter(
+          [:supavisor, :client, :admission, :rejected],
+          event_name: [:supavisor, :client, :admission, :rejected],
+          description:
+            "The total number of connections rejected with EMAXCONN after exhausting the wait for a free client slot.",
+          tags: @tags
+        ),
+        counter(
           [:supavisor, :client_handler, :started, :count],
           event_name: [:supavisor, :client_handler, :started, :all],
           description: "The total number of created client_handler.",

--- a/priv/repo/seeds_after_migration.exs
+++ b/priv/repo/seeds_after_migration.exs
@@ -127,6 +127,28 @@ if !Tenants.get_tenant_by_external_id("proxy_pool_tenant") do
     |> Tenants.create_tenant()
 end
 
+if !Tenants.get_tenant_by_external_id("admission_tenant") do
+  {:ok, _} =
+    %{
+      db_host: db_conf[:hostname],
+      db_port: db_conf[:port],
+      db_database: db_conf[:database],
+      default_parameter_status: %{},
+      external_id: "admission_tenant",
+      require_user: true,
+      users: [
+        %{
+          "db_user" => db_conf[:username],
+          "db_password" => db_conf[:password],
+          "pool_size" => 2,
+          "max_clients" => 2,
+          "mode_type" => "transaction"
+        }
+      ]
+    }
+    |> Tenants.create_tenant()
+end
+
 if !Tenants.get_tenant_by_external_id("dead_port_repro_tenant") do
   {:ok, _} =
     %{

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -439,6 +439,96 @@ defmodule Supavisor.Integration.ProxyTest do
             }} = single_connection(connection_opts)
   end
 
+  describe "waiting for a free client slot" do
+    setup do
+      db_conf = Application.get_env(:supavisor, Supavisor.Repo)
+
+      connection_opts = [
+        hostname: db_conf[:hostname],
+        port: Application.get_env(:supavisor, :proxy_port_transaction),
+        username: db_conf[:username] <> ".admission_tenant",
+        database: db_conf[:database],
+        password: db_conf[:password]
+      ]
+
+      test_pid = self()
+      ref = make_ref()
+      handler_id = {__MODULE__, ref}
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:supavisor, :client, :admission, :admitted],
+          [:supavisor, :client, :admission, :rejected]
+        ],
+        fn event, _measurements, _metadata, _config -> send(test_pid, {ref, event}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{connection_opts: connection_opts, ref: ref}
+    end
+
+    test "admits a waiting client when a slot frees up", ctx do
+      ref = ctx.ref
+
+      # admission_tenant allows 2 clients, so the pool is now full
+      assert {:ok, conn} = single_connection(ctx.connection_opts)
+      assert {:ok, _conn} = single_connection(ctx.connection_opts)
+
+      test_pid = self()
+      connection_opts = ctx.connection_opts
+
+      spawn(fn ->
+        result =
+          try do
+            SingleConnection.connect(connection_opts)
+          catch
+            kind, reason -> {:error, {kind, reason}}
+          end
+
+        send(test_pid, {:waiter, result})
+      end)
+
+      # Give the third connection time to hit the limit and start waiting, then free a
+      # slot well inside its budget. Before waiting was introduced this connection would
+      # already have been rejected.
+      Process.sleep(50)
+      GenServer.stop(conn)
+
+      assert_receive {:waiter, {:ok, _pid}}, 5_000
+      assert_receive {^ref, [:supavisor, :client, :admission, :admitted]}, 1_000
+    end
+
+    test "rejects with EMAXCONN once the wait budget is exhausted", ctx do
+      ref = ctx.ref
+
+      assert {:ok, _conn} = single_connection(ctx.connection_opts)
+      assert {:ok, _conn} = single_connection(ctx.connection_opts)
+
+      {elapsed, result} = :timer.tc(fn -> single_connection(ctx.connection_opts) end)
+
+      assert {:error,
+              %Postgrex.Error{
+                postgres: %{
+                  code: :internal_error,
+                  message: "(EMAXCONN) max client connections reached, limit: 2",
+                  pg_code: "XX000",
+                  severity: "FATAL"
+                }
+              }} = result
+
+      assert_receive {^ref, [:supavisor, :client, :admission, :rejected]}, 1_000
+
+      # The throttle: the client is held rather than being rejected immediately, which is
+      # what slows down a client reconnecting in a tight loop.
+      retries = Application.get_env(:supavisor, :admission_retries)
+      backoff = Application.get_env(:supavisor, :admission_backoff)
+      assert elapsed >= retries * div(backoff, 2) * 1_000
+    end
+  end
+
   test "checkout timeout in transaction mode" do
     %{db_conf: db_conf} = setup_tenant_connections(List.first(@tenants))
 

--- a/test/supavisor/client_handler_test.exs
+++ b/test/supavisor/client_handler_test.exs
@@ -70,6 +70,62 @@ defmodule Supavisor.ClientHandlerTest do
     end
   end
 
+  describe "waiting for a free client slot" do
+    alias Supavisor.Errors.MaxConnectionsError
+
+    setup do
+      %{
+        exception: MaxConnectionsError.new(:transaction, 2),
+        retry_event: {:hello, {:single, {"user", "tenant", "postgres", nil, false, false}}},
+        budget: Application.get_env(:supavisor, :admission_retries)
+      }
+    end
+
+    test "holds the connection and schedules a retry while budget remains", ctx do
+      data = %{admission_retries: 0, id: nil}
+      retry_event = ctx.retry_event
+
+      assert {:keep_state, %{admission_retries: 1},
+              {{:timeout, :admission_retry}, delay, ^retry_event}} =
+               @subject.wait_for_slot_or_terminate(data, retry_event, ctx.exception)
+
+      assert delay > 0
+    end
+
+    test "keeps counting retries so the total wait stays bounded", ctx do
+      data = %{admission_retries: ctx.budget - 1, id: nil}
+
+      assert {:keep_state, %{admission_retries: retries}, _action} =
+               @subject.wait_for_slot_or_terminate(data, ctx.retry_event, ctx.exception)
+
+      assert retries == ctx.budget
+    end
+
+    test "sends the original error to the client once the budget is exhausted", ctx do
+      {client, server} = sockpair()
+      data = %{admission_retries: ctx.budget, id: nil, sock: {:gen_tcp, server}}
+
+      assert {:stop, :normal} =
+               @subject.wait_for_slot_or_terminate(data, ctx.retry_event, ctx.exception)
+
+      assert {:ok, response} = :gen_tcp.recv(client, 0, 1_000)
+      assert response =~ "EMAXCONN"
+      assert response =~ "max client connections reached"
+    end
+
+    test "replays the pending event when the retry timer fires", ctx do
+      retry_event = ctx.retry_event
+
+      assert {:keep_state_and_data, {:next_event, :internal, ^retry_event}} =
+               @subject.handle_event(
+                 {:timeout, :admission_retry},
+                 retry_event,
+                 :handshake,
+                 %{}
+               )
+    end
+  end
+
   describe "socket DOWN handler" do
     test "handles DOWN message for matching ref" do
       ref = make_ref()


### PR DESCRIPTION
Instead of rejecting right away, hold the connection after the handshake and re-run admission a few times. A client is admitted as soon as a slot frees, and one that never gets a slot receives the expected EMAXCONN error. This throttles its retry loop by roughly the wait budget.
