### PR TITLE
fix: forward client_ip internal pooling

### DIFF
--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -212,9 +212,12 @@ defmodule Supavisor.ClientHandler do
 
   def handle_event(:info, {_, _, bin}, :handshake, data) do
     case ProtocolHelpers.parse_startup_packet(bin) do
-      {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls}}, app_name,
-       log_level} ->
-        event = {:hello, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls}}}
+      {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls, client_ip}},
+       app_name, log_level} ->
+        event =
+          {:hello,
+           {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls, client_ip}}}
+
         if log_level, do: Logger.put_process_level(self(), log_level)
 
         {:keep_state, %{data | app_name: app_name}, {:next_event, :internal, event}}
@@ -226,11 +229,19 @@ defmodule Supavisor.ClientHandler do
 
   def handle_event(
         :internal,
-        {:hello, {type, {user, tenant_or_alias, db_name, search_path, client_jit, client_tls}}},
+        {:hello,
+         {type, {user, tenant_or_alias, db_name, search_path, client_jit, client_tls, client_ip}}},
         :handshake,
         %{sock: sock} = data
       ) do
     sni_hostname = HandlerHelpers.try_get_sni(sock)
+
+    # When receiving a proxied connection on a local listener, client_tls and
+    # client_ip carry the original client's TLS status and IP address (the socket
+    # peer is the forwarding node). Otherwise, use what we observed on the socket.
+    effective_ssl = if(data.local && client_tls, do: client_tls, else: data.ssl)
+    peer_ip = ProtocolHelpers.effective_peer_ip(data.local, client_ip, data.peer_ip)
+    data = %{data | peer_ip: peer_ip}
 
     Logger.metadata(
       project: tenant_or_alias,
@@ -238,12 +249,9 @@ defmodule Supavisor.ClientHandler do
       mode: data.mode,
       type: type,
       app_name: data.app_name,
-      db_name: db_name
+      db_name: db_name,
+      peer_ip: peer_ip
     )
-
-    # When receiving a proxied connection on a local listener, client_tls
-    # carries the original client's TLS status. Otherwise, use data.ssl.
-    effective_ssl = if(data.local && client_tls, do: client_tls, else: data.ssl)
 
     case Tenants.get_user_cache(type, user, tenant_or_alias, sni_hostname) do
       {:ok, info} ->
@@ -400,7 +408,8 @@ defmodule Supavisor.ClientHandler do
              data.tenant_feature_flags,
              data.pool_ranch,
              client_ssl: data.ssl,
-             client_jit: data.use_jit_flow
+             client_jit: data.use_jit_flow,
+             client_ip: forwardable_peer_ip(data.peer_ip)
            ),
          {:ok, db_sock} <- DbHandler.checkout(db_pid, data.sock, self(), data.mode) do
       {:keep_state, %{data | db_connection: {nil, db_pid, db_sock}, mode: :proxy}}
@@ -848,6 +857,11 @@ defmodule Supavisor.ClientHandler do
   end
 
   defp cache_validated_password(_data, _secrets), do: :ok
+
+  # Helpers.peer_ip/1 returns "undefined" when the socket address can't be read;
+  # don't forward that to the pool node.
+  defp forwardable_peer_ip("undefined"), do: nil
+  defp forwardable_peer_ip(peer_ip), do: peer_ip
 
   defp handle_auth_failure(exception, data) do
     AuthMethods.handle_auth_failure(data.auth_context, exception)

