### PR TITLE
fix: replay parse before named statement describe

### DIFF
--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -1083,11 +1083,15 @@ defmodule Supavisor.DbHandler do
   defp take_chunk([], _remaining, acc), do: {:lists.reverse(acc), []}
 
   # If the prepared statement exists for us, it exists for the server, so we just send the
-  # bind to the socket. If it doesn't, we must send the parse pkt first.
+  # packet to the socket. If it doesn't, we must send the parse pkt first.
   #
-  # If we received a bind without a parse, we need to intercept the parse response, otherwise,
-  # the client will receive an unexpected message.
-  defp handle_prepared_statement_pkt({:bind_pkt, stmt_name, pkt, parse_pkt}, {iodata, data}) do
+  # If we replay a parse, we need to intercept the parse response, otherwise the client will
+  # receive an unexpected message.
+  defp handle_prepared_statement_pkt(
+         {packet_type, stmt_name, pkt, parse_pkt},
+         {iodata, data}
+       )
+       when packet_type in [:bind_pkt, :describe_pkt] do
     storage_mod = data.prepared_statements_storage
 
     if storage_mod.member?(data.prepared_statements, stmt_name) do
@@ -1128,10 +1132,6 @@ defmodule Supavisor.DbHandler do
              )
            end)
      }}
-  end
-
-  defp handle_prepared_statement_pkt({:describe_pkt, _stmt_name, pkt}, {iodata, data}) do
-    {[pkt | iodata], data}
   end
 
   # If we stop generating unique id per statement, and instead do deterministic ids,

--- a/lib/supavisor/protocol/debug.ex
+++ b/lib/supavisor/protocol/debug.ex
@@ -21,8 +21,8 @@ defmodule Supavisor.Protocol.Debug do
   @type message_source :: :frontend | :backend
   @type packet :: binary()
   @type structured_packet ::
-          {:parse_pkt | :close_pkt | :describe_pkt, String.t(), packet()}
-          | {:bind_pkt, String.t(), packet(), packet()}
+          {:parse_pkt | :close_pkt, String.t(), packet()}
+          | {:bind_pkt | :describe_pkt, String.t(), packet(), packet()}
   @type debug_input :: packet() | structured_packet() | %{bin: packet()}
   @type format_result :: String.t()
   @type extract_result :: {String.t(), binary()} | nil
@@ -49,7 +49,7 @@ defmodule Supavisor.Protocol.Debug do
       {:close_pkt, stmt_name, _pkt} ->
         format_structured_packet(:close, stmt_name)
 
-      {:describe_pkt, stmt_name, _pkt} ->
+      {:describe_pkt, stmt_name, _pkt, _parse_pkt} ->
         format_structured_packet(:describe, stmt_name)
 
       {:parse_pkt, stmt_name, _pkt} ->

--- a/lib/supavisor/protocol/prepared_statements.ex
+++ b/lib/supavisor/protocol/prepared_statements.ex
@@ -15,9 +15,9 @@ defmodule Supavisor.Protocol.PreparedStatements do
   as each gets mapped to a unique server-side name generated from the statement's hash
   (like "sv_9d8sad98sahzlxkc...").
 
-  Parse statements are cached in storage. When a `Bind` message is processed, the module
-  retrieves and attaches the corresponding `Parse` message, providing the DbHandler with
-  all necessary information to prepare the statement when needed.
+  Parse statements are cached in storage. When a `Bind` or named statement `Describe` message
+  is processed, the module retrieves and attaches the corresponding `Parse` message, providing
+  the DbHandler with all necessary information to prepare the statement when needed.
 
   ## Limits and Safety
 
@@ -40,7 +40,7 @@ defmodule Supavisor.Protocol.PreparedStatements do
           {:parse_pkt, statement_name(), pkt()}
           | {:bind_pkt, statement_name(), bind_pkt :: pkt(), parse_pkt :: pkt()}
           | {:close_pkt, statement_name(), pkt()}
-          | {:describe_pkt, statement_name(), pkt()}
+          | {:describe_pkt, statement_name(), describe_pkt :: pkt(), parse_pkt :: pkt()}
           | pkt()
 
   @backend_limit 200
