### PR TITLE
feat: subscribe for a free client slot before rejecting with EMAXCONN

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,8 @@ config :supavisor,
   switch_active_count: System.get_env("SWITCH_ACTIVE_COUNT", "100") |> String.to_integer(),
   subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "20") |> String.to_integer(),
   # How long a client queues for a free slot before being rejected with EMAXCONN.
-  slot_wait_timeout: System.get_env("SLOT_WAIT_TIMEOUT", "1500") |> String.to_integer()
+  connection_slot_wait_timeout:
+    System.get_env("CONNECTION_SLOT_WAIT_TIMEOUT", "1500") |> String.to_integer()
 
 config :prom_ex, storage_adapter: Supavisor.Monitoring.PromEx.Store
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,9 @@ config :supavisor,
   env: Mix.env(),
   metrics_disabled: System.get_env("METRICS_DISABLED") == "true",
   switch_active_count: System.get_env("SWITCH_ACTIVE_COUNT", "100") |> String.to_integer(),
-  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "20") |> String.to_integer()
+  subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "20") |> String.to_integer(),
+  # How long a client queues for a free slot before being rejected with EMAXCONN.
+  slot_wait_timeout: System.get_env("SLOT_WAIT_TIMEOUT", "1500") |> String.to_integer()
 
 config :prom_ex, storage_adapter: Supavisor.Monitoring.PromEx.Store
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,7 +32,8 @@ config :supavisor,
     System.get_env("TRANSACTION_PROXY_PORTS", "12104,12105,12106,12107") |> parse_integer_list.(),
   max_pools: 10,
   subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer(),
-  slot_wait_timeout: System.get_env("SLOT_WAIT_TIMEOUT", "400") |> String.to_integer(),
+  connection_slot_wait_timeout:
+    System.get_env("CONNECTION_SLOT_WAIT_TIMEOUT", "400") |> String.to_integer(),
   metrics_pusher_req_options: [
     plug: {Req.Test, Supavisor.MetricsPusher.Global}
   ],

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,6 +32,7 @@ config :supavisor,
     System.get_env("TRANSACTION_PROXY_PORTS", "12104,12105,12106,12107") |> parse_integer_list.(),
   max_pools: 10,
   subscribe_retries: System.get_env("SUBSCRIBE_RETRIES", "5") |> String.to_integer(),
+  slot_wait_timeout: System.get_env("SLOT_WAIT_TIMEOUT", "400") |> String.to_integer(),
   metrics_pusher_req_options: [
     plug: {Req.Test, Supavisor.MetricsPusher.Global}
   ],

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -1050,9 +1050,10 @@ defmodule Supavisor.ClientHandler do
   # Completes connection setup once this client holds a pool slot, whether it was granted
   # synchronously by `Supavisor.subscribe/1` or handed over later by the Manager.
   defp finish_subscribe(data, opts) do
-    with manager_ref = Process.monitor(opts.workers.manager),
-         data = Map.merge(data, opts.workers),
-         {:ok, db_connection} <- maybe_checkout(:on_connect, data),
+    manager_ref = Process.monitor(opts.workers.manager)
+    data = Map.merge(data, opts.workers)
+
+    with {:ok, db_connection} <- maybe_checkout(:on_connect, data),
          :ok <- maybe_set_application_name(data, db_connection) do
       data = %{
         data

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -17,7 +17,7 @@ defmodule Supavisor.ClientHandler do
   @proto [:tcp, :ssl]
   @switch_active_count Application.compile_env(:supavisor, :switch_active_count)
   @subscribe_retries Application.compile_env(:supavisor, :subscribe_retries)
-  @slot_wait_timeout Application.compile_env(:supavisor, :slot_wait_timeout)
+  @connection_slot_wait_timeout Application.compile_env(:supavisor, :connection_slot_wait_timeout)
   @max_checkout_retries 2
   @timeout_subscribe 500
   @ssl_handshake_timeout 2_500
@@ -353,8 +353,7 @@ defmodule Supavisor.ClientHandler do
 
       # The pool is full. Queue for a slot instead of rejecting: the Manager grants slots
       # in request order as clients disconnect, so a client is admitted the moment one
-      # frees rather than having to reconnect - and reconnecting is what makes a saturated
-      # pool expensive, since every attempt pays for another TLS handshake.
+      # frees rather than having to reconnect.
       {:error, %MaxConnectionsError{} = exception} ->
         queue_for_slot_or_terminate(data, exception)
 
@@ -406,7 +405,7 @@ defmodule Supavisor.ClientHandler do
     Error.terminate_with_error(data, exception, :handshake)
   end
 
-  def handle_event(:state_timeout, :slot_wait_timeout, :waiting_for_slot, data) do
+  def handle_event(:state_timeout, :connection_slot_wait_timeout, :waiting_for_slot, data) do
     Telem.client_admission(:rejected, data.id)
     Error.terminate_with_error(data, data.pending_max_connections, :handshake)
   end
@@ -1037,9 +1036,8 @@ defmodule Supavisor.ClientHandler do
   @doc """
   Queues this client for a slot on a full pool instead of rejecting it immediately.
 
-  Rejecting makes the client reconnect, and every reconnect pays for another TLS handshake
-  before being rejected again - which is how a saturated pool becomes a CPU outage. Queuing
-  keeps the handshake we already paid for and lets the Manager hand over a slot the instant
+  Rejecting makes the client reconnect and go through the TLS handshake again.
+  Queuing keeps the handshake we already paid for and lets the Manager hand over a slot the instant
   one frees. A client that never gets one receives the same error it would have received
   immediately, just later, which throttles its retry loop.
   """
@@ -1054,7 +1052,7 @@ defmodule Supavisor.ClientHandler do
         Manager.request_slot(manager)
 
         {:next_state, :waiting_for_slot, %{data | pending_max_connections: exception},
-         {:state_timeout, @slot_wait_timeout, :slot_wait_timeout}}
+         {:state_timeout, @connection_slot_wait_timeout, :connection_slot_wait_timeout}}
     end
   end
 