--- a/lib/supavisor/client_handler/protocol_helpers.ex
+++ b/lib/supavisor/client_handler/protocol_helpers.ex
@@ -98,7 +98,8 @@ defmodule Supavisor.ClientHandler.ProtocolHelpers do
   """
   @spec effective_peer_ip(local? :: boolean(), forwarded_ip :: String.t() | nil, String.t()) ::
           String.t()
-  def effective_peer_ip(_local? = true, forwarded_ip, socket_peer_ip) when is_binary(forwarded_ip) do
+  def effective_peer_ip(_local? = true, forwarded_ip, socket_peer_ip)
+      when is_binary(forwarded_ip) do
     case :inet.parse_strict_address(to_charlist(forwarded_ip)) do
       {:ok, ip} -> List.to_string(:inet.ntoa(ip))
       {:error, _} -> socket_peer_ip

--- a/lib/supavisor/client_handler/protocol_helpers.ex
+++ b/lib/supavisor/client_handler/protocol_helpers.ex
@@ -39,7 +39,7 @@ defmodule Supavisor.ClientHandler.ProtocolHelpers do
   @type startup_message_data() ::
           {atom(),
            {String.t(), String.t(), String.t() | nil, String.t() | nil, boolean(),
-            boolean() | nil}}
+            boolean() | nil, String.t() | nil}}
 
   ## Startup Packet Processing
 
@@ -53,14 +53,14 @@ defmodule Supavisor.ClientHandler.ProtocolHelpers do
           | {:error, StartupMessageError.t() | InvalidUserInfoError.t()}
   def parse_startup_packet(bin) do
     with {:ok, hello} <- Client.decode_startup_packet(bin),
-         {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls}}} <-
+         {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls, client_ip}}} <-
            extract_and_validate_user_info(hello.payload) do
       Logger.debug("ClientHandler: Client startup message: #{inspect(hello)}")
       app_name = normalize_app_name(hello.payload["application_name"])
       log_level = extract_log_level(hello)
 
-      {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls}}, app_name,
-       log_level}
+      {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls, client_ip}},
+       app_name, log_level}
     end
   end
 
@@ -78,11 +78,34 @@ defmodule Supavisor.ClientHandler.ProtocolHelpers do
       search_path = payload["search_path"] || options["search_path"]
       jit = options["jit"] == "true"
       client_tls = options["client_tls"] && options["client_tls"] == "true"
-      {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls}}}
+      # Set by a peer node when it forwards a proxied connection; carries the
+      # original client's IP. Only honored on local listeners, see effective_peer_ip/3.
+      client_ip = options["client_ip"]
+      {:ok, {type, {user, tenant_or_alias, db_name, search_path, jit, client_tls, client_ip}}}
     else
       {:error, %InvalidUserInfoError{user: user, db_name: db_name}}
     end
   end
+
+  @doc """
+  Resolves the peer IP to attribute a connection to.
+
+  Proxied connections arrive on a `local: true` listener from a peer node, so the
+  socket's peer is that node rather than the client. The forwarding node passes the
+  original client's IP in the `client_ip` startup option; we use it only when the
+  listener is local (never reachable by external clients) and the value is a valid
+  IP address. Otherwise the socket's peer IP is kept.
+  """
+  @spec effective_peer_ip(local? :: boolean(), forwarded_ip :: String.t() | nil, String.t()) ::
+          String.t()
+  def effective_peer_ip(true, forwarded_ip, socket_peer_ip) when is_binary(forwarded_ip) do
+    case :inet.parse_strict_address(to_charlist(forwarded_ip)) do
+      {:ok, ip} -> List.to_string(:inet.ntoa(ip))
+      {:error, _} -> socket_peer_ip
+    end
+  end
+
+  def effective_peer_ip(_local?, _forwarded_ip, socket_peer_ip), do: socket_peer_ip
 
   ## Client Packet Processing
 

--- a/lib/supavisor/client_handler/protocol_helpers.ex
+++ b/lib/supavisor/client_handler/protocol_helpers.ex
@@ -98,7 +98,7 @@ defmodule Supavisor.ClientHandler.ProtocolHelpers do
   """
   @spec effective_peer_ip(local? :: boolean(), forwarded_ip :: String.t() | nil, String.t()) ::
           String.t()
-  def effective_peer_ip(true, forwarded_ip, socket_peer_ip) when is_binary(forwarded_ip) do
+  def effective_peer_ip(_local? = true, forwarded_ip, socket_peer_ip) when is_binary(forwarded_ip) do
     case :inet.parse_strict_address(to_charlist(forwarded_ip)) do
       {:ok, ip} -> List.to_string(:inet.ntoa(ip))
       {:error, _} -> socket_peer_ip

--- a/lib/supavisor/client_handler/proxy.ex
+++ b/lib/supavisor/client_handler/proxy.ex
@@ -130,7 +130,8 @@ defmodule Supavisor.ClientHandler.Proxy do
       proxy: true,
       log_level: nil,
       client_tls: Keyword.fetch!(client_opts, :client_ssl),