@@ -186,10 +186,10 @@ defmodule Supavisor.Protocol.PreparedStatements do
 
       {?S, _} ->
         case Storage.get(client_statements, name) do
-          %PreparedStatement{name: server_name} ->
+          %PreparedStatement{name: server_name, parse_pkt: parse_pkt} ->
             new_len = len + (byte_size(server_name) - byte_size(name))
             new_bin = <<?D, new_len::32, ?S, server_name::binary, 0>>
-            {:ok, client_statements, {:describe_pkt, server_name, new_bin}}
+            {:ok, client_statements, {:describe_pkt, server_name, new_bin, parse_pkt}}
 
           nil ->
             {:error, %Supavisor.Errors.PreparedStatementNotFoundError{name: name}}

--- a/test/integration/prepared_statements_test.exs
+++ b/test/integration/prepared_statements_test.exs
@@ -4,6 +4,7 @@ defmodule Supavisor.Integration.PreparedStatementsTest do
   require Logger
 
   alias Supavisor.Protocol.PreparedStatements
+  alias Supavisor.Support.ProtocolClient
 
   @tenant "proxy_tenant_ps_enabled"
 
@@ -166,6 +167,42 @@ defmodule Supavisor.Integration.PreparedStatementsTest do
     assert {:ok, _, _} = Postgrex.execute(c2, q2, ["private"])
   end
 
+  test "describes a named statement after its original backend is checked out" do
+    client = connect_protocol_client()
+    statement_name = "metadata_statement"
+
+    initial_query = [
+      :pgo_protocol.encode_parse_message(statement_name, "SELECT $1::int", []),
+      encode_bind_message(statement_name, "7"),
+      :pgo_protocol.encode_execute_message("", 0),
+      :pgo_protocol.encode_sync_message()
+    ]
+
+    :ok = :gen_tcp.send(client, initial_query)
+    initial_response = recv_until_ready_for_query(client)
+    refute Enum.any?(initial_response, &match?(<<?E, _::binary>>, &1))
+
+    holder = connect_protocol_client()
+    :ok = :gen_tcp.send(holder, :pgo_protocol.encode_query_message("BEGIN"))
+    holder_response = recv_until_ready_for_query(holder)
+    assert Enum.any?(holder_response, &match?(<<?Z, 5::32, ?T>>, &1))
+
+    :ok =
+      :gen_tcp.send(client, [
+        encode_describe_statement_message(statement_name),
+        :pgo_protocol.encode_sync_message()
+      ])
+
+    describe_response = recv_until_ready_for_query(client)
+
+    refute Enum.any?(describe_response, &match?(<<?E, _::binary>>, &1))
+    assert Enum.any?(describe_response, &match?(<<?t, _::binary>>, &1))
+    assert Enum.any?(describe_response, &match?(<<?T, _::binary>>, &1))
+
+    :ok = :gen_tcp.send(holder, :pgo_protocol.encode_query_message("ROLLBACK"))
+    recv_until_ready_for_query(holder)
+  end
+
   test "prepared statements error on simple query protocol", %{conn_opts: conn_opts} do
     expected_message =
       "(EPSSIMPLEQUERY) transaction mode only supports prepared statements using the Extended Query Protocol"