--- a/lib/supavisor/client_handler.ex
+++ b/lib/supavisor/client_handler.ex
@@ -17,6 +17,7 @@ defmodule Supavisor.ClientHandler do
   @proto [:tcp, :ssl]
   @switch_active_count Application.compile_env(:supavisor, :switch_active_count)
   @subscribe_retries Application.compile_env(:supavisor, :subscribe_retries)
+  @slot_wait_timeout Application.compile_env(:supavisor, :slot_wait_timeout)
   @max_checkout_retries 2
   @timeout_subscribe 500
   @ssl_handshake_timeout 2_500
@@ -54,6 +55,7 @@ defmodule Supavisor.ClientHandler do
     ClientSocketClosedError,
     DbHandlerExitedError,
     HandshakeTimeoutError,
+    MaxConnectionsError,
     PoolCheckoutError,
     PoolConfigNotFoundError,
     PoolRanchNotFoundError,
@@ -273,7 +275,6 @@ defmodule Supavisor.ClientHandler do
         with :ok <- Checks.check_tenant_not_banned(info),
              :ok <- Checks.check_ssl_enforcement(data, info, user),
              :ok <- Checks.check_address_allowed(sock, info),
-             :ok <- Manager.check_client_limit(id, info, data.mode),
              {:ok, auth_method} <-
                AuthMethods.fetch_authentication_method(
                  info.tenant,
@@ -341,40 +342,21 @@ defmodule Supavisor.ClientHandler do
            ),
          :not_proxy <-
            if(node(sup) != node() and data.mode != :proxy, do: :proxy, else: :not_proxy),
-         {:ok, opts} <- Supavisor.subscribe(data.id),
-         manager_ref = Process.monitor(opts.workers.manager),
-         data = Map.merge(data, opts.workers),
-         {:ok, db_connection} <- maybe_checkout(:on_connect, data),
-         :ok <- maybe_set_application_name(data, db_connection) do
-      data = %{
-        data
-        | manager: manager_ref,
-          db_connection: db_connection,
-          idle_timeout: opts.idle_timeout
-      }
-
-      Registry.register(@clients_registry, data.id,
-        started_at: System.monotonic_time(),
-        app_name: data.app_name,
-        include_app_name: include_app_name?(data)
-      )
-
-      cond do
-        data.client_ready ->
-          {:next_state, :idle, data, handle_actions(data)}
-
-        opts.ps == [] ->
-          {:keep_state, data, {:timeout, 1_000, :wait_ps}}
-
-        true ->
-          {:keep_state, data, {:next_event, :internal, {:greetings, opts.ps}}}
-      end
+         {:ok, opts} <- Supavisor.subscribe(data.id) do
+      finish_subscribe(data, opts)
     else
       {:error, %WorkerNotFoundError{}} ->
         timeout_subscribe_or_terminate(data)
 
       {:error, %PoolConfigNotFoundError{}} ->
         timeout_subscribe_or_terminate(data)
+
+      # The pool is full. Queue for a slot instead of rejecting: the Manager grants slots
+      # in request order as clients disconnect, so a client is admitted the moment one
+      # frees rather than having to reconnect - and reconnecting is what makes a saturated
+      # pool expensive, since every attempt pays for another TLS handshake.
+      {:error, %MaxConnectionsError{} = exception} ->
+        queue_for_slot_or_terminate(data, exception)
 
       {:error, exception} when is_exception(exception) ->
         Error.terminate_with_error(data, exception, :handshake)