-      client_jit: Keyword.fetch!(client_opts, :client_jit)
+      client_jit: Keyword.fetch!(client_opts, :client_jit),
+      client_ip: Keyword.get(client_opts, :client_ip)
     }
   end
 end

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -306,9 +306,6 @@ defmodule Supavisor.DbHandler do
               "search_path" => Supavisor.id(data.id, :search_path),
               "client_tls" => if(data.proxy, do: to_string(data.client_tls)),
               "jit" => if(data.proxy, do: to_string(data.client_jit)),
-              # original client's IP, so the pool node attributes the
-              # connection (JIT auth, circuit breaker, logs) to the client
-              # rather than to this node
               "client_ip" => if(data.proxy, do: data.client_ip)
             }
 

--- a/lib/supavisor/db_handler.ex
+++ b/lib/supavisor/db_handler.ex
@@ -230,6 +230,7 @@ defmodule Supavisor.DbHandler do
       proxy: proxy,
       client_tls: Map.get(config, :client_tls),
       client_jit: Map.get(config, :client_jit),
+      client_ip: Map.get(config, :client_ip),
       stream_state: MessageStreamer.new_stream_state(BackendMessageHandler),
       backend_message_streaming: true,
       mode: config.mode,
@@ -304,7 +305,11 @@ defmodule Supavisor.DbHandler do
             options = %{
               "search_path" => Supavisor.id(data.id, :search_path),
               "client_tls" => if(data.proxy, do: to_string(data.client_tls)),
-              "jit" => if(data.proxy, do: to_string(data.client_jit))
+              "jit" => if(data.proxy, do: to_string(data.client_jit)),
+              # original client's IP, so the pool node attributes the
+              # connection (JIT auth, circuit breaker, logs) to the client
+              # rather than to this node
+              "client_ip" => if(data.proxy, do: data.client_ip)
             }
 
             case send_startup(sock, conn_params, tenant, options) do

--- a/test/integration/protocol_integration_test.exs
+++ b/test/integration/protocol_integration_test.exs
@@ -191,4 +191,127 @@ defmodule Supavisor.Integration.ProtocolIntegrationTest do
     #   assert auth_type == 3
     # end
   end
