### PR TITLE
chore: backport push metrics support (POOLER-638) to v2.9

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -113,20 +113,6 @@ config :libcluster,
   topologies: topologies
 
 if config_env() != :test do
-  metrics_pusher_extra_labels =
-    case System.get_env("METRICS_PUSHER_EXTRA_LABELS", "") do
-      "" ->
-        []
-
-      labels ->
-        labels
-        |> String.split(",")
-        |> Enum.map(fn pair ->
-          [k, v] = String.split(pair, "=", parts: 2)
-          {k, v}
-        end)
-    end
-
   config :supavisor,
     metrics_pusher_enabled: Supavisor.Helpers.get_env_bool("METRICS_PUSHER_ENABLED", false),
     metrics_pusher_url: System.get_env("METRICS_PUSHER_URL"),
@@ -137,7 +123,21 @@ if config_env() != :test do
     metrics_pusher_timeout_ms:
       System.get_env("METRICS_PUSHER_TIMEOUT_MS", "15000") |> String.to_integer(),
     metrics_pusher_compress: Supavisor.Helpers.get_env_bool("METRICS_PUSHER_COMPRESS", true),
-    metrics_pusher_extra_labels: metrics_pusher_extra_labels
+    metrics_pusher_extra_labels:
+      Supavisor.Helpers.parse_extra_labels("METRICS_PUSHER_EXTRA_LABELS"),
+    tenant_metrics_pusher_enabled:
+      Supavisor.Helpers.get_env_bool("TENANT_METRICS_PUSHER_ENABLED", false),
+    tenant_metrics_pusher_url: System.get_env("TENANT_METRICS_PUSHER_URL"),
+    tenant_metrics_pusher_user: System.get_env("TENANT_METRICS_PUSHER_USER", "supavisor"),
+    tenant_metrics_pusher_auth: System.get_env("TENANT_METRICS_PUSHER_AUTH"),
+    tenant_metrics_pusher_interval_ms:
+      System.get_env("TENANT_METRICS_PUSHER_INTERVAL_MS", "30000") |> String.to_integer(),
+    tenant_metrics_pusher_timeout_ms:
+      System.get_env("TENANT_METRICS_PUSHER_TIMEOUT_MS", "15000") |> String.to_integer(),
+    tenant_metrics_pusher_compress:
+      Supavisor.Helpers.get_env_bool("TENANT_METRICS_PUSHER_COMPRESS", true),
+    tenant_metrics_pusher_extra_labels:
+      Supavisor.Helpers.parse_extra_labels("TENANT_METRICS_PUSHER_EXTRA_LABELS")
 end
 
 upstream_ca =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -112,6 +112,34 @@ config :libcluster,
   debug: false,
   topologies: topologies
 
+if config_env() != :test do
+  metrics_pusher_extra_labels =
+    case System.get_env("METRICS_PUSHER_EXTRA_LABELS", "") do
+      "" ->
+        []
+
+      labels ->
+        labels
+        |> String.split(",")
+        |> Enum.map(fn pair ->
+          [k, v] = String.split(pair, "=", parts: 2)
+          {k, v}
+        end)
+    end
+
+  config :supavisor,
+    metrics_pusher_enabled: Supavisor.Helpers.get_env_bool("METRICS_PUSHER_ENABLED", false),
+    metrics_pusher_url: System.get_env("METRICS_PUSHER_URL"),
+    metrics_pusher_user: System.get_env("METRICS_PUSHER_USER", "supavisor"),
+    metrics_pusher_auth: System.get_env("METRICS_PUSHER_AUTH"),
+    metrics_pusher_interval_ms:
+      System.get_env("METRICS_PUSHER_INTERVAL_MS", "30000") |> String.to_integer(),
+    metrics_pusher_timeout_ms:
+      System.get_env("METRICS_PUSHER_TIMEOUT_MS", "15000") |> String.to_integer(),
+    metrics_pusher_compress: Supavisor.Helpers.get_env_bool("METRICS_PUSHER_COMPRESS", true),
+    metrics_pusher_extra_labels: metrics_pusher_extra_labels
+end
+
 upstream_ca =
   if path = System.get_env("GLOBAL_UPSTREAM_CA_PATH") do
     File.read!(path)

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,7 +33,10 @@ config :supavisor,
   max_pools: 10,
   subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer(),
   metrics_pusher_req_options: [
-    plug: {Req.Test, Supavisor.MetricsPusher}
+    plug: {Req.Test, Supavisor.MetricsPusher.Global}
+  ],
+  tenant_metrics_pusher_req_options: [
+    plug: {Req.Test, Supavisor.MetricsPusher.Tenant}
   ]
 
 config :supavisor, Supavisor.Repo,

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,7 +31,10 @@ config :supavisor,
   transaction_proxy_ports:
     System.get_env("TRANSACTION_PROXY_PORTS", "12104,12105,12106,12107") |> parse_integer_list.(),
   max_pools: 10,
-  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer()
+  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer(),
+  metrics_pusher_req_options: [
+    plug: {Req.Test, Supavisor.MetricsPusher}
+  ]
 
 config :supavisor, Supavisor.Repo,
   username: "postgres",

--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -110,6 +110,7 @@ defmodule Supavisor.Application do
         Supavisor.ConnectBackoff.Janitor,
         Supavisor.DeadPortSweeper,
         {Task.Supervisor, name: Supavisor.PoolTerminator},
+        {Task.Supervisor, name: Supavisor.TaskSupervisor},
         {Registry, keys: :unique, name: Supavisor.Registry.Tenants},
         {Registry, keys: :unique, name: Supavisor.Registry.ManagerTables},
         {Registry, keys: :unique, name: Supavisor.Registry.PoolPids},
@@ -144,7 +145,9 @@ defmodule Supavisor.Application do
       if @metrics_disabled do
         children
       else
-        children ++ [PromEx, Supavisor.TenantsMetrics, Supavisor.MetricsCleaner]
+        children ++
+          [PromEx, Supavisor.TenantsMetrics, Supavisor.MetricsCleaner] ++
+          metrics_pusher_children()
       end
 
     # See https://hexdocs.pm/elixir/Supervisor.html
@@ -159,6 +162,14 @@ defmodule Supavisor.Application do
   def config_change(changed, _new, removed) do
     SupavisorWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp metrics_pusher_children do
+    if Application.get_env(:supavisor, :metrics_pusher_enabled) do
+      [Supavisor.MetricsPusher]
+    else
+      []
+    end
   end
 
   @spec build_shards([pos_integer()], atom()) :: term()