@@ -395,6 +377,38 @@ defmodule Supavisor.ClientHandler do
             timeout_subscribe_or_terminate(data)
         end
     end
+  end
+
+  # The Manager granted a slot, so this client is already registered as a pool client -
+  # picking up where a successful `Supavisor.subscribe/1` would have left off. Leaving
+  # :waiting_for_slot is what cancels the wait timeout.
+  def handle_event(:info, {:slot_granted, ps, idle_timeout}, :waiting_for_slot, data) do
+    {:next_state, :connecting, data, {:next_event, :internal, {:slot_granted, ps, idle_timeout}}}
+  end
+
+  def handle_event(:internal, {:slot_granted, ps, idle_timeout}, :connecting, data) do
+    Telem.client_admission(:admitted, data.id)
+
+    case Supavisor.get_local_workers(data.id) do
+      {:ok, workers} ->
+        finish_subscribe(%{data | pending_max_connections: nil}, %{
+          workers: workers,
+          ps: ps,
+          idle_timeout: idle_timeout
+        })
+
+      {:error, exception} ->
+        Error.terminate_with_error(data, exception, :handshake)
+    end
+  end
+
+  def handle_event(:info, {:slot_denied, exception}, :waiting_for_slot, data) do
+    Error.terminate_with_error(data, exception, :handshake)
+  end
+
+  def handle_event(:state_timeout, :slot_wait_timeout, :waiting_for_slot, data) do
+    Telem.client_admission(:rejected, data.id)
+    Error.terminate_with_error(data, data.pending_max_connections, :handshake)
   end
 
   def handle_event(:internal, :connect_db, _state, data) do
@@ -740,7 +754,8 @@ defmodule Supavisor.ClientHandler do
   end
 
   # Any message when connecting - postpone
-  def handle_event(_kind, {proto, _socket, _msg}, :connecting, _data) when proto in @proto do
+  def handle_event(_kind, {proto, _socket, _msg}, state, _data)
+      when proto in @proto and state in [:connecting, :waiting_for_slot] do
     {:keep_state_and_data, :postpone}
   end
 
@@ -1016,6 +1031,66 @@ defmodule Supavisor.ClientHandler do
        {:timeout, @timeout_subscribe, :subscribe}}
     else
       Error.terminate_with_error(data, %SubscribeRetriesExhaustedError{}, :handshake)
+    end
+  end
+
+  @doc """
+  Queues this client for a slot on a full pool instead of rejecting it immediately.
+
+  Rejecting makes the client reconnect, and every reconnect pays for another TLS handshake
+  before being rejected again - which is how a saturated pool becomes a CPU outage. Queuing
+  keeps the handshake we already paid for and lets the Manager hand over a slot the instant
+  one frees. A client that never gets one receives the same error it would have received
+  immediately, just later, which throttles its retry loop.
+  """
+  @spec queue_for_slot_or_terminate(map(), Exception.t()) :: :gen_statem.handle_event_result()
+  def queue_for_slot_or_terminate(data, exception) do
+    case Supavisor.get_local_manager(data.id) do
+      nil ->
+        Error.terminate_with_error(data, exception, :handshake)
+
+      manager ->
+        Logger.debug("ClientHandler: Queueing for a free client slot")
+        Manager.request_slot(manager)
+
+        {:next_state, :waiting_for_slot, %{data | pending_max_connections: exception},
+         {:state_timeout, @slot_wait_timeout, :slot_wait_timeout}}
+    end
+  end
+
+  # Completes connection setup once this client holds a pool slot, whether it was granted
+  # synchronously by `Supavisor.subscribe/1` or handed over later by the Manager.
+  defp finish_subscribe(data, opts) do
+    with manager_ref = Process.monitor(opts.workers.manager),
+         data = Map.merge(data, opts.workers),
+         {:ok, db_connection} <- maybe_checkout(:on_connect, data),
+         :ok <- maybe_set_application_name(data, db_connection) do
+      data = %{
+        data
+        | manager: manager_ref,
+          db_connection: db_connection,
+          idle_timeout: opts.idle_timeout
+      }
+
+      Registry.register(@clients_registry, data.id,
+        started_at: System.monotonic_time(),
+        app_name: data.app_name,
+        include_app_name: include_app_name?(data)
+      )
+
+      cond do
+        data.client_ready ->
+          {:next_state, :idle, data, handle_actions(data)}
+
+        opts.ps == [] ->
+          {:keep_state, data, {:timeout, 1_000, :wait_ps}}
+
+        true ->
+          {:keep_state, data, {:next_event, :internal, {:greetings, opts.ps}}}
+      end
+    else
+      {:error, exception} when is_exception(exception) ->
+        Error.terminate_with_error(data, exception, :handshake)
     end
   end
 