+
+  describe "client_ip forwarded on proxied JIT connections" do
+    # Stands in for the tenant's JIT API. Records the request body (which carries
+    # `rhost`, the IP Supavisor attributes the connection to) and rejects the token
+    # so the connection is terminated cleanly without reaching the database.
+    defmodule JitApiStub do
+      @behaviour Plug
+      import Plug.Conn
+
+      def init(test_pid), do: test_pid
+
+      def call(conn, test_pid) do
+        {:ok, body, conn} = read_body(conn)
+        send(test_pid, {:jit_request, Jason.decode!(body)})
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(403, Jason.encode!(%{"message" => "forbidden"}))
+      end
+    end
+
+    @forwarded_ip "203.0.113.9"
+    @token "sbp_0000000000000000000000000000000000000000"
+
+    setup do
+      Supavisor.Support.SSLHelper.setup_downstream_certs()
+
+      ref = :"jit_api_stub_#{System.unique_integer([:positive])}"
+
+      start_supervised!(
+        {Plug.Cowboy, scheme: :http, plug: {JitApiStub, self()}, options: [port: 0, ref: ref]}
+      )
+
+      jit_port = :ranch.get_port(ref)
+
+      db_conf = Application.get_env(:supavisor, Supavisor.Repo)
+      tenant_id = "jit_client_ip_tenant_#{System.unique_integer([:positive])}"
+
+      {:ok, _tenant} =
+        Supavisor.Tenants.create_tenant(%{
+          db_database: db_conf[:database],
+          db_host: to_string(db_conf[:hostname]),
+          db_port: db_conf[:port],
+          external_id: tenant_id,
+          require_user: true,
+          default_parameter_status: %{"server_version" => "15.0"},
+          use_jit: true,
+          jit_api_url: "http://127.0.0.1:#{jit_port}/jit",
+          users: [
+            %{
+              "db_user" => to_string(db_conf[:username]),
+              "db_password" => to_string(db_conf[:password]),
+              "pool_size" => 3,
+              "mode_type" => "transaction"
+            }
+          ]
+        })
+
+      on_exit(fn -> Supavisor.Tenants.delete_tenant_by_external_id(tenant_id) end)
+
+      %{
+        user: "#{db_conf[:username]}.#{tenant_id}",
+        database: to_string(db_conf[:database]),
+        local_port: hd(Application.get_env(:supavisor, :transaction_proxy_ports)),
+        public_port: Application.get_env(:supavisor, :proxy_port_transaction)
+      }
+    end
+
+    test "local listener attributes the connection to the forwarded client_ip", ctx do
+      {:ok, sock} = :gen_tcp.connect(~c"127.0.0.1", ctx.local_port, [:binary, active: false])
+
+      # This is what a peer node's proxy DbHandler sends when forwarding a client
+      # that authenticated with JIT over TLS (see DbHandler.send_startup/4).
+      jit_handshake(
+        {:gen_tcp, sock},
+        ctx,
+        "--jit=true --client_tls=true --client_ip=#{@forwarded_ip}"
+      )
+
+      assert_receive {:jit_request, %{"rhost" => @forwarded_ip, "role" => "postgres"}}, 5_000
+    end
+
+    test "local listener falls back to the socket peer without client_ip", ctx do
+      {:ok, sock} = :gen_tcp.connect(~c"127.0.0.1", ctx.local_port, [:binary, active: false])
+
+      jit_handshake({:gen_tcp, sock}, ctx, "--jit=true --client_tls=true")
+
+      assert_receive {:jit_request, %{"rhost" => "127.0.0.1", "role" => "postgres"}}, 5_000
+    end
+
+    test "public listener ignores client_ip supplied by the client", ctx do
+      {:ok, tcp} = :gen_tcp.connect(~c"127.0.0.1", ctx.public_port, [:binary, active: false])
+      :ok = :gen_tcp.send(tcp, Server.ssl_request_message())
+      {:ok, "S"} = :gen_tcp.recv(tcp, 1, 5_000)
+      {:ok, ssl} = :ssl.connect(tcp, [verify: :verify_none, active: false], 5_000)
+
+      # An external client must not be able to pick the IP the JIT API sees.
+      jit_handshake({:ssl, ssl}, ctx, "--jit=true --client_ip=#{@forwarded_ip}")
+
+      assert_receive {:jit_request, %{"rhost" => "127.0.0.1", "role" => "postgres"}}, 5_000
+    end
+
+    # Sends the startup message, answers the cleartext password request with a JIT
+    # token and reads the server's (error) reply.
+    defp jit_handshake({mod, sock}, ctx, options) do
+      startup =
+        :pgo_protocol.encode_startup_message([
+          {"user", ctx.user},
+          {"database", ctx.database},
+          {"options", options}
+        ])
+
+      :ok = mod.send(sock, startup)
+
+      # 3 = AuthenticationCleartextPassword
+      {:ok, <<?R, 8::32, 3::32>>} = mod.recv(sock, 0, 5_000)
+
+      password_message = <<?p, byte_size(@token) + 5::32, @token::binary, 0>>
+      :ok = mod.send(sock, password_message)
+
+      assert {:ok, <<?E, _::binary>>} = mod.recv(sock, 0, 5_000)
+    end
+  end
 end