--- a/lib/supavisor/application.ex
+++ b/lib/supavisor/application.ex
@@ -164,12 +164,23 @@ defmodule Supavisor.Application do
     :ok
   end
 
-  defp metrics_pusher_children do
-    if Application.get_env(:supavisor, :metrics_pusher_enabled) do
-      [Supavisor.MetricsPusher]
-    else
-      []
-    end
+  @spec metrics_pusher_children() :: [Supervisor.child_spec()]
+  def metrics_pusher_children do
+    [
+      if Application.get_env(:supavisor, :metrics_pusher_enabled) do
+        Supervisor.child_spec(
+          {Supavisor.MetricsPusher, scope: :global, name: Supavisor.MetricsPusher.Global},
+          id: Supavisor.MetricsPusher.Global
+        )
+      end,
+      if Application.get_env(:supavisor, :tenant_metrics_pusher_enabled) do
+        Supervisor.child_spec(
+          {Supavisor.MetricsPusher, scope: :tenant, name: Supavisor.MetricsPusher.Tenant},
+          id: Supavisor.MetricsPusher.Tenant
+        )
+      end
+    ]
+    |> Enum.reject(&is_nil/1)
   end
 
   @spec build_shards([pos_integer()], atom()) :: term()

--- a/lib/supavisor/helpers.ex
+++ b/lib/supavisor/helpers.ex
@@ -451,6 +451,25 @@ defmodule Supavisor.Helpers do
     end
   end
 
+  @doc """
+  Parses a comma-separated `k1=v1,k2=v2` env var into a list of `{k, v}` tuples.
+  """
+  @spec parse_extra_labels(String.t()) :: [{String.t(), String.t()}]
+  def parse_extra_labels(env_var) do
+    case System.get_env(env_var, "") do
+      "" ->
+        []
+
+      labels ->
+        labels
+        |> String.split(",")
+        |> Enum.map(fn pair ->
+          [k, v] = String.split(pair, "=", parts: 2)
+          {k, v}
+        end)
+    end
+  end
+
   def no_warm_pool_user?(user) do
     no_warm_pool_users = Application.get_env(:supavisor, :no_warm_pool_users, [])
     user in no_warm_pool_users

--- a/lib/supavisor/metrics_pusher.ex
+++ b/lib/supavisor/metrics_pusher.ex
@@ -2,7 +2,12 @@ defmodule Supavisor.MetricsPusher do
   @moduledoc """
   GenServer that periodically pushes Prometheus metrics to an endpoint.
 
-  Only starts if `url` is configured.
+  Runs once per `:scope` (`:tenant` or `:global`), pushing only the metrics
+  belonging to that scope (see `Supavisor.Monitoring.PromEx.get_metrics/1`) so
+  tenant-tagged and cluster/node-level metrics can be routed to different
+  Prometheus endpoints.
+
+  Only starts if the scope's `url` is configured.
   Pushes metrics every 30 seconds (configurable) to the configured URL endpoint.
   """
 
@@ -12,22 +17,27 @@ defmodule Supavisor.MetricsPusher do
 
   alias Supavisor.Monitoring.PromEx
 
+  @type scope :: :tenant | :global
+
   @type t :: %__MODULE__{
+          scope: scope(),
           push_ref: reference() | nil,
           interval: pos_integer() | nil,
           req_options: keyword() | nil
         }
 
-  defstruct [:push_ref, :interval, :req_options]
+  defstruct [:scope, :push_ref, :interval, :req_options]
 
   @spec start_link(keyword()) :: {:ok, pid()} | :ignore
   def start_link(opts) do
-    url = Keyword.get(opts, :url, Application.get_env(:supavisor, :metrics_pusher_url))
+    scope = Keyword.fetch!(opts, :scope)
+    name = Keyword.get(opts, :name, __MODULE__)
+    url = Keyword.get(opts, :url, Application.get_env(:supavisor, config_key(scope, :url)))
 
     if is_binary(url) do
-      GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+      GenServer.start_link(__MODULE__, opts, name: name)
     else
-      Logger.warning("MetricsPusher not started: url must be configured")
+      Logger.warning("MetricsPusher (#{scope}) not started: url must be configured")
 
       :ignore
     end
@@ -35,45 +45,51 @@ defmodule Supavisor.MetricsPusher do
 
   @impl true
   def init(opts) do
-    url = Keyword.get(opts, :url, Application.get_env(:supavisor, :metrics_pusher_url))
+    scope = Keyword.fetch!(opts, :scope)
+
+    url = Keyword.get(opts, :url, Application.get_env(:supavisor, config_key(scope, :url)))
 
     user =
-      Keyword.get(opts, :user, Application.get_env(:supavisor, :metrics_pusher_user, "supavisor"))
+      Keyword.get(
+        opts,
+        :user,
+        Application.get_env(:supavisor, config_key(scope, :user), "supavisor")
+      )
 
-    auth = Keyword.get(opts, :auth, Application.get_env(:supavisor, :metrics_pusher_auth))
+    auth = Keyword.get(opts, :auth, Application.get_env(:supavisor, config_key(scope, :auth)))
 
     interval =
       Keyword.get(
         opts,
         :interval,
-        Application.get_env(:supavisor, :metrics_pusher_interval_ms, :timer.seconds(30))
+        Application.get_env(:supavisor, config_key(scope, :interval_ms), :timer.seconds(30))
       )
 
     timeout =
       Keyword.get(
         opts,
         :timeout,
-        Application.get_env(:supavisor, :metrics_pusher_timeout_ms, :timer.seconds(15))
+        Application.get_env(:supavisor, config_key(scope, :timeout_ms), :timer.seconds(15))
       )
 
     compress =
       Keyword.get(
         opts,
         :compress,
-        Application.get_env(:supavisor, :metrics_pusher_compress, true)
+        Application.get_env(:supavisor, config_key(scope, :compress), true)
       )
 
     extra_labels =
       Keyword.get(
         opts,
         :extra_labels,
-        Application.get_env(:supavisor, :metrics_pusher_extra_labels, [])
+        Application.get_env(:supavisor, config_key(scope, :extra_labels), [])
       )
 
     params = Enum.map(extra_labels, fn {k, v} -> {:extra_label, "#{k}=#{v}"} end)
 
     Logger.info(
-      "Starting MetricsPusher (url: #{url}, interval: #{interval}ms, compress: #{compress})"
+      "Starting MetricsPusher (scope: #{scope}, url: #{url}, interval: #{interval}ms, compress: #{compress})"
     )
 
     headers = [{"content-type", "text/plain"}]