@@ -237,5 +274,50 @@ defmodule Supavisor.Integration.PreparedStatementsTest do
     AND #{i} > 0
     ORDER BY tablename;
     """
+  end
+
+  defp connect_protocol_client do
+    db_conf = Application.get_env(:supavisor, Repo)
+    port = Application.get_env(:supavisor, :proxy_port_transaction)
+    {:ok, sock} = :gen_tcp.connect(~c"127.0.0.1", port, [:binary, active: false])
+
+    ProtocolClient.authenticate(
+      sock,
+      "#{db_conf[:username]}.#{@tenant}",
+      db_conf[:password]
+    )
+
+    sock
+  end
+
+  defp encode_bind_message(statement_name, value) do
+    payload =
+      IO.iodata_to_binary([
+        0,
+        statement_name,
+        0,
+        <<0::16, 1::16, byte_size(value)::32>>,
+        value,
+        <<0::16>>
+      ])
+
+    <<?B, byte_size(payload) + 4::32, payload::binary>>
+  end
+
+  defp encode_describe_statement_message(statement_name) do
+    payload = <<?S, statement_name::binary, 0>>
+    <<?D, byte_size(payload) + 4::32, payload::binary>>
+  end
+
+  defp recv_until_ready_for_query(sock, buffered \\ <<>>, packets \\ []) do
+    {received_packets, rest} = Supavisor.Protocol.split_pkts(buffered)
+    packets = packets ++ received_packets
+
+    if Enum.any?(received_packets, &match?(<<?Z, _::binary>>, &1)) do
+      packets
+    else
+      {:ok, more} = :gen_tcp.recv(sock, 0, 5000)
+      recv_until_ready_for_query(sock, rest <> more, packets)
+    end
   end
 end

--- a/test/supavisor/db_handler_test.exs
+++ b/test/supavisor/db_handler_test.exs
@@ -10,8 +10,11 @@ defmodule Supavisor.DbHandlerTest do
   alias Supavisor.DbHandler, as: Db
   alias Supavisor.Protocol.BackendMessageHandler
   alias Supavisor.Protocol.MessageStreamer
+  alias Supavisor.Protocol.PreparedStatements.BackendStorage
   alias Supavisor.Protocol.Server
 
+  require BackendMessageHandler
+  require MessageStreamer
   require Supavisor
 
   # import Mock
@@ -1160,6 +1163,83 @@ defmodule Supavisor.DbHandlerTest do
                  :setting_application_name,
                  data
                )
+    end
+  end
+
+  describe "handle_event/4 prepared statement packets" do
+    test "replays a missing parse before a named statement describe" do
+      {backend_send, backend_recv} = sockpair()
+      {client_send, client_recv} = sockpair()
+      statement_name = "server_stmt"
+      parse_pkt = <<?P, 27::32, statement_name::binary, 0, "select 1", 0, 0, 0>>
+      describe_pkt = <<?D, 17::32, ?S, statement_name::binary, 0>>
+      from = {self(), make_ref()}
+
+      data =
+        busy_data(%{
+          sock: {:gen_tcp, backend_send},
+          client_sock: {:gen_tcp, client_send},
+          prepared_statements_storage: BackendStorage.LRU,
+          prepared_statements: BackendStorage.LRU.new()
+        })
+
+      assert {:keep_state, new_data, {:reply, ^from, :ok}} =
+               Db.handle_event(
+                 {:call, from},
+                 {:handle_ps_pkts, [{:describe_pkt, statement_name, describe_pkt, parse_pkt}]},
+                 :busy,
+                 data
+               )
+
+      assert {:ok, sent} = :gen_tcp.recv(backend_recv, 0, 1000)
+      assert sent == parse_pkt <> describe_pkt
+
+      assert BackendStorage.LRU.member?(new_data.prepared_statements, statement_name)
+
+      handler_state = MessageStreamer.stream_state(new_data.stream_state, :handler_state)
+
+      assert :queue.to_list(BackendMessageHandler.handler_state(handler_state, :action_queue)) ==
+               [{:intercept, :parse}]
+
+      assert {:keep_state, after_parse} =
+               Db.handle_event(:info, {:tcp, :sock, <<?1, 4::32>>}, :busy, new_data)
+
+      assert {:error, :timeout} = :gen_tcp.recv(client_recv, 0, 50)
+
+      handler_state = MessageStreamer.stream_state(after_parse.stream_state, :handler_state)
+      assert :queue.is_empty(BackendMessageHandler.handler_state(handler_state, :action_queue))
+    end
+
+    test "sends only describe when the named statement exists on the backend" do
+      {backend_send, backend_recv} = sockpair()
+      statement_name = "server_stmt"
+      parse_pkt = <<?P, 27::32, statement_name::binary, 0, "select 1", 0, 0, 0>>
+      describe_pkt = <<?D, 17::32, ?S, statement_name::binary, 0>>
+      from = {self(), make_ref()}
+
+      prepared_statements =
+        BackendStorage.LRU.new()
+        |> BackendStorage.LRU.put(statement_name)
+
+      data =
+        busy_data(%{
+          sock: {:gen_tcp, backend_send},
+          prepared_statements_storage: BackendStorage.LRU,
+          prepared_statements: prepared_statements
+        })
+
+      assert {:keep_state, new_data, {:reply, ^from, :ok}} =
+               Db.handle_event(
+                 {:call, from},
+                 {:handle_ps_pkts, [{:describe_pkt, statement_name, describe_pkt, parse_pkt}]},
+                 :busy,
+                 data
+               )
+
+      assert {:ok, ^describe_pkt} = :gen_tcp.recv(backend_recv, 0, 1000)
+
+      handler_state = MessageStreamer.stream_state(new_data.stream_state, :handler_state)
+      assert :queue.is_empty(BackendMessageHandler.handler_state(handler_state, :action_queue))
     end
   end
 

--- a/test/supavisor/protocol/debug_test.exs
+++ b/test/supavisor/protocol/debug_test.exs
@@ -63,6 +63,9 @@ defmodule Supavisor.Protocol.DebugTest do
       assert Debug.packet_to_string({:bind_pkt, "stmt1", nil, nil}, :frontend) ==
                "BindMessage(statement=\"stmt1\")"
 
+      assert Debug.packet_to_string({:describe_pkt, "stmt1", nil, nil}, :frontend) ==
+               "DescribeMessage(statement=\"stmt1\")"
+
       assert Debug.packet_to_string({:parse_pkt, "stmt2", nil}, :backend) ==
                "ParseMessage(statement=\"stmt2\")"
     end

--- a/test/supavisor/protocol/prepared_statements_test.exs
+++ b/test/supavisor/protocol/prepared_statements_test.exs
@@ -116,8 +116,9 @@ defmodule Supavisor.Protocol.PreparedStatements.PreparedStatementTest do
       # Should not change client_statements
       assert new_client_statements == client_statements
 
-      # Should return describe_pkt tuple with statement name
-      assert {:describe_pkt, "server_stmt", result_bin} = result
+      # Should return describe_pkt tuple with statement name and cached parse packet
+      assert {:describe_pkt, "server_stmt", result_bin, returned_parse_pkt} = result
+      assert returned_parse_pkt == parse_pkt
 
       # Verify the result binary has the correct format
       assert <<?D, _len::32, ?S, "server_stmt", 0>> = result_bin


### PR DESCRIPTION
## Summary

Named statement `Describe` messages were translated and forwarded without ensuring that the selected transaction-pool backend had seen the corresponding `Parse`. This caused clients such as pgJDBC to receive SQLSTATE `26000` from `PreparedStatement.getMetaData()` after a backend switch, even though executing the statement worked through the existing `Bind` replay path.

This change carries the cached `Parse` with named statement `Describe` packets and lets `Describe` use the same backend storage check and replay behavior as `Bind`. The replayed `ParseComplete` is intercepted so the client sees only the response to its original `Describe`.

Portal and unnamed statement describes remain unchanged.

Closes #1174

## Tests

- `mix test test/supavisor/protocol/prepared_statements_test.exs test/supavisor/protocol/debug_test.exs test/supavisor/db_handler_test.exs` (75 tests, 0 failures)
- `mix test test/integration/prepared_statements_test.exs` (9 tests, 0 failures)
- `mix format --check-formatted` on all changed files
- `mix dialyzer`
- Repeated the issue pgJDBC scenario with `prepareThreshold=1`: direct PostgreSQL and Supavisor both returned metadata successfully and executed with result `7`

The full `mix test` suite was also attempted in WSL on a Windows-mounted checkout. It completed 679 tests with 20 failures outside the changed areas, confined to an existing CRLF-sensitive assertion, 300 ms timing-sensitive tests, and peer-node startup exceeding its fixed 5 second timeout. The focused and prepared-statement suites pass cleanly; native Linux CI remains the authoritative full-suite result.