--- a/test/supavisor/client_handler/protocol_helpers_test.exs
+++ b/test/supavisor/client_handler/protocol_helpers_test.exs
@@ -1,0 +1,76 @@
+defmodule Supavisor.ClientHandler.ProtocolHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias Supavisor.ClientHandler.ProtocolHelpers
+  alias Supavisor.Protocol.StartupOptions
+
+  describe "extract_and_validate_user_info/1" do
+    test "returns nil client_ip when the option is absent" do
+      payload = %{"user" => "postgres.some_tenant", "options" => %{"jit" => "true"}}
+
+      assert {:ok, {_type, {"postgres", "some_tenant", nil, nil, true, nil, nil}}} =
+               ProtocolHelpers.extract_and_validate_user_info(payload)
+    end
+
+    test "returns nil client_ip when there are no options" do
+      payload = %{"user" => "postgres.some_tenant"}
+
+      assert {:ok, {_type, {"postgres", "some_tenant", nil, nil, false, nil, nil}}} =
+               ProtocolHelpers.extract_and_validate_user_info(payload)
+    end
+
+    test "extracts client_ip alongside jit and client_tls" do
+      payload = %{
+        "user" => "postgres.some_tenant",
+        "options" => %{"jit" => "true", "client_tls" => "true", "client_ip" => "203.0.113.9"}
+      }
+
+      assert {:ok, {_type, {"postgres", "some_tenant", nil, nil, true, true, "203.0.113.9"}}} =
+               ProtocolHelpers.extract_and_validate_user_info(payload)
+    end
+
+    test "round-trips client_ip through the startup options wire format" do
+      # This is the format DbHandler.send_startup/4 uses when forwarding a
+      # proxied connection to the pool node.
+      encoded =
+        StartupOptions.encode(%{
+          "jit" => "true",
+          "client_tls" => "true",
+          "client_ip" => "2001:db8::1"
+        })
+
+      payload = %{"user" => "postgres.some_tenant", "options" => StartupOptions.parse(encoded)}
+
+      assert {:ok, {_type, {"postgres", "some_tenant", nil, nil, true, true, "2001:db8::1"}}} =
+               ProtocolHelpers.extract_and_validate_user_info(payload)
+    end
+  end
+
+  describe "effective_peer_ip/3" do
+    @socket_ip "10.0.0.5"
+
+    test "uses the forwarded IPv4 address on a local listener" do
+      assert ProtocolHelpers.effective_peer_ip(true, "203.0.113.9", @socket_ip) == "203.0.113.9"
+    end
+
+    test "uses the forwarded IPv6 address on a local listener" do
+      assert ProtocolHelpers.effective_peer_ip(true, "2001:db8::1", @socket_ip) == "2001:db8::1"
+    end
+
+    test "ignores the forwarded address on a non-local (public) listener" do
+      assert ProtocolHelpers.effective_peer_ip(false, "203.0.113.9", @socket_ip) == @socket_ip
+    end
+
+    test "falls back to the socket peer when nothing was forwarded" do
+      assert ProtocolHelpers.effective_peer_ip(true, nil, @socket_ip) == @socket_ip
+      assert ProtocolHelpers.effective_peer_ip(false, nil, @socket_ip) == @socket_ip
+    end
+
+    test "falls back to the socket peer when the forwarded value is not an IP" do
+      for bad <- ["", "undefined", "not-an-ip", "203.0.113", "203.0.113.9 ", "example.com"] do
+        assert ProtocolHelpers.effective_peer_ip(true, bad, @socket_ip) == @socket_ip,
+               "expected fallback for #{inspect(bad)}"
+      end
+    end
+  end
+end

--- a/test/supavisor/client_handler_test.exs
+++ b/test/supavisor/client_handler_test.exs
@@ -165,7 +165,7 @@ defmodule Supavisor.ClientHandlerTest do
 
       assert {:keep_state, %{app_name: ""},
               {:next_event, :internal,
-               {:hello, {:single, {"postgres", "dev_tenant", "postgres", nil, false, nil}}}}} =
+               {:hello, {:single, {"postgres", "dev_tenant", "postgres", nil, false, nil, nil}}}}} =
                @subject.handle_event(:info, {:tcp, :fake_port, bin}, :handshake, data)
 
       assert Logger.get_process_level(self()) == :debug


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a pool already exists on Node A, Node B will forward the connection. With JIT auth, Node A would end up seeing the IP address of Node B, rather than the connecting external client's IP address. This IP address would be used in network restriction checks, leading to failed checks as the internal address is unexptected.

## What is the new behavior?

When forwarding a connection to an existing pool on another node, forward the client_ip of the external client (for JIT connections). This ensures JIT authentication uses the correct external IP address for both authz and logging.

Fixes authz for JIT seeing the internal ip address of the node forwarding the connection, rather than the external client's ip.

## Additional context

Fixes instances where JIT authentication would fail on some requests when using ip restrictions. This would occur when a load balancer is in the mix and it was non-deterministic which node would receive the connection.