@@ -90,9 +106,10 @@ defmodule Supavisor.MetricsPusher do
         params: params
       ]
       |> Keyword.merge(basic_auth)
-      |> Keyword.merge(Application.get_env(:supavisor, :metrics_pusher_req_options, []))
+      |> Keyword.merge(Application.get_env(:supavisor, config_key(scope, :req_options), []))
 
     state = %__MODULE__{
+      scope: scope,
       push_ref: schedule_push(interval),
       interval: interval,
       req_options: req_options
@@ -103,7 +120,8 @@ defmodule Supavisor.MetricsPusher do
 
   @impl true
   def handle_info(:push, state) do
-    {exec_time, _} = :timer.tc(fn -> push(state.req_options) end, :millisecond)
+    {exec_time, _} =
+      :timer.tc(fn -> push(state.scope, state.req_options) end, :millisecond)
 
     if exec_time > :timer.seconds(5) do
       Logger.warning("Metrics push took: #{exec_time} ms")
@@ -120,18 +138,21 @@ defmodule Supavisor.MetricsPusher do
 
   defp schedule_push(delay), do: Process.send_after(self(), :push, delay)
 
-  # Unlike realtime, which keeps separate global and per-tenant PromEx trees,
-  # supavisor keeps every plugin (Application, Beam, Ecto, OsMon, NetStat,
-  # Tenant, Cluster) in a single collector. PromEx.get_metrics/0 is this node's
-  # own local export (no cross-node RPC fan-out) and already includes any
-  # tenant-tagged series for tenants attached to this node, so one push per
-  # tick is enough. Each node pushing only its own metrics (tagged with its
-  # node identity via global_tags) avoids the O(n^2) RPC fan-out that
+  @spec config_key(scope(), atom()) :: atom()
+  defp config_key(:global, suffix), do: :"metrics_pusher_#{suffix}"
+  defp config_key(:tenant, suffix), do: :"tenant_metrics_pusher_#{suffix}"
+
+  # PromEx.get_metrics/1 is this node's own local export (no cross-node RPC
+  # fan-out), filtered down to just this pusher's scope (tenant-tagged series,
+  # or everything else). Each node pushing only its own metrics (tagged with
+  # its node identity via global_tags) avoids the O(n^2) RPC fan-out that
   # PromEx.get_cluster_metrics/0 would cause if every node in the cluster
   # pushed on its own interval.
-  defp push(req_options) do
+  defp push(scope, req_options) do
     task =
-      Task.Supervisor.async_nolink(Supavisor.TaskSupervisor, fn -> push_metrics(req_options) end)
+      Task.Supervisor.async_nolink(Supavisor.TaskSupervisor, fn ->
+        push_metrics(scope, req_options)
+      end)
 
     case Task.yield(task, :timer.minutes(1)) do
       nil ->
@@ -146,8 +167,8 @@ defmodule Supavisor.MetricsPusher do
     end
   end
 
-  defp push_metrics(req_options) do
-    case send_metrics(req_options, PromEx.get_metrics()) do
+  defp push_metrics(scope, req_options) do
+    case send_metrics(req_options, PromEx.get_metrics(scope)) do
       :ok ->
         :ok
 

--- a/lib/supavisor/metrics_pusher.ex
+++ b/lib/supavisor/metrics_pusher.ex
@@ -1,0 +1,177 @@
+defmodule Supavisor.MetricsPusher do
+  @moduledoc """
+  GenServer that periodically pushes Prometheus metrics to an endpoint.
+
+  Only starts if `url` is configured.
+  Pushes metrics every 30 seconds (configurable) to the configured URL endpoint.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Supavisor.Monitoring.PromEx
+
+  @type t :: %__MODULE__{
+          push_ref: reference() | nil,
+          interval: pos_integer() | nil,
+          req_options: keyword() | nil
+        }
+
+  defstruct [:push_ref, :interval, :req_options]
+
+  @spec start_link(keyword()) :: {:ok, pid()} | :ignore
+  def start_link(opts) do
+    url = Keyword.get(opts, :url, Application.get_env(:supavisor, :metrics_pusher_url))
+
+    if is_binary(url) do
+      GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    else
+      Logger.warning("MetricsPusher not started: url must be configured")
+
+      :ignore
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    url = Keyword.get(opts, :url, Application.get_env(:supavisor, :metrics_pusher_url))
+
+    user =
+      Keyword.get(opts, :user, Application.get_env(:supavisor, :metrics_pusher_user, "supavisor"))
+
+    auth = Keyword.get(opts, :auth, Application.get_env(:supavisor, :metrics_pusher_auth))
+
+    interval =
+      Keyword.get(
+        opts,
+        :interval,
+        Application.get_env(:supavisor, :metrics_pusher_interval_ms, :timer.seconds(30))
+      )
+
+    timeout =
+      Keyword.get(
+        opts,
+        :timeout,
+        Application.get_env(:supavisor, :metrics_pusher_timeout_ms, :timer.seconds(15))
+      )
+
+    compress =
+      Keyword.get(
+        opts,
+        :compress,
+        Application.get_env(:supavisor, :metrics_pusher_compress, true)
+      )
+
+    extra_labels =
+      Keyword.get(
+        opts,
+        :extra_labels,
+        Application.get_env(:supavisor, :metrics_pusher_extra_labels, [])
+      )
+
+    params = Enum.map(extra_labels, fn {k, v} -> {:extra_label, "#{k}=#{v}"} end)
+
+    Logger.info(
+      "Starting MetricsPusher (url: #{url}, interval: #{interval}ms, compress: #{compress})"
+    )
+
+    headers = [{"content-type", "text/plain"}]
+
+    basic_auth = if auth, do: [auth: {:basic, "#{user}:#{auth}"}], else: []
+
+    req_options =
+      [
+        method: :post,
+        url: url,
+        headers: headers,
+        compress_body: compress,
+        receive_timeout: timeout,
+        params: params
+      ]
+      |> Keyword.merge(basic_auth)
+      |> Keyword.merge(Application.get_env(:supavisor, :metrics_pusher_req_options, []))
+
+    state = %__MODULE__{
+      push_ref: schedule_push(interval),
+      interval: interval,
+      req_options: req_options
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:push, state) do
+    {exec_time, _} = :timer.tc(fn -> push(state.req_options) end, :millisecond)
+
+    if exec_time > :timer.seconds(5) do
+      Logger.warning("Metrics push took: #{exec_time} ms")
+    end
+
+    {:noreply, %{state | push_ref: schedule_push(state.interval)}}
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    Logger.error("MetricsPusher received unexpected message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
+  defp schedule_push(delay), do: Process.send_after(self(), :push, delay)
+
+  # Unlike realtime, which keeps separate global and per-tenant PromEx trees,
+  # supavisor keeps every plugin (Application, Beam, Ecto, OsMon, NetStat,
+  # Tenant, Cluster) in a single collector. PromEx.get_metrics/0 is this node's
+  # own local export (no cross-node RPC fan-out) and already includes any
+  # tenant-tagged series for tenants attached to this node, so one push per
+  # tick is enough. Each node pushing only its own metrics (tagged with its
+  # node identity via global_tags) avoids the O(n^2) RPC fan-out that
+  # PromEx.get_cluster_metrics/0 would cause if every node in the cluster
+  # pushed on its own interval.
+  defp push(req_options) do
+    task =
+      Task.Supervisor.async_nolink(Supavisor.TaskSupervisor, fn -> push_metrics(req_options) end)
+
+    case Task.yield(task, :timer.minutes(1)) do
+      nil ->
+        Task.shutdown(task, :brutal_kill)
+        Logger.error("MetricsPusher: Task timed out: #{inspect(task)}")
+
+      {:exit, reason} ->
+        Logger.error("MetricsPusher: Task exited with reason: #{inspect(reason)}")
+
+      {:ok, _} ->
+        :ok
+    end
+  end
+
+  defp push_metrics(req_options) do
+    case send_metrics(req_options, PromEx.get_metrics()) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "MetricsPusher: Failed to push metrics to #{req_options[:url]}: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  rescue
+    error ->
+      Logger.error("MetricsPusher: Exception during push: #{inspect(error)}")
+      :ok
+  end
+
+  defp send_metrics(req_options, metrics) do
+    [{:body, metrics} | req_options] |> Req.request() |> handle_response()
+  end
+
+  defp handle_response({:ok, %{status: status}}) when status in 200..299, do: :ok
+
+  defp handle_response({:ok, %{status: status} = response}),
+    do: {:error, {:http_error, status, response.body}}
+
+  defp handle_response({:error, reason}), do: {:error, reason}
+end

--- a/lib/supavisor/metrics_pusher.ex
+++ b/lib/supavisor/metrics_pusher.ex
@@ -139,8 +139,23 @@ defmodule Supavisor.MetricsPusher do
   defp schedule_push(delay), do: Process.send_after(self(), :push, delay)
 
   @spec config_key(scope(), atom()) :: atom()
-  defp config_key(:global, suffix), do: :"metrics_pusher_#{suffix}"
-  defp config_key(:tenant, suffix), do: :"tenant_metrics_pusher_#{suffix}"
+  defp config_key(:global, :url), do: :metrics_pusher_url
+  defp config_key(:global, :user), do: :metrics_pusher_user
+  defp config_key(:global, :auth), do: :metrics_pusher_auth
+  defp config_key(:global, :interval_ms), do: :metrics_pusher_interval_ms
+  defp config_key(:global, :timeout_ms), do: :metrics_pusher_timeout_ms
+  defp config_key(:global, :compress), do: :metrics_pusher_compress
+  defp config_key(:global, :extra_labels), do: :metrics_pusher_extra_labels
+  defp config_key(:global, :req_options), do: :metrics_pusher_req_options
+
+  defp config_key(:tenant, :url), do: :tenant_metrics_pusher_url
+  defp config_key(:tenant, :user), do: :tenant_metrics_pusher_user
+  defp config_key(:tenant, :auth), do: :tenant_metrics_pusher_auth
+  defp config_key(:tenant, :interval_ms), do: :tenant_metrics_pusher_interval_ms
+  defp config_key(:tenant, :timeout_ms), do: :tenant_metrics_pusher_timeout_ms
+  defp config_key(:tenant, :compress), do: :tenant_metrics_pusher_compress
+  defp config_key(:tenant, :extra_labels), do: :tenant_metrics_pusher_extra_labels
+  defp config_key(:tenant, :req_options), do: :tenant_metrics_pusher_req_options
 
   # PromEx.get_metrics/1 is this node's own local export (no cross-node RPC
   # fan-out), filtered down to just this pusher's scope (tenant-tagged series,

--- a/lib/supavisor/monitoring/prom_ex.ex
+++ b/lib/supavisor/monitoring/prom_ex.ex
@@ -75,10 +75,36 @@ defmodule Supavisor.Monitoring.PromEx do
   end
 
   @spec get_metrics() :: iodata()
-  def get_metrics do
-    fetch_metrics()
+  def get_metrics, do: get_metrics(:all)
+
+  @spec get_metrics(:tenant | :global | :all) :: iodata()
+  def get_metrics(scope) when scope in [:tenant, :global, :all] do
+    {reverse_tags_tid, cache_tid, global_tags, metrics} = fetch_metrics()
+
+    scoped_metrics =
+      case scope do
+        :all -> metrics
+        :tenant -> partition_metrics(metrics) |> elem(0)
+        :global -> partition_metrics(metrics) |> elem(1)
+      end
+
+    {reverse_tags_tid, cache_tid, global_tags, scoped_metrics}
     |> PrometheusCached.export()
   end
+
+  @doc """
+  Splits a metrics map (the 4th element returned by `fetch_metrics/0`) into
+  `{tenant_metrics, global_metrics}` based on whether each metric is tagged
+  with `:tenant`.
+  """
+  @spec partition_metrics(map()) :: {map(), map()}
+  def partition_metrics(metrics) do
+    {tenant, global} = Enum.split_with(metrics, fn {metric, _} -> tenant_metric?(metric) end)
+    {Map.new(tenant), Map.new(global)}
+  end
+
+  @spec tenant_metric?(Metrics.t()) :: boolean()
+  def tenant_metric?(metric), do: :tenant in metric.tags
 
   @spec get_cluster_metrics() :: iodata()
   def get_cluster_metrics do

--- a/test/supavisor/application_test.exs
+++ b/test/supavisor/application_test.exs
@@ -1,0 +1,53 @@
+defmodule Supavisor.ApplicationTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    original_global = Application.get_env(:supavisor, :metrics_pusher_enabled)
+    original_tenant = Application.get_env(:supavisor, :tenant_metrics_pusher_enabled)
+
+    on_exit(fn ->
+      Application.put_env(:supavisor, :metrics_pusher_enabled, original_global)
+      Application.put_env(:supavisor, :tenant_metrics_pusher_enabled, original_tenant)
+    end)
+
+    :ok
+  end
+
+  describe "metrics_pusher_children/0" do
+    test "returns no children when both scopes are disabled" do
+      Application.put_env(:supavisor, :metrics_pusher_enabled, false)
+      Application.put_env(:supavisor, :tenant_metrics_pusher_enabled, false)
+
+      assert Supavisor.Application.metrics_pusher_children() == []
+    end
+
+    test "returns only the global child when only the global scope is enabled" do
+      Application.put_env(:supavisor, :metrics_pusher_enabled, true)
+      Application.put_env(:supavisor, :tenant_metrics_pusher_enabled, false)
+
+      assert [%{id: Supavisor.MetricsPusher.Global}] =
+               Supavisor.Application.metrics_pusher_children()
+    end
+
+    test "returns only the tenant child when only the tenant scope is enabled" do
+      Application.put_env(:supavisor, :metrics_pusher_enabled, false)
+      Application.put_env(:supavisor, :tenant_metrics_pusher_enabled, true)
+
+      assert [%{id: Supavisor.MetricsPusher.Tenant}] =
+               Supavisor.Application.metrics_pusher_children()
+    end
+
+    test "returns both children with distinct ids when both scopes are enabled" do
+      Application.put_env(:supavisor, :metrics_pusher_enabled, true)
+      Application.put_env(:supavisor, :tenant_metrics_pusher_enabled, true)
+
+      children = Supavisor.Application.metrics_pusher_children()
+      ids = Enum.map(children, & &1.id)
+
+      assert length(children) == 2
+
+      assert Enum.sort(ids) ==
+               Enum.sort([Supavisor.MetricsPusher.Global, Supavisor.MetricsPusher.Tenant])
+    end
+  end
+end

--- a/test/supavisor/metrics_pusher_test.exs
+++ b/test/supavisor/metrics_pusher_test.exs
@@ -56,13 +56,14 @@ defmodule Supavisor.MetricsPusherTest do
                  "Basic #{Base.encode64("supavisor:hunter2")}"
                ]
 
-        assert Conn.get_req_header(conn, "content-encoding") == ["gzip"]
         assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
 
+        # Req.Test's plug adapter transparently decompresses gzip'd request
+        # bodies (and strips content-encoding) before the plug sees them, so
+        # the body here is already plaintext regardless of `compress: true`.
         {:ok, body, conn} = Conn.read_body(conn)
-        decompressed_body = :zlib.gunzip(body)
 
-        send(parent, {:req_called, decompressed_body})
+        send(parent, {:req_called, body})
         Req.Test.text(conn, "")
       end)
 

--- a/test/supavisor/metrics_pusher_test.exs
+++ b/test/supavisor/metrics_pusher_test.exs
@@ -1,0 +1,224 @@
+defmodule Supavisor.MetricsPusherTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  require Supavisor
+
+  alias Plug.Conn
+  alias Supavisor.MetricsPusher
+  alias Supavisor.Monitoring.Telem
+
+  setup {Req.Test, :verify_on_exit!}
+
+  # Helper function to start MetricsPusher and allow it to use Req.Test
+  defp start_and_allow_pusher(opts) do
+    opts = Keyword.put(opts, :interval, :timer.minutes(5))
+    pid = start_supervised!({MetricsPusher, opts})
+    Req.Test.allow(MetricsPusher, self(), pid)
+    send(pid, :push)
+    {:ok, pid}
+  end
+
+  describe "start_link/1" do
+    test "does not start when URL is missing" do
+      opts = [enabled: true]
+      assert :ignore = MetricsPusher.start_link(opts)
+    end
+
+    test "sends request successfully" do
+      opts = [
+        url: "https://example.com:8428/api/v1/import/prometheus",
+        user: "supavisor",
+        auth: "hunter2",
+        compress: true,
+        timeout: 5000
+      ]
+
+      tenant = "metrics_pusher_test_tenant"
+
+      Telem.client_join(
+        :ok,
+        Supavisor.id(type: :single, tenant: tenant, user: "u", mode: :session, db: "db")
+      )
+
+      parent = self()
+
+      # A single request carrying this node's local metrics: both node-wide
+      # (beam/OS-level) and tenant-tagged series live in the same collector.
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        assert conn.method == "POST"
+        assert conn.scheme == :https
+        assert conn.host == "example.com"
+        assert conn.port == 8428
+        assert conn.request_path == "/api/v1/import/prometheus"
+
+        assert Conn.get_req_header(conn, "authorization") == [
+                 "Basic #{Base.encode64("supavisor:hunter2")}"
+               ]
+
+        assert Conn.get_req_header(conn, "content-encoding") == ["gzip"]
+        assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
+
+        {:ok, body, conn} = Conn.read_body(conn)
+        decompressed_body = :zlib.gunzip(body)
+
+        send(parent, {:req_called, decompressed_body})
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+
+      assert_receive {:req_called, body}, 300
+
+      assert body =~ "beam_stats_run_queue_count"
+      assert body =~ "supavisor_client_joins_ok"
+      assert body =~ ~s(tenant="#{tenant}")
+    end
+
+    test "sends request successfully without auth header" do
+      opts = [
+        url: "http://localhost:8428/api/v1/import/prometheus",
+        compress: true,
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        assert Conn.get_req_header(conn, "authorization") == []
+
+        send(parent, :req_called)
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+      assert_receive :req_called, 300
+    end
+
+    test "sends request body untouched when compress=false" do
+      opts = [
+        url: "http://localhost:8428/api/v1/import/prometheus",
+        user: "hunter2",
+        auth: "supavisor",
+        compress: false,
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        assert Conn.get_req_header(conn, "content-encoding") == []
+        assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
+
+        send(parent, :req_called)
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+      assert_receive :req_called, 300
+    end
+
+    test "when request receives non 2XX response" do
+      opts = [
+        url: "https://example.com:8428/api/v1/import/prometheus",
+        auth: "hunter2",
+        compress: true,
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      log =
+        capture_log(fn ->
+          Req.Test.expect(MetricsPusher, 1, fn conn ->
+            send(parent, :req_called)
+            Conn.send_resp(conn, 500, "")
+          end)
+
+          {:ok, pid} = start_and_allow_pusher(opts)
+          assert_receive :req_called, 300
+          assert Process.alive?(pid)
+          # Wait enough for the log to be captured
+          Process.sleep(100)
+        end)
+
+      assert log =~ "MetricsPusher: Failed to push"
+      assert log =~ "metrics to"
+    end
+
+    test "when an error is raised" do
+      opts = [
+        url: "https://example.com:8428/api/v1/import/prometheus",
+        timeout: 5000
+      ]
+
+      parent = self()
+
+      log =
+        capture_log(fn ->
+          Req.Test.expect(MetricsPusher, 1, fn _conn ->
+            send(parent, :req_called)
+            raise RuntimeError, "unexpected error"
+          end)
+
+          {:ok, pid} = start_and_allow_pusher(opts)
+          assert_receive :req_called, 300
+          assert Process.alive?(pid)
+          # Wait enough for the log to be captured
+          Process.sleep(100)
+        end)
+
+      assert log =~ "MetricsPusher: Exception during"
+      assert log =~ "push: %RuntimeError{message: \"unexpected error\"}"
+    end
+
+    test "appends extra_label query params to URL" do
+      opts = [
+        url: "http://localhost:8428/api/v1/import/prometheus",
+        compress: false,
+        timeout: 5000,
+        extra_labels: [{"region", "us-east-1"}, {"env", "prod"}]
+      ]
+
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        send(parent, {:req_called, conn.query_string})
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+      assert_receive {:req_called, query_string}, 300
+
+      decoded_params = query_string |> String.split("&") |> Enum.map(&URI.decode_www_form/1)
+      assert "extra_label=region=us-east-1" in decoded_params
+      assert "extra_label=env=prod" in decoded_params
+    end
+
+    test "logs unexpected messages and stays alive" do
+      parent = self()
+
+      Req.Test.expect(MetricsPusher, 1, fn conn ->
+        send(parent, :push_happened)
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, pid} =
+        start_and_allow_pusher(
+          url: "http://localhost:8428/api/v1/import/prometheus",
+          timeout: 5000
+        )
+
+      assert_receive :push_happened, 500
+
+      log =
+        capture_log(fn ->
+          send(pid, :unexpected_message)
+          Process.sleep(50)
+          assert Process.alive?(pid)
+        end)
+
+      assert log =~ "MetricsPusher received unexpected message: :unexpected_message"
+    end
+  end
+end

--- a/test/supavisor/metrics_pusher_test.exs
+++ b/test/supavisor/metrics_pusher_test.exs
@@ -10,6 +10,13 @@ defmodule Supavisor.MetricsPusherTest do
 
   setup {Req.Test, :verify_on_exit!}
 
+  # Req.Test's plug adapter decompresses gzip'd request bodies (and strips
+  # content-encoding) before the plug sees them on newer Req versions, but
+  # not on the Req pinned here — so handle both to keep the assertions
+  # independent of that internal behavior.
+  defp maybe_gunzip(<<0x1F, 0x8B, _::binary>> = body), do: :zlib.gunzip(body)
+  defp maybe_gunzip(body), do: body
+
   # Helper function to start MetricsPusher and allow it to use Req.Test.
   # Defaults to the :global scope so existing scope-agnostic tests (HTTP
   # mechanics: auth, compression, error handling, extra_labels) don't need
@@ -73,10 +80,8 @@ defmodule Supavisor.MetricsPusherTest do
 
         assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
 
-        # Req.Test's plug adapter transparently decompresses gzip'd request
-        # bodies (and strips content-encoding) before the plug sees them, so
-        # the body here is already plaintext regardless of `compress: true`.
         {:ok, body, conn} = Conn.read_body(conn)
+        body = maybe_gunzip(body)
 
         send(parent, {:req_called, body})
         Req.Test.text(conn, "")
@@ -259,6 +264,7 @@ defmodule Supavisor.MetricsPusherTest do
 
       Req.Test.expect(Supavisor.MetricsPusher.Tenant, 1, fn conn ->
         {:ok, body, conn} = Conn.read_body(conn)
+        body = maybe_gunzip(body)
         send(parent, {:req_called, body})
         Req.Test.text(conn, "")
       end)

--- a/test/supavisor/metrics_pusher_test.exs
+++ b/test/supavisor/metrics_pusher_test.exs
@@ -10,19 +10,33 @@ defmodule Supavisor.MetricsPusherTest do
 
   setup {Req.Test, :verify_on_exit!}
 
-  # Helper function to start MetricsPusher and allow it to use Req.Test
+  # Helper function to start MetricsPusher and allow it to use Req.Test.
+  # Defaults to the :global scope so existing scope-agnostic tests (HTTP
+  # mechanics: auth, compression, error handling, extra_labels) don't need
+  # to change.
   defp start_and_allow_pusher(opts) do
-    opts = Keyword.put(opts, :interval, :timer.minutes(5))
-    pid = start_supervised!({MetricsPusher, opts})
-    Req.Test.allow(MetricsPusher, self(), pid)
+    opts =
+      opts
+      |> Keyword.put_new(:scope, :global)
+      |> Keyword.put_new(:name, Supavisor.MetricsPusher.Global)
+      |> Keyword.put(:interval, :timer.minutes(5))
+
+    name = Keyword.fetch!(opts, :name)
+    pid = start_supervised!(Supervisor.child_spec({MetricsPusher, opts}, id: name))
+    Req.Test.allow(name, self(), pid)
     send(pid, :push)
     {:ok, pid}
   end
 
   describe "start_link/1" do
     test "does not start when URL is missing" do
-      opts = [enabled: true]
+      opts = [scope: :global, enabled: true]
       assert :ignore = MetricsPusher.start_link(opts)
+    end
+
+    test "raises when :scope is omitted" do
+      opts = [url: "https://example.com:8428/api/v1/import/prometheus"]
+      assert_raise KeyError, fn -> MetricsPusher.start_link(opts) end
     end
 
     test "sends request successfully" do
@@ -43,9 +57,10 @@ defmodule Supavisor.MetricsPusherTest do
 
       parent = self()
 
-      # A single request carrying this node's local metrics: both node-wide
-      # (beam/OS-level) and tenant-tagged series live in the same collector.
-      Req.Test.expect(MetricsPusher, 1, fn conn ->
+      # The :global scope carries this node's node-wide (beam/OS-level)
+      # metrics, but excludes tenant-tagged series — those go through the
+      # separate :tenant-scoped pusher instead.
+      Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn conn ->
         assert conn.method == "POST"
         assert conn.scheme == :https
         assert conn.host == "example.com"
@@ -72,8 +87,8 @@ defmodule Supavisor.MetricsPusherTest do
       assert_receive {:req_called, body}, 300
 
       assert body =~ "beam_stats_run_queue_count"
-      assert body =~ "supavisor_client_joins_ok"
-      assert body =~ ~s(tenant="#{tenant}")
+      refute body =~ "supavisor_client_joins_ok"
+      refute body =~ ~s(tenant="#{tenant}")
     end
 
     test "sends request successfully without auth header" do
@@ -85,7 +100,7 @@ defmodule Supavisor.MetricsPusherTest do
 
       parent = self()
 
-      Req.Test.expect(MetricsPusher, 1, fn conn ->
+      Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn conn ->
         assert Conn.get_req_header(conn, "authorization") == []
 
         send(parent, :req_called)
@@ -107,7 +122,7 @@ defmodule Supavisor.MetricsPusherTest do
 
       parent = self()
 
-      Req.Test.expect(MetricsPusher, 1, fn conn ->
+      Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn conn ->
         assert Conn.get_req_header(conn, "content-encoding") == []
         assert Conn.get_req_header(conn, "content-type") == ["text/plain"]
 
@@ -131,7 +146,7 @@ defmodule Supavisor.MetricsPusherTest do
 
       log =
         capture_log(fn ->
-          Req.Test.expect(MetricsPusher, 1, fn conn ->
+          Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn conn ->
             send(parent, :req_called)
             Conn.send_resp(conn, 500, "")
           end)
@@ -157,7 +172,7 @@ defmodule Supavisor.MetricsPusherTest do
 
       log =
         capture_log(fn ->
-          Req.Test.expect(MetricsPusher, 1, fn _conn ->
+          Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn _conn ->
             send(parent, :req_called)
             raise RuntimeError, "unexpected error"
           end)
@@ -183,7 +198,7 @@ defmodule Supavisor.MetricsPusherTest do
 
       parent = self()
 
-      Req.Test.expect(MetricsPusher, 1, fn conn ->
+      Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn conn ->
         send(parent, {:req_called, conn.query_string})
         Req.Test.text(conn, "")
       end)
@@ -199,7 +214,7 @@ defmodule Supavisor.MetricsPusherTest do
     test "logs unexpected messages and stays alive" do
       parent = self()
 
-      Req.Test.expect(MetricsPusher, 1, fn conn ->
+      Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn conn ->
         send(parent, :push_happened)
         Req.Test.text(conn, "")
       end)
@@ -220,6 +235,76 @@ defmodule Supavisor.MetricsPusherTest do
         end)
 
       assert log =~ "MetricsPusher received unexpected message: :unexpected_message"
+    end
+  end
+
+  describe "start_link/1 with :tenant scope" do
+    test "pushes only tenant-tagged metrics" do
+      opts = [
+        scope: :tenant,
+        name: Supavisor.MetricsPusher.Tenant,
+        url: "https://example.com:8428/api/v1/import/prometheus",
+        compress: true,
+        timeout: 5000
+      ]
+
+      tenant = "metrics_pusher_test_tenant"
+
+      Telem.client_join(
+        :ok,
+        Supavisor.id(type: :single, tenant: tenant, user: "u", mode: :session, db: "db")
+      )
+
+      parent = self()
+
+      Req.Test.expect(Supavisor.MetricsPusher.Tenant, 1, fn conn ->
+        {:ok, body, conn} = Conn.read_body(conn)
+        send(parent, {:req_called, body})
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _pid} = start_and_allow_pusher(opts)
+
+      assert_receive {:req_called, body}, 300
+
+      assert body =~ "supavisor_client_joins_ok"
+      assert body =~ ~s(tenant="#{tenant}")
+      refute body =~ "beam_stats_run_queue_count"
+    end
+  end
+
+  describe "running both scopes concurrently" do
+    test "each scope's pusher only receives its own traffic" do
+      parent = self()
+
+      Req.Test.expect(Supavisor.MetricsPusher.Global, 1, fn conn ->
+        send(parent, :global_called)
+        Req.Test.text(conn, "")
+      end)
+
+      Req.Test.expect(Supavisor.MetricsPusher.Tenant, 1, fn conn ->
+        send(parent, :tenant_called)
+        Req.Test.text(conn, "")
+      end)
+
+      {:ok, _global_pid} =
+        start_and_allow_pusher(
+          scope: :global,
+          name: Supavisor.MetricsPusher.Global,
+          url: "http://localhost:8428/api/v1/import/prometheus",
+          timeout: 5000
+        )
+
+      {:ok, _tenant_pid} =
+        start_and_allow_pusher(
+          scope: :tenant,
+          name: Supavisor.MetricsPusher.Tenant,
+          url: "http://localhost:8429/api/v1/import/prometheus",
+          timeout: 5000
+        )
+
+      assert_receive :global_called, 300
+      assert_receive :tenant_called, 300
     end
   end
 end

--- a/test/supavisor/monitoring/prom_ex_test.exs
+++ b/test/supavisor/monitoring/prom_ex_test.exs
@@ -6,6 +6,28 @@ defmodule Supavisor.Monitoring.PromExTest do
 
   @subject Supavisor.Monitoring.PromEx
 
+  describe "tenant_metric?/1" do
+    test "classifies by tag presence, not by which plugin module defined the metric" do
+      tenant_tagged = %Telemetry.Metrics.Counter{
+        name: [:supavisor, :some, :metric],
+        event_name: [:supavisor, :some, :metric],
+        tags: [:tenant, :user]
+      }
+
+      # Mirrors Supavisor.PromEx.Plugins.Tenant.concurrent_tenants/1's
+      # `[:supavisor, :tenants, :active]` last_value: defined inside the
+      # Tenant plugin module, but not tagged per-tenant.
+      tagless_metric_in_tenant_module = %Telemetry.Metrics.LastValue{
+        name: [:supavisor, :tenants, :active],
+        event_name: [:supavisor, :tenants],
+        tags: []
+      }
+
+      assert @subject.tenant_metric?(tenant_tagged)
+      refute @subject.tenant_metric?(tagless_metric_in_tenant_module)
+    end
+  end
+
   describe "get_metrics/1" do
     @sources %{
       {:darwin, :aarch64} => {
@@ -109,6 +131,61 @@ defmodule Supavisor.Monitoring.PromExTest do
                  Enum.find(measurements, &(&1["name"] == "supavisor_client_joins_ok"))
 
         assert Enum.find(metrics, &(&1["labels"]["db_name"] == db_name))
+      end
+    end
+
+    @tag :tmp_dir
+    test "get_metrics(:tenant) includes tenant-tagged LastValue metrics but excludes global ones",
+         %{tmp_dir: dir, prom2json: exe} do
+      tenant = "prom_ex_split_test_tenant_1"
+
+      Supavisor.PromEx.Plugins.Tenant.emit_telemetry_for_tenant(
+        Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
+        1,
+        ""
+      )
+
+      Supavisor.PromEx.Plugins.Cluster.emit_cluster_size()
+
+      metrics = @subject.get_metrics(:tenant)
+      file = Path.join(dir, "prom.out")
+      File.write!(file, metrics)
+
+      assert {out, 0} = System.cmd(exe, [file])
+      assert {:ok, measurements} = JSON.decode(out)
+
+      assert %{"metrics" => series} =
+               Enum.find(measurements, &(&1["name"] == "supavisor_connections_active"))
+
+      assert Enum.find(series, &(&1["labels"]["tenant"] == tenant))
+      refute Enum.find(measurements, &(&1["name"] == "supavisor_prom_ex_cluster_size"))
+    end
+
+    @tag :tmp_dir
+    test "get_metrics(:global) includes global LastValue metrics but excludes tenant-tagged ones",
+         %{tmp_dir: dir, prom2json: exe} do
+      tenant = "prom_ex_split_test_tenant_2"
+
+      Supavisor.PromEx.Plugins.Tenant.emit_telemetry_for_tenant(
+        Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
+        1,
+        ""
+      )
+
+      Supavisor.PromEx.Plugins.Cluster.emit_cluster_size()
+
+      metrics = @subject.get_metrics(:global)
+      file = Path.join(dir, "prom.out")
+      File.write!(file, metrics)
+
+      assert {out, 0} = System.cmd(exe, [file])
+      assert {:ok, measurements} = JSON.decode(out)
+
+      assert Enum.find(measurements, &(&1["name"] == "supavisor_prom_ex_cluster_size"))
+
+      case Enum.find(measurements, &(&1["name"] == "supavisor_connections_active")) do
+        nil -> :ok
+        %{"metrics" => series} -> refute Enum.find(series, &(&1["labels"]["tenant"] == tenant))
       end
     end
   end

--- a/test/supavisor/monitoring/prom_ex_test.exs
+++ b/test/supavisor/monitoring/prom_ex_test.exs
@@ -140,9 +140,8 @@ defmodule Supavisor.Monitoring.PromExTest do
       tenant = "prom_ex_split_test_tenant_1"
 
       Supavisor.PromEx.Plugins.Tenant.emit_telemetry_for_tenant(
-        Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
-        1,
-        ""
+        {Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
+         1}
       )
 
       Supavisor.PromEx.Plugins.Cluster.emit_cluster_size()
@@ -167,9 +166,8 @@ defmodule Supavisor.Monitoring.PromExTest do
       tenant = "prom_ex_split_test_tenant_2"
 
       Supavisor.PromEx.Plugins.Tenant.emit_telemetry_for_tenant(
-        Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
-        1,
-        ""
+        {Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
+         1}
       )
 
       Supavisor.PromEx.Plugins.Cluster.emit_cluster_size()

--- a/test/supavisor/monitoring/prom_ex_test.exs
+++ b/test/supavisor/monitoring/prom_ex_test.exs
@@ -4,6 +4,8 @@ defmodule Supavisor.Monitoring.PromExTest do
 
   require Supavisor
 
+  alias Supavisor.PromEx.Plugins.{Cluster, Tenant}
+
   @subject Supavisor.Monitoring.PromEx
 
   describe "tenant_metric?/1" do
@@ -139,12 +141,12 @@ defmodule Supavisor.Monitoring.PromExTest do
          %{tmp_dir: dir, prom2json: exe} do
       tenant = "prom_ex_split_test_tenant_1"
 
-      Supavisor.PromEx.Plugins.Tenant.emit_telemetry_for_tenant(
+      Tenant.emit_telemetry_for_tenant(
         {Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
          1}
       )
 
-      Supavisor.PromEx.Plugins.Cluster.emit_cluster_size()
+      Cluster.emit_cluster_size()
 
       metrics = @subject.get_metrics(:tenant)
       file = Path.join(dir, "prom.out")
@@ -165,12 +167,12 @@ defmodule Supavisor.Monitoring.PromExTest do
          %{tmp_dir: dir, prom2json: exe} do
       tenant = "prom_ex_split_test_tenant_2"
 
-      Supavisor.PromEx.Plugins.Tenant.emit_telemetry_for_tenant(
+      Tenant.emit_telemetry_for_tenant(
         {Supavisor.id(type: :single, tenant: tenant, user: "user", mode: :session, db: "db_name"),
          1}
       )
 
-      Supavisor.PromEx.Plugins.Cluster.emit_cluster_size()
+      Cluster.emit_cluster_size()
 
       metrics = @subject.get_metrics(:global)
       file = Path.join(dir, "prom.out")


### PR DESCRIPTION
## Summary
- Backports `Supavisor.MetricsPusher` (Prometheus remote-write style push metrics) from `main` to `v2.9`, cherry-picked from #1150 and #1166:
  - `feat: push local metrics to a remote endpoint (Prometheus remote-write style)`
  - `fix: correct gzip assertion in MetricsPusher test`
  - `feat: split tenant metrics from cluster metrics in MetricsPusher`
  - `fix: replace dynamic atom interpolation in config_key/2 with static clauses`
- Adds one fixup commit adapting two tests to v2.9's older dependency/API surface (not needed on `main`):
  - v2.9 pins Req 0.5.8, whose `Req.Test` plug adapter doesn't auto-decompress gzip'd bodies like 0.6.3 does on `main`
  - v2.9's `Tenant.emit_telemetry_for_tenant/1` still takes the older `{id, count}` tuple rather than the 3-arity form on `main` (that signature change landed separately and is out of scope here)

## Test plan
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 600 tests, 0 failures
- [ ] Confirm with observability/whoever owns the nimbus v2.9 release that this is the scope they want before merging