### PR TITLE
chore(dialyzer): remove outdated ignore rule

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,6 +1,3 @@
 [
-  ~r(test/support/[^.]*\.ex),
-  # Defensive 2-tuple clause kept for relup compatibility with v2.9.6 nodes
-  # whose Helpers.get_client_final/5 returned a 2-tuple. Remove with the TODO.
-  ~r{^lib/supavisor/db_handler\.ex:822:\d+:pattern_match\b}
+  ~r(test/support/[^.]*\.ex)
 ]


### PR DESCRIPTION
Housekeeping.

The intended clause was removed in [682214f](https://github.com/supabase/supavisor/commit/682214ff10d56fa56085c0f9bcd7148c1b7beef4#diff-d8700638a792725504b589b6a2670ed08fe23870e1ee45955063cb7e48da2883), but the ignore rule was not removed (which is now dead).