--- a/lib/supavisor/client_handler/data.ex
+++ b/lib/supavisor/client_handler/data.ex
@@ -39,6 +39,7 @@ defmodule Supavisor.ClientHandler.Data do
     :connection_start,
     :state_entered_at,
     :subscribe_retries,
+    :pending_max_connections,
     :client_ready,
     :max_clients,
     :pool_ranch,

--- a/lib/supavisor/manager.ex
+++ b/lib/supavisor/manager.ex
@@ -67,6 +67,27 @@ defmodule Supavisor.Manager do
   end
 
   @doc """
+  Asks the pool for a client slot without blocking the caller.
+
+  The caller receives `{:slot_granted, parameter_status, idle_timeout}` once it holds a
+  slot - immediately if the pool has room, otherwise when another client releases one.
+  Equivalent to `subscribe/2` having returned `{:ok, ps, idle_timeout}`, so the caller must
+  not also call `subscribe/2`.
+
+  Slots are granted in request order, so a client cannot lose its place to a newer arrival.
+  The caller is monitored, which makes terminating enough to withdraw the request - there
+  is no cancellation message to get wrong, and no reply that can arrive after the caller
+  has given up.
+
+  Sends `{:slot_denied, exception}` instead if the pool is shutting down.
+  """
+  @spec request_slot(pid | Supavisor.id(), pid) :: :ok
+  def request_slot(manager_or_id, pid \\ self()) do
+    manager = resolve_manager(manager_or_id)
+    GenServer.cast(manager, {:request_slot, pid})
+  end
+
+  @doc """
   Updates parameter status for the pool
 
   Sends the parameter status update to all subscribed client handlers.
@@ -234,7 +255,12 @@ defmodule Supavisor.Manager do
       terminating_error: nil,
       drain_caller: nil,
       drain_timer: nil,
-      waiting_for_secrets: []
+      waiting_for_secrets: [],
+      # Clients queued for a slot, in request order. Entries are never removed on
+      # withdrawal - `slot_waiters_live` is the source of truth and stale entries are
+      # skipped when granting, which keeps withdrawal O(1) instead of O(queue).
+      slot_waiters: :queue.new(),
+      slot_waiters_live: MapSet.new()
     }
 
     Logger.metadata(project: tenant, user: user, type: type, db_name: db_name)
@@ -256,18 +282,8 @@ defmodule Supavisor.Manager do
 
     case check_limit(state.mode, state.pool_size, state.max_clients, current_count) do
       :ok ->
-        ref = Process.monitor(pid)
-        :ets.insert(state.tid, {ref, pid, now()})
-        :ets.insert(state.pid_to_ref, {pid, ref})
-
-        new_state =
-          if state.parameter_status == [] do
-            update_in(state.wait_ps, &[pid | &1])
-          else
-            state
-          end
-
-        {:reply, {:ok, state.parameter_status, state.idle_timeout}, new_state}
+        {ps, idle_timeout, new_state} = do_subscribe(pid, state)
+        {:reply, {:ok, ps, idle_timeout}, new_state}
 
       {:error, _} = error ->
         {:reply, error, state}
@@ -284,9 +300,12 @@ defmodule Supavisor.Manager do
         Logger.warning("Unsubscribe: no entry found for #{inspect(pid)}")
     end
 
-    new_state = %{state | wait_ps: Enum.reject(state.wait_ps, &(&1 == pid))}
+    new_state =
+      %{state | wait_ps: Enum.reject(state.wait_ps, &(&1 == pid))}
+      |> maybe_complete_drain()
+      |> maybe_grant_slot()
 
-    {:reply, :ok, maybe_complete_drain(new_state)}
+    {:reply, :ok, new_state}
   end
 
   def handle_call({:set_parameter_status, ps}, _, %{parameter_status: []} = state) do
@@ -356,6 +375,37 @@ defmodule Supavisor.Manager do
   end
 
   @impl true
+  def handle_cast({:request_slot, pid}, %{terminating_error: error} = state)
+      when not is_nil(error) do
+    send(pid, {:slot_denied, %PoolTerminatingError{underlying_error: error}})
+    {:noreply, state}
+  end
+
+  def handle_cast({:request_slot, pid}, state) do
+    current_count = :ets.info(state.tid, :size)
+
+    case check_limit(state.mode, state.pool_size, state.max_clients, current_count) do
+      :ok ->
+        {ps, idle_timeout, new_state} = do_subscribe(pid, state)
+        send(pid, {:slot_granted, ps, idle_timeout})
+        {:noreply, new_state}
+
+      {:error, _} ->
+        Logger.debug("Queueing #{inspect(pid)} for a slot on #{Supavisor.inspect_id(state.id)}")
+
+        # Monitoring the waiter is what makes withdrawal implicit: a client that gives up
+        # terminates, and the DOWN takes it out of the queue.
+        mon = Process.monitor(pid)
+
+        {:noreply,
+         %{
+           state
+           | slot_waiters: :queue.in({mon, pid}, state.slot_waiters),
+             slot_waiters_live: MapSet.put(state.slot_waiters_live, mon)
+         }}
+    end
+  end
+
   def handle_cast({:shutdown_with_error, error}, state) do
     Logger.warning(
       "Shutting down pool #{Supavisor.inspect_id(state.id)} with error: #{inspect(error)}"
@@ -410,13 +460,19 @@ defmodule Supavisor.Manager do
 
   @impl true
   def handle_info({:DOWN, ref, _, pid, _}, state) do
-    Process.cancel_timer(state.check_ref)
-    :ets.delete(state.tid, ref)
-    :ets.delete(state.pid_to_ref, pid)
+    # A client queued for a slot gave up or died before getting one. It holds nothing, so
+    # there is no slot to release - just drop it from the live set.
+    if MapSet.member?(state.slot_waiters_live, ref) do
+      {:noreply, %{state | slot_waiters_live: MapSet.delete(state.slot_waiters_live, ref)}}
+    else
+      Process.cancel_timer(state.check_ref)
+      :ets.delete(state.tid, ref)
+      :ets.delete(state.pid_to_ref, pid)
 
-    state = maybe_complete_drain(state)
+      state = state |> maybe_complete_drain() |> maybe_grant_slot()
 
-    {:noreply, %{state | check_ref: check_subscribers()}}
+      {:noreply, %{state | check_ref: check_subscribers()}}
+    end
   end
 
   def handle_info({:DB_HANDLER_DOWN, ref, _, _, _}, state) do
@@ -532,6 +588,63 @@ defmodule Supavisor.Manager do
     case Supavisor.get_local_manager(id) do
       nil -> raise "Manager not found for pool #{Supavisor.inspect_id(id)}"
       pid -> pid
+    end
+  end
+
+  # Registers `pid` as a client of this pool. Shared by the synchronous `subscribe/2` and
+  # by slot grants, so both produce identical state.
+  defp do_subscribe(pid, state) do
+    ref = Process.monitor(pid)
+    :ets.insert(state.tid, {ref, pid, now()})
+    :ets.insert(state.pid_to_ref, {pid, ref})
+
+    new_state =
+      if state.parameter_status == [] do
+        update_in(state.wait_ps, &[pid | &1])
+      else
+        state
+      end
+
+    {state.parameter_status, state.idle_timeout, new_state}
+  end
+
+  # Hands the slot just released to the client that has been queued longest.
+  #
+  # Called only from the two places a slot can be released, both of which run in this
+  # process - so the limit re-check below cannot be raced by a new arrival, and exactly one
+  # waiter can be admitted per release.
+  defp maybe_grant_slot(%{terminating_error: error} = state) when not is_nil(error), do: state
+
+  defp maybe_grant_slot(state) do
+    current_count = :ets.info(state.tid, :size)
+
+    case check_limit(state.mode, state.pool_size, state.max_clients, current_count) do
+      :ok -> grant_next_slot(state)
+      {:error, _} -> state
+    end
+  end
+
+  defp grant_next_slot(state) do
+    case :queue.out(state.slot_waiters) do
+      {:empty, slot_waiters} ->
+        %{state | slot_waiters: slot_waiters}
+
+      {{:value, {mon, pid}}, slot_waiters} ->
+        state = %{state | slot_waiters: slot_waiters}
+
+        if MapSet.member?(state.slot_waiters_live, mon) do
+          # do_subscribe/2 installs its own monitor for the client, so the queue monitor
+          # has done its job.
+          Process.demonitor(mon, [:flush])
+          state = %{state | slot_waiters_live: MapSet.delete(state.slot_waiters_live, mon)}
+
+          {ps, idle_timeout, state} = do_subscribe(pid, state)
+          send(pid, {:slot_granted, ps, idle_timeout})
+          state
+        else
+          # Stale entry for a waiter that already withdrew.
+          grant_next_slot(state)
+        end
     end
   end
 

--- a/lib/supavisor/monitoring/telem.ex
+++ b/lib/supavisor/monitoring/telem.ex
@@ -90,6 +90,26 @@ defmodule Supavisor.Monitoring.Telem do
     Logger.debug("client_join is called with a mismatched id: #{Supavisor.inspect_id(id)}")
   end
 
+  @doc """
+  Outcome of a connection that found the pool full and queued for a slot.
+
+  `:admitted` means the Manager handed over a slot within the wait timeout, so the
+  connection would have been rejected before queuing was introduced. `:rejected` means the
+  timeout expired first and the client received EMAXCONN.
+  """
+  @spec client_admission(:admitted | :rejected, Supavisor.id() | any()) :: :ok | nil
+  def client_admission(status, Supavisor.id() = id) do
+    telemetry_execute(
+      [:supavisor, :client, :admission, status],
+      %{},
+      id_to_tags(id)
+    )
+  end
+
+  def client_admission(_status, id) do
+    Logger.debug("client_admission is called with a mismatched id: #{Supavisor.inspect_id(id)}")
+  end
+
   @spec handler_action(
           :client_handler | :db_handler,
           :started | :stopped | :db_connection,

--- a/lib/supavisor/monitoring/tenant.ex
+++ b/lib/supavisor/monitoring/tenant.ex
@@ -169,6 +169,19 @@ defmodule Supavisor.PromEx.Plugins.Tenant do
           tags: @tags
         ),
         counter(
+          [:supavisor, :client, :admission, :admitted],
+          event_name: [:supavisor, :client, :admission, :admitted],
+          description: "The total number of connections admitted after queuing for a slot.",
+          tags: @tags
+        ),
+        counter(
+          [:supavisor, :client, :admission, :rejected],
+          event_name: [:supavisor, :client, :admission, :rejected],
+          description:
+            "The total number of connections rejected with EMAXCONN after the slot wait timed out.",
+          tags: @tags
+        ),
+        counter(
           [:supavisor, :client_handler, :started, :count],
           event_name: [:supavisor, :client_handler, :started, :all],
           description: "The total number of created client_handler.",

--- a/priv/repo/seeds_after_migration.exs
+++ b/priv/repo/seeds_after_migration.exs
@@ -127,6 +127,28 @@ if !Tenants.get_tenant_by_external_id("proxy_pool_tenant") do
     |> Tenants.create_tenant()
 end
 
+if !Tenants.get_tenant_by_external_id("admission_tenant") do
+  {:ok, _} =
+    %{
+      db_host: db_conf[:hostname],
+      db_port: db_conf[:port],
+      db_database: db_conf[:database],
+      default_parameter_status: %{},
+      external_id: "admission_tenant",
+      require_user: true,
+      users: [
+        %{
+          "db_user" => db_conf[:username],
+          "db_password" => db_conf[:password],
+          "pool_size" => 2,
+          "max_clients" => 2,
+          "mode_type" => "transaction"
+        }
+      ]
+    }
+    |> Tenants.create_tenant()
+end
+
 if !Tenants.get_tenant_by_external_id("dead_port_repro_tenant") do
   {:ok, _} =
     %{

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -523,7 +523,8 @@ defmodule Supavisor.Integration.ProxyTest do
 
       # The throttle: the client is held rather than rejected immediately, which is what
       # slows down a client reconnecting in a tight loop.
-      assert elapsed >= Application.get_env(:supavisor, :slot_wait_timeout) * 1_000 * 0.9
+      assert elapsed >=
+               Application.get_env(:supavisor, :connection_slot_wait_timeout) * 1_000 * 0.9
     end
 
     test "grants slots in request order", ctx do

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -439,6 +439,141 @@ defmodule Supavisor.Integration.ProxyTest do
             }} = single_connection(connection_opts)
   end
 
+  describe "queuing for a free client slot" do
+    setup do
+      db_conf = Application.get_env(:supavisor, Supavisor.Repo)
+
+      connection_opts = [
+        hostname: db_conf[:hostname],
+        port: Application.get_env(:supavisor, :proxy_port_transaction),
+        username: db_conf[:username] <> ".admission_tenant",
+        database: db_conf[:database],
+        password: db_conf[:password]
+      ]
+
+      test_pid = self()
+      ref = make_ref()
+      handler_id = {__MODULE__, ref}
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:supavisor, :client, :admission, :admitted],
+          [:supavisor, :client, :admission, :rejected]
+        ],
+        fn event, _measurements, _metadata, _config -> send(test_pid, {ref, event}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{connection_opts: connection_opts, ref: ref}
+    end
+
+    test "admits a queued client when a slot frees up", ctx do
+      ref = ctx.ref
+
+      # admission_tenant allows 2 clients, so the pool is now full
+      assert {:ok, conn} = single_connection(ctx.connection_opts)
+      assert {:ok, _conn} = single_connection(ctx.connection_opts)
+
+      test_pid = self()
+      connection_opts = ctx.connection_opts
+
+      spawn(fn ->
+        result =
+          try do
+            SingleConnection.connect(connection_opts)
+          catch
+            kind, reason -> {:error, {kind, reason}}
+          end
+
+        send(test_pid, {:waiter, result})
+      end)
+
+      # Give the third connection time to queue, then free a slot well inside its wait
+      # timeout. Before queuing was introduced this connection would already have been
+      # rejected.
+      Process.sleep(50)
+      GenServer.stop(conn)
+
+      assert_receive {:waiter, {:ok, _pid}}, 5_000
+      assert_receive {^ref, [:supavisor, :client, :admission, :admitted]}, 1_000
+    end
+
+    test "rejects with EMAXCONN once the slot wait times out", ctx do
+      ref = ctx.ref
+
+      assert {:ok, _conn} = single_connection(ctx.connection_opts)
+      assert {:ok, _conn} = single_connection(ctx.connection_opts)
+
+      {elapsed, result} = :timer.tc(fn -> single_connection(ctx.connection_opts) end)
+
+      assert {:error,
+              %Postgrex.Error{
+                postgres: %{
+                  code: :internal_error,
+                  message: "(EMAXCONN) max client connections reached, limit: 2",
+                  pg_code: "XX000",
+                  severity: "FATAL"
+                }
+              }} = result
+
+      assert_receive {^ref, [:supavisor, :client, :admission, :rejected]}, 1_000
+
+      # The throttle: the client is held rather than rejected immediately, which is what
+      # slows down a client reconnecting in a tight loop.
+      assert elapsed >= Application.get_env(:supavisor, :slot_wait_timeout) * 1_000 * 0.9
+    end
+
+    test "grants slots in request order", ctx do
+      ref = ctx.ref
+
+      assert {:ok, conn} = single_connection(ctx.connection_opts)
+      assert {:ok, _conn} = single_connection(ctx.connection_opts)
+
+      test_pid = self()
+      connection_opts = ctx.connection_opts
+
+      # Supervised so the waiters are torn down with the test. They have to outlive their
+      # own result: SingleConnection links to them, so exiting early would close the
+      # connection and hand the slot straight to the next waiter.
+      waiter = fn tag ->
+        {:ok, _pid} =
+          start_supervised(%{
+            id: {:waiter, tag},
+            restart: :temporary,
+            start:
+              {Task, :start_link,
+               [
+                 fn ->
+                   # SingleConnection links to us, so without this a rejected connection
+                   # takes the waiter down before it can report.
+                   Process.flag(:trap_exit, true)
+                   send(test_pid, {tag, SingleConnection.connect(connection_opts)})
+                   Process.sleep(:infinity)
+                 end
+               ]}
+          })
+      end
+
+      waiter.(:first)
+      Process.sleep(30)
+      waiter.(:second)
+      Process.sleep(30)
+
+      # Exactly one slot frees, so the client that queued first must get it and the one
+      # that queued second must time out.
+      GenServer.stop(conn)
+
+      # The client that queued first gets the slot; the one behind it times out.
+      assert_receive {:first, {:ok, _pid}}, 5_000
+      assert_receive {^ref, [:supavisor, :client, :admission, :admitted]}, 1_000
+      assert_receive {^ref, [:supavisor, :client, :admission, :rejected]}, 5_000
+      refute_received {:second, {:ok, _pid}}
+    end
+  end
+
   test "checkout timeout in transaction mode" do
     %{db_conf: db_conf} = setup_tenant_connections(List.first(@tenants))
 

--- a/test/supavisor/manager_test.exs
+++ b/test/supavisor/manager_test.exs
@@ -1,0 +1,163 @@
+defmodule Supavisor.ManagerTest do
+  use ExUnit.Case, async: true
+
+  require Supavisor
+
+  @subject Supavisor.Manager
+
+  @id Supavisor.id(
+        type: :single,
+        tenant: "manager_test",
+        user: "postgres",
+        mode: :transaction,
+        db: "postgres"
+      )
+
+  # The Manager's state is a plain map, so the slot queue can be driven through the
+  # callbacks directly. That keeps these tests off the database - the end-to-end behaviour
+  # is covered by the integration tests.
+  defp state(max_clients) do
+    %{
+      id: @id,
+      tid: :ets.new(:clients, [:public, :set]),
+      pid_to_ref: :ets.new(:pid_to_ref, [:public, :set]),
+      mode: :transaction,
+      pool_size: 10,
+      max_clients: max_clients,
+      parameter_status: [<<"S">>],
+      idle_timeout: 0,
+      wait_ps: [],
+      terminating_error: nil,
+      drain_caller: nil,
+      drain_timer: nil,
+      check_ref: Process.send_after(self(), :never, 60_000),
+      slot_waiters: :queue.new(),
+      slot_waiters_live: MapSet.new()
+    }
+  end
+
+  defp idle_client do
+    spawn(fn ->
+      receive do
+        :stop -> :ok
+      end
+    end)
+  end
+
+  defp subscribed_pids(state), do: state.tid |> :ets.tab2list() |> Enum.map(&elem(&1, 1))
+
+  describe "request_slot/2 with room in the pool" do
+    test "grants a slot immediately" do
+      state = state(1)
+
+      assert {:noreply, state} = @subject.handle_cast({:request_slot, self()}, state)
+
+      assert subscribed_pids(state) == [self()]
+      assert :queue.is_empty(state.slot_waiters)
+      assert_received {:slot_granted, [<<"S">>], 0}
+    end
+  end
+
+  describe "request_slot/2 on a full pool" do
+    setup do
+      state = state(1)
+      holder = idle_client()
+      {:noreply, state} = @subject.handle_cast({:request_slot, holder}, state)
+      assert subscribed_pids(state) == [holder]
+
+      %{state: state, holder: holder}
+    end
+
+    test "queues the client instead of granting or rejecting", ctx do
+      waiter = idle_client()
+
+      assert {:noreply, state} = @subject.handle_cast({:request_slot, waiter}, ctx.state)
+
+      # Still only the original holder, and nothing was sent to the waiter.
+      assert subscribed_pids(state) == [ctx.holder]
+      assert :queue.len(state.slot_waiters) == 1
+      assert MapSet.size(state.slot_waiters_live) == 1
+    end
+
+    test "grants the freed slot on unsubscribe", ctx do
+      waiter = idle_client()
+      {:noreply, state} = @subject.handle_cast({:request_slot, waiter}, ctx.state)
+
+      assert {:reply, :ok, state} =
+               @subject.handle_call({:unsubscribe, ctx.holder}, {self(), make_ref()}, state)
+
+      assert subscribed_pids(state) == [waiter]
+      assert :queue.is_empty(state.slot_waiters)
+      assert MapSet.size(state.slot_waiters_live) == 0
+    end
+
+    test "grants the freed slot when a client dies", ctx do
+      waiter = idle_client()
+      {:noreply, state} = @subject.handle_cast({:request_slot, waiter}, ctx.state)
+
+      [{holder_ref, _pid, _}] =
+        :ets.tab2list(state.tid) |> Enum.filter(&(elem(&1, 1) == ctx.holder))
+
+      assert {:noreply, state} =
+               @subject.handle_info({:DOWN, holder_ref, :process, ctx.holder, :normal}, state)
+
+      assert subscribed_pids(state) == [waiter]
+    end
+
+    test "grants in request order", ctx do
+      first = idle_client()
+      second = idle_client()
+      {:noreply, state} = @subject.handle_cast({:request_slot, first}, ctx.state)
+      {:noreply, state} = @subject.handle_cast({:request_slot, second}, state)
+
+      assert {:reply, :ok, state} =
+               @subject.handle_call({:unsubscribe, ctx.holder}, {self(), make_ref()}, state)
+
+      assert subscribed_pids(state) == [first]
+      assert :queue.len(state.slot_waiters) == 1
+    end
+
+    test "skips a waiter that gave up and grants to the next one", ctx do
+      gave_up = idle_client()
+      still_waiting = idle_client()
+      {:noreply, state} = @subject.handle_cast({:request_slot, gave_up}, ctx.state)
+      {:noreply, state} = @subject.handle_cast({:request_slot, still_waiting}, state)
+
+      [gave_up_mon] =
+        state.slot_waiters
+        |> :queue.to_list()
+        |> Enum.filter(fn {_mon, pid} -> pid == gave_up end)
+        |> Enum.map(&elem(&1, 0))
+
+      # A waiter that terminates is withdrawn by its monitor, and holds no slot to release.
+      assert {:noreply, state} =
+               @subject.handle_info({:DOWN, gave_up_mon, :process, gave_up, :normal}, state)
+
+      assert subscribed_pids(state) == [ctx.holder]
+
+      assert {:reply, :ok, state} =
+               @subject.handle_call({:unsubscribe, ctx.holder}, {self(), make_ref()}, state)
+
+      assert subscribed_pids(state) == [still_waiting]
+    end
+
+    test "tells the waiter once its slot is granted", ctx do
+      {:noreply, state} = @subject.handle_cast({:request_slot, self()}, ctx.state)
+      refute_received {:slot_granted, _ps, _idle}
+
+      assert {:reply, :ok, _state} =
+               @subject.handle_call({:unsubscribe, ctx.holder}, {self(), make_ref()}, state)
+
+      assert_received {:slot_granted, [<<"S">>], 0}
+    end
+
+    test "denies the request when the pool is shutting down", ctx do
+      state = %{ctx.state | terminating_error: %{"M" => "shutting down"}}
+
+      assert {:noreply, state} = @subject.handle_cast({:request_slot, self()}, state)
+
+      assert :queue.is_empty(state.slot_waiters)
+      assert_received {:slot_denied, %Supavisor.Errors.PoolTerminatingError{}}
+    end
+  end
+end


### PR DESCRIPTION
Instead of rejecting right away, subscribe and briefly wait for a connection slot to be assigned, if nothing is freed on time returns the expected EMAXCONN error.

Similar to #1179 but waits for the Manager to assign a slot instead of retrying after a delay